### PR TITLE
Add a switch to disable SNMP support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,13 @@ These instructions will get you a copy of the project up and running on your loc
 - OSX (macOS)
 
   Following packages on homebrew
-  
+
   * automake
   * autoconf
   * libtool
   * osxfuse (brew cask install osxfuse)
   * ossp-uuid
-  * libxml-2.0
-  * net-snmp 5.3
+  * libxml2
   * icu4c
   * gnu-sed
 
@@ -58,9 +57,11 @@ brew link --force icu4c
 brew link --force libxml2
 ```
 
+On OSX (macOS), snmp cannot be supported. Need to disable it on configure script.
+
 ```
 ./autogen.sh
-./configure
+./configure --disable-snmp
 make
 make install
 ```

--- a/configure.ac
+++ b/configure.ac
@@ -53,9 +53,8 @@ AM_PROG_AR
 AC_PROG_LIBTOOL
 
 dnl
-dnl Check OS
+dnl Detecting OS
 dnl
-
 host_linux=no
 host_mac=no
 
@@ -72,7 +71,7 @@ case "${host_os}" in
 esac
 
 dnl
-dnl Check for debug
+dnl Handle --enable-debug (default:no)
 dnl
 AC_MSG_CHECKING([whether to compile in debug mode])
 AC_ARG_ENABLE([debug],
@@ -83,7 +82,7 @@ AC_ARG_ENABLE([debug],
 AC_MSG_RESULT([$use_debug])
 
 dnl
-dnl Check for max speed
+dnl Handle --enable-fast (default:no)
 dnl
 AC_MSG_CHECKING([whether to enable optimizations])
 AC_ARG_ENABLE([fast],
@@ -93,9 +92,16 @@ AC_ARG_ENABLE([fast],
 )
 AC_MSG_RESULT([$use_fast])
 
+if test "x${use_fast}" != "xno"
+then
+	if test "x${use_debug}" != "xno"
+	then
+		AC_MSG_ERROR([Cannot specify --enable-fast and --enable-debug at the same time.])
+	fi
+fi
 
 dnl
-dnl Check for livelink enable
+dnl Handle --enable-livelink (default:yes)
 dnl
 AC_MSG_CHECKING([whether to enable livelink mode support [default=yes] ])
 AC_ARG_ENABLE([livelink],
@@ -105,14 +111,16 @@ AC_ARG_ENABLE([livelink],
 )
 AC_MSG_RESULT([$livelink])
 
-
-if test "x${use_fast}" != "xno"
-then
-	if test "x${use_debug}" != "xno"
-	then
-		AC_MSG_ERROR([Cannot specify --enable-fast and --enable-debug at the same time.])
-	fi
-fi
+dnl
+dnl Handle --enable-snmp (default:yes)
+dnl
+AC_MSG_CHECKING([whether to enable snmp or not])
+AC_ARG_ENABLE([snmp],
+	[AS_HELP_STRING([--enable-snmp],[Support SNMP handling or not])],
+	[snmp=$enableval],
+	[snmp=yes]
+)
+AC_MSG_RESULT([$snmp])
 
 dnl
 dnl Check for special environment variables
@@ -194,17 +202,25 @@ fi
 dnl
 dnl Check for SNMP
 dnl
-SNMP_MODULE_CFLAGS="`net-snmp-config --cflags 2> /dev/null`";
-SNMP_MODULE_LIBS_A="`net-snmp-config --agent-libs` 2> /dev/null";
-SNMP_MODULE_LIBS="`net-snmp-config --libs 2> /dev/null`";
-if test -z "$SNMP_MODULE_LIBS_A"
+SNMP_ENABLE=""
+SNMP_MODULE_CFLAGS=""
+SNMP_MODULE_LIBS_A=""
+SNMP_MODULE_LIBS=""
+if test "x${snmp}" != "xno"
 then
-	PKG_CHECK_MODULES([SNMP_MODULE], [net-snmp >= 5.3])
-fi
+	SNMP_ENABLE="-D ENABLE_SNMP"
+	SNMP_MODULE_CFLAGS="`net-snmp-config --cflags 2> /dev/null`";
+	SNMP_MODULE_LIBS_A="`net-snmp-config --agent-libs` 2> /dev/null";
+	SNMP_MODULE_LIBS="`net-snmp-config --libs 2> /dev/null`";
+	if test -z "$SNMP_MODULE_LIBS_A"
+	then
+		PKG_CHECK_MODULES([SNMP_MODULE], [net-snmp >= 5.3])
+	fi
 
-if test -z "$SNMP_MODULE_LIBS"
-then
-	PKG_CHECK_MODULES([SNMP_MODULE], [net-snmp >= 5.3])
+	if test -z "$SNMP_MODULE_LIBS"
+	then
+		PKG_CHECK_MODULES([SNMP_MODULE], [net-snmp >= 5.3])
+	fi
 fi
 
 dnl
@@ -266,7 +282,7 @@ dnl Update flags
 dnl Sets CFLAGS to force optimization and debugging options, which isn't quite kosher
 dnl
 AM_CPPFLAGS="-D_GNU_SOURCE -I\$(top_srcdir)/src -DLTFS_CONFIG_FILE='\"${sysconfdir}/ltfs.conf\"' -DLTFS_BASE_DIR='\"${prefix}\"'"
-AM_CFLAGS="-Wall -Wsign-compare ${FUSE_MODULE_CFLAGS} ${UUID_MODULE_CFLAGS} ${LIBXML2_MODULE_CFLAGS} ${ICU_MODULE_CFLAGS} ${SNMP_MODULE_CFLAGS}"
+AM_CFLAGS="-Wall -Wsign-compare ${FUSE_MODULE_CFLAGS} ${UUID_MODULE_CFLAGS} ${LIBXML2_MODULE_CFLAGS} ${ICU_MODULE_CFLAGS} ${SNMP_ENABLE} ${SNMP_MODULE_CFLAGS}"
 
 if test "x$use_fast" = "xyes"
 then
@@ -288,7 +304,7 @@ fi
 dnl
 dnl Specify CPU specific optimizer options for CRC calculation
 dnl
-AC_MSG_CHECKING([SSE4.2])
+AC_MSG_CHECKING([for SSE4.2])
 CRC_OPTIMIZE="-O2"
 
 if test "x$GCC" = 'xyes'

--- a/src/libltfs/ltfslogging.c
+++ b/src/libltfs/ltfslogging.c
@@ -474,31 +474,17 @@ int ltfsmsg_internal(bool print_id, int level, char **msg_out, const char *id, .
 		*msg_out = strdup(msg_buf);
 	}
 
-#if ((!defined (__APPLE__)) && (!defined (mingw_PLATFORM)))
+#ifdef ENABLE_SNMP
 	if (is_snmp_enabled()) {
-#if 0 // SNMP Error Trap
-		if (level <= LTFS_ERR) {
-			/* Send a trap of Error (id and pos+1) */
+		if (is_snmp_trapid(id) == true) {
+			/* Send a trap of Info (id and pos+1) */
 			char *pos;
 			va_start(argp, id);
 			vsprintf(msg_buf, output_buf, argp);
 			va_end(argp);
 			pos = strstr(msg_buf, " ");
-			send_ltfsErrorTrap(pos+1);
-		} else  {
-#endif
-			if (is_snmp_trapid(id) == true) {
-				/* Send a trap of Info (id and pos+1) */
-				char *pos;
-				va_start(argp, id);
-				vsprintf(msg_buf, output_buf, argp);
-				va_end(argp);
-				pos = strstr(msg_buf, " ");
-				send_ltfsInfoTrap(pos+1);
-			}
-#if 0 // SNMP Error Trap
+			send_ltfsInfoTrap(pos+1);
 		}
-#endif
 	}
 #endif
 

--- a/src/libltfs/ltfssnmp.c
+++ b/src/libltfs/ltfssnmp.c
@@ -54,7 +54,7 @@
 #define AGENT "ltfs"
 #define TABLE_FILE_MODE "rb"
 
-#if ((!defined (__APPLE__)) && (!defined (mingw_PLATFORM)))
+#ifdef ENABLE_SNMP
 #define DEFAULT_DEFFILE LTFS_BASE_DIR "/share/snmp/LtfsSnmpTrapDef.txt"
 static const oid snmptrap_oid[] = { 1, 3, 6, 1, 6, 3, 1, 1, 4, 1, 0 };
 #else
@@ -145,7 +145,7 @@ bool is_snmp_trapid(const char *id)
 
 int ltfs_snmp_init(char *snmp_deffile)
 {
-#if ((!defined (__APPLE__)) && (!defined (mingw_PLATFORM)))
+#ifdef ENABLE_SNMP
 	ltfs_snmp_enabled = true;
 	netsnmp_ds_set_boolean(NETSNMP_DS_APPLICATION_ID, NETSNMP_DS_AGENT_ROLE, 1);
 	init_agent(AGENT);
@@ -160,7 +160,7 @@ int ltfs_snmp_finish()
 	struct trap_entry *entry = NULL;
 	TAILQ_FOREACH(entry, &trap_entries, list)
 		free(entry->id);
-#if ((!defined (__APPLE__)) && (!defined (mingw_PLATFORM)))
+#ifdef ENABLE_SNMP
 	send_ltfsStopTrap();
 	snmp_shutdown(AGENT);
 #endif
@@ -169,7 +169,7 @@ int ltfs_snmp_finish()
 
 int send_ltfsStartTrap(void)
 {
-#if ((!defined (__APPLE__)) && (!defined (mingw_PLATFORM)))
+#ifdef ENABLE_SNMP
 	netsnmp_variable_list *var_list = NULL;
 	const oid ltfsStartTrap_oid[] = { 1, 3, 6, 1, 4, 1, 2, 6, 248, 2, 1 };
 
@@ -191,7 +191,7 @@ int send_ltfsStartTrap(void)
 
 int send_ltfsStopTrap(void)
 {
-#if ((!defined (__APPLE__)) && (!defined (mingw_PLATFORM)))
+#ifdef ENABLE_SNMP
 	netsnmp_variable_list *var_list = NULL;
 	const oid ltfsStopTrap_oid[] = { 1, 3, 6, 1, 4, 1, 2, 6, 248, 2, 2 };
 
@@ -213,7 +213,7 @@ int send_ltfsStopTrap(void)
 
 int send_ltfsInfoTrap(char *str)
 {
-#if ((!defined (__APPLE__)) && (!defined (mingw_PLATFORM)))
+#ifdef ENABLE_SNMP
 	netsnmp_variable_list *var_list = NULL;
 	const oid ltfsInfoTrap_oid[] = { 1, 3, 6, 1, 4, 1, 2, 6, 248, 2, 3 };
 	const oid ltfsTrapInfo_oid[] = { 1, 3, 6, 1, 4, 1, 2, 6, 248, 1, 1, 0 };
@@ -244,7 +244,7 @@ int send_ltfsInfoTrap(char *str)
 
 int send_ltfsErrorTrap(char *str)
 {
-#if ((!defined (__APPLE__)) && (!defined (mingw_PLATFORM)))
+#ifdef ENABLE_SNMP
 	netsnmp_variable_list *var_list = NULL;
 	const oid ltfsErrorTrap_oid[] = { 1, 3, 6, 1, 4, 1, 2, 6, 248, 2, 4 };
 	const oid ltfsTrapInfo_oid[] = { 1, 3, 6, 1, 4, 1, 2, 6, 248, 1, 1, 0 };

--- a/src/libltfs/ltfssnmp.h
+++ b/src/libltfs/ltfssnmp.h
@@ -50,11 +50,11 @@
 #ifndef __LTFSSNMP_H__
 #define __LTFSSNMP_H__
 
-#if ((!defined (__APPLE__)) && (!defined (mingw_PLATFORM)))
+#ifdef ENABLE_SNMP
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/net-snmp-includes.h>
 #include <net-snmp/agent/net-snmp-agent-includes.h>
-#endif /* ((!defined (__APPLE__)) && (!defined (mingw_PLATFORM))) */
+#endif
 
 #include <stdbool.h>
 #include <errno.h>
@@ -63,7 +63,7 @@
 #include "libltfs/ltfslogging.h"
 
 /*
- * function declarations 
+ * function declarations
  */
 int ltfs_snmp_init(char *);
 int ltfs_snmp_finish();


### PR DESCRIPTION
# Summary: Add a switch to disable SNMP support

# Description

Add a switch to disable SNMP support because it can't be supported under OSX (macOS) Homebrew environment. --disable-snmp is needed to build on OSX (macOS) Homebrew environment.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
