### PR TITLE
Make lin_tape driver optional 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ At this time, the LTFS format specifications 2.4 is the target. The LTFS format 
 
 These instructions will get you a copy of the project up and running on your local machine for development and testing purposes.
 
-### Prerequisites
+## Prerequisites
 
 - Linux
   * automake 1.13.4 or later
@@ -35,9 +35,9 @@ These instructions will get you a copy of the project up and running on your loc
   * icu4c
   * gnu-sed
 
-### Installing
+## Installing
 
-#### Buid and install on Linux
+### Buid and install on Linux
 
 ```
 ./autogen.sh
@@ -48,7 +48,11 @@ make install
 
 `./configure --help` shows various options for build and install.
 
-#### Build and install on OSX (macOS)
+#### IBM lin_tape driver support
+
+You need to add `--enable-lintappe` as an argument of ./configure script if you want to build the backend for lin_tape. You also need to add `DEFAULT_TAPE=lin_tape` if you set the lin_tape backend as default backend.
+
+### Build and install on OSX (macOS)
 
 Before build on OSX (macOS), some include path adjustment is required.
 

--- a/conf/Makefile.am
+++ b/conf/Makefile.am
@@ -1,11 +1,17 @@
 dist_sysconf_DATA = ltfs.conf
 
+PLAT_OPT =
+
 if PLATFORM_LINUX
-PLAT_OPT = plugin tape lin_tape __LIBDIR__/ltfs/libtape-lin_tape.so\\nplugin tape sg __LIBDIR__/ltfs/libtape-sg-ibmtape.so
+PLAT_OPT += plugin tape sg __LIBDIR__/ltfs/libtape-sg-ibmtape.so
 endif
 
 if PLATFORM_MAC
-PLAT_OPT = plugin tape iokit __LIBDIR__/ltfs/libtape-iokit-ibmtape.so
+PLAT_OPT += plugin tape iokit __LIBDIR__/ltfs/libtape-iokit-ibmtape.so
+endif
+
+if ENABLE_LIN_TAPE
+PLAT_OPT += \\nplugin tape lin_tape __LIBDIR__/ltfs/libtape-lin_tape.so
 endif
 
 ltfs.conf: ltfs.conf.in

--- a/configure.ac
+++ b/configure.ac
@@ -116,33 +116,55 @@ dnl Handle --enable-snmp (default:yes)
 dnl
 AC_MSG_CHECKING([whether to enable snmp or not])
 AC_ARG_ENABLE([snmp],
-	[AS_HELP_STRING([--enable-snmp],[Support SNMP handling or not])],
+	[AS_HELP_STRING([--enable-snmp],[Support SNMP or not])],
 	[snmp=$enableval],
 	[snmp=yes]
 )
 AC_MSG_RESULT([$snmp])
 
 dnl
-dnl Check for special environment variables
+dnl Handle --enable-lin-tape (default:no, Linux Only)
+dnl
+AC_MSG_CHECKING([whether to enable lin_tape or not (Linux Only)])
+AC_ARG_ENABLE([lintape],
+	[AS_HELP_STRING([--enable-lintape],[Support IBM's lin_tape driver or not])],
+	[lintape=$enableval],
+	[lintape=no]
+)
+AC_MSG_RESULT([$lintape])
+
+dnl
+dnl Handle default backends
 dnl
 if test -z "$DEFAULT_TAPE"
 then
 	if test "x${host_linux}" = "xyes"
 	then
-		DEFAULT_TAPE=lin_tape
+		DEFAULT_TAPE=sg
 	fi
 	if test "x${host_mac}" = "xyes"
 	then
 		DEFAULT_TAPE=iokit
 	fi
 fi
+
+if test "x${DEFAULT_TAPE}" = "xlin_tape"
+then
+	if test "x${lintape}" != "xyes"
+	then
+		AC_MSG_ERROR([lin_tape is not enabled --enable-lintape is required.])
+	fi
+fi
+
 if test -z "$DEFAULT_IOSCHED" ; then
 	DEFAULT_IOSCHED=unified
 fi
+
 if test -z "$DEFAULT_KMI" ; then
 	DEFAULT_KMI=none
 fi
-AC_ARG_VAR([DEFAULT_TAPE], [default tape device plugin, e.g. lin_tape])
+
+AC_ARG_VAR([DEFAULT_TAPE], [default tape device plugin, e.g. sg])
 AC_ARG_VAR([DEFAULT_IOSCHED], [default I/O scheduler plugin, e.g. unified])
 AC_ARG_VAR([DEFAULT_KMI], [default key manager interface plugin, e.g. none])
 
@@ -358,8 +380,9 @@ CFLAGS="${CFLAGS} ${OPT_FLAGS}"
 dnl
 dnl Define options
 dnl
-AM_CONDITIONAL([PLATFORM_LINUX], [test "$host_linux" = "yes"])
-AM_CONDITIONAL([PLATFORM_MAC], [test "$host_mac" = "yes"])
+AM_CONDITIONAL([PLATFORM_LINUX], [test "x${host_linux}" = "xyes"])
+AM_CONDITIONAL([ENABLE_LIN_TAPE], [test "x${lintape}" = "xyes"])
+AM_CONDITIONAL([PLATFORM_MAC], [test "x${host_mac}" = "xyes"])
 
 AC_SUBST(CFLAGS)
 AC_SUBST(CRC_OPTIMIZE)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,14 +40,20 @@ ltfs_DEPENDENCIES = libltfs/libltfs.la ../messages/bin_ltfs_dat.o
 ltfs_CPPFLAGS = @AM_CPPFLAGS@ -I ../ltfs-sde/src
 ltfs_LDADD = libltfs/libltfs.la ../messages/bin_ltfs_dat.o
 
+PLAT_DRV =
+
 if PLATFORM_LINUX
-PLAT_OPT = tape_drivers/linux/lin_tape tape_drivers/linux/sg-ibmtape
+PLAT_DRV += tape_drivers/linux/sg-ibmtape
 endif
 
 if PLATFORM_MAC
-PLAT_OPT = tape_drivers/osx/iokit-ibmtape
+PLAT_DRV += tape_drivers/osx/iokit-ibmtape
+endif
+
+if ENABLE_LIN_TAPE
+PLAT_DRV += tape_drivers/linux/lin_tape
 endif
 
 generic_drivers = tape_drivers/generic/file tape_drivers/generic/itdtimg
-platform_drivers = $(PLAT_OPT)
+platform_drivers = $(PLAT_DRV)
 SUBDIRS = $(generic_drivers) $(platform_drivers) iosched kmi libltfs utils


### PR DESCRIPTION
# Summary: Please include a summary of the change

# Description

To support wider platforms, I decided to switch default backend from
lin_tape to sg, because lin_tape only supports a few platform.

After this change, sg backend is the default in Linux and iokit backend
is the default in OSX. lin_tape backend is built only when
`--enable-lintape` is specified in configure script. And lin_tape backend
is set default when `DEFAULT_TAPE=lin_tape` is specified in configure
script.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
