### PR TITLE
Avoid build break on non-unix environment

### DIFF
--- a/src/tape_drivers/ibm_tape.c
+++ b/src/tape_drivers/ibm_tape.c
@@ -47,11 +47,13 @@
 *************************************************************************************
 */
 
+#ifndef mingw_PLATFORM
 #include <netdb.h>
 #include <ifaddrs.h>
 #include <unistd.h>
 
 #define LOOP_BACK_DEVICE "lo"
+#endif
 
 #include "tape_drivers/ibm_tape.h"
 
@@ -1188,6 +1190,11 @@ int ibmtape_is_supported_tape(unsigned char type, unsigned char density, bool *i
  */
 int ibmtape_genkey(unsigned char *key)
 {
+#ifdef mingw_PLATFORM
+	memset(key, 0x00, KEYLEN);
+	*key = KEY_PREFIX_HOST;
+	strncpy(key + 1, "WINLTFS", KEYLEN - 1);
+#else
 	unsigned char host[KEYLEN];
 
 	struct ifaddrs *ifaddr, *ifa;
@@ -1256,6 +1263,7 @@ int ibmtape_genkey(unsigned char *key)
 	/* Return host name based key */
 	*key = KEY_PREFIX_HOST;
 	memcpy(key + 1, host, KEYLEN -1);
+#endif
 
 	return 0;
 }


### PR DESCRIPTION
# Summary: Avoid build break on non-unix environment

# Description

src/tape_drivers/ibm_tape.c makes a build break on MinGW. This fix avoid
this with dummy key data.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
