### PR TITLE
Cleaning LTFS label and LTFS index parser

### DIFF
--- a/src/libltfs/xml_libltfs.h
+++ b/src/libltfs/xml_libltfs.h
@@ -75,11 +75,10 @@
 
 /* Functions for writing XML files. See xml_writer_libltfs.c */
 xmlBufferPtr xml_make_label(const char *creator, tape_partition_t partition,
-	const struct ltfs_label *label);
-int xml_label_to_file(const char *filename, const char *creator, const struct ltfs_label *label);
+							const struct ltfs_label *label);
 xmlBufferPtr xml_make_schema(const char *creator, const struct ltfs_index *idx);
-int xml_schema_to_file(const char *filename, const char *creator
-					   , const char *reason, const struct ltfs_index *idx);
+int xml_schema_to_file(const char *filename, const char *creator,
+					   const char *reason, const struct ltfs_index *idx);
 int xml_schema_to_tape(char *reason, struct ltfs_volume *vol);
 
 /* Functions for reading XML files. See xml_reader_libltfs.c */

--- a/src/libltfs/xml_reader_libltfs.c
+++ b/src/libltfs/xml_reader_libltfs.c
@@ -73,35 +73,1544 @@
 #define IDX_VERSION_BACKUPTIME MAKE_LTFS_VERSION(2,0,0)
 #define IDX_VERSION_UID        MAKE_LTFS_VERSION(2,0,0)
 
-/* Label tag parsers */
-int _xml_parse_label(xmlTextReaderPtr reader, struct ltfs_label *label);
-int _xml_parse_label_location(xmlTextReaderPtr reader, struct ltfs_label *label);
-int _xml_parse_partition_map(xmlTextReaderPtr reader, struct ltfs_label *label);
+/**************************************************************************************
+ * Local Functions
+ **************************************************************************************/
 
-/* Schema tag parsers */
-int _xml_parse_schema(xmlTextReaderPtr reader, struct ltfs_index *idx, struct ltfs_volume *vol);
-int _xml_parse_policy(xmlTextReaderPtr reader, struct ltfs_index *idx);
-int _xml_parse_ip_criteria(xmlTextReaderPtr reader, struct ltfs_index *idx);
-int _xml_parse_dirtree(xmlTextReaderPtr reader, struct dentry *parent,
-	struct ltfs_index *idx, struct ltfs_volume *vol, struct name_list *list);
-int _xml_parse_dir_contents(xmlTextReaderPtr reader, struct dentry *dir, struct ltfs_index *idx);
-int _xml_parse_file(xmlTextReaderPtr reader, struct ltfs_index *idx, struct dentry *dir, struct name_list *list);
-int _xml_parse_extents(xmlTextReaderPtr reader, int idx_version, struct dentry *d);
-int _xml_parse_one_extent(xmlTextReaderPtr reader, int idx_version, struct dentry *d);
-int _xml_parse_xattrs(xmlTextReaderPtr reader, struct dentry *d);
-int _xml_parse_one_xattr(xmlTextReaderPtr read, struct dentry *d);
-int _xml_scan_tapepos(xmlTextReaderPtr reader, const char *tag, struct tape_offset *pos);
+/* Local functions for common parser setting */
 
-/* Generic tag parsers */
-int _xml_parser_init(xmlTextReaderPtr reader, const char *top_name, int *idx_version,
-	int min_version, int max_version);
+/**
+ * Make a percent encoded string
+ * @param new_name encoded string with memory allocation on success, to free the allocated
+ * 	               memory is caller responsibility
+ * @param name original text to encode
+ * @return 0 on success or a negative value on error.
+ */
+static int decode_entry_name(char **new_name, const char *name)
+{
+	int len;
+	char *tmp_name;
+	char buf_decode[3];
+	bool encoded = false;
+	int i = 0, j = 0;
 
-/* Value parsers */
-int _xml_parse_version(const char *version_str, int *version_int);
-int _xml_parse_partition(const char *val);
+	CHECK_ARG_NULL(name, -LTFS_NULL_ARG);
 
-/* Save symlink/extent conflicted dentries */
-int _xml_save_symlink_conflict(struct ltfs_index *idx, struct dentry *d);
+	len = strlen(name);
+	tmp_name = malloc(len * sizeof(UChar));
+	buf_decode[2] = '\0';
+
+	while (i < len) {
+		if (name[i] == '%') {
+			encoded = true;
+			i++;
+			continue;
+		}
+
+		if (encoded) {
+			buf_decode[0] = name[i];
+			buf_decode[1] = name[i+1];
+			tmp_name[j] = (int)strtol(buf_decode, NULL, 16);
+			encoded = false;
+			i+=2;
+		} else {
+			tmp_name[j] = name[i];
+			i++;
+		}
+		j++;
+	}
+	tmp_name[j] = '\0';
+
+	*new_name = strdup(tmp_name);
+	free(tmp_name);
+
+	return 0;
+}
+
+/**
+ * Verify that a given string really does represent a partition (single character, a-z).
+ */
+static int _xml_parse_partition(const char *val)
+{
+	CHECK_ARG_NULL(val, -LTFS_NULL_ARG);
+
+	if (strlen(val) != 1 || val[0] < 'a' || val[0] > 'z') {
+		ltfsmsg(LTFS_ERR, "17033E", val);
+		return -1;
+	}
+
+	return 0;
+}
+
+/**
+ * Parse a version number of the form X.Y from a string.
+ * @param version_str String to parse
+ * @param major Outputs the major version number X
+ * @param minor Outputs the minor version number Y
+ * @return 0 on success or a negative value on error.
+ */
+static int _xml_parse_version(const char *version_str, int *version_int)
+{
+	const char *y_str, *z_str, *tmp;
+
+	CHECK_ARG_NULL(version_str, -LTFS_NULL_ARG);
+	CHECK_ARG_NULL(version_int, -LTFS_NULL_ARG);
+
+	/* Legacy index version 1.0 */
+	if (! strcmp(version_str, "1.0")) {
+		*version_int = MAKE_LTFS_VERSION(1,0,0);
+		return 0;
+	}
+
+	tmp = version_str;
+	while (*tmp && *tmp >= '0' && *tmp <= '9')
+		++tmp;
+	if (tmp == version_str || *tmp != '.')
+		return -LTFS_BAD_ARG;
+	y_str = ++tmp;
+	while (*tmp && *tmp >= '0' && *tmp <= '9')
+		++tmp;
+	if (tmp == y_str || *tmp != '.')
+		return -LTFS_BAD_ARG;
+	z_str = ++tmp;
+	while (*tmp && *tmp >= '0' && *tmp <= '9')
+		++tmp;
+	if (tmp == z_str || *tmp != '\0')
+		return -LTFS_BAD_ARG;
+
+	*version_int = MAKE_LTFS_VERSION(atoi(version_str), atoi(y_str), atoi(z_str));
+	return 0;
+}
+
+/**
+ * Start parsing an XML stream by checking the encoding and version.
+ */
+static int _xml_parser_init(xmlTextReaderPtr reader, const char *top_name, int *idx_version,
+							int min_version, int max_version)
+{
+	const char *name, *encoding;
+	char *value;
+	int type, ver;
+
+	if (xml_next_tag(reader, "", &name, &type) < 0)
+		return -1;
+	if (strcmp(name, top_name)) {
+		ltfsmsg(LTFS_ERR, "17017E", name);
+		return -1;
+	}
+
+	/* reject this XML file if it isn't UTF-8 */
+	encoding = (const char *)xmlTextReaderConstEncoding(reader);
+	if (! encoding || strcmp(encoding, "UTF-8")) {
+		ltfsmsg(LTFS_ERR, "17018E", encoding);
+		return -1;
+	}
+
+	/* check the version attribute of the top-level tag */
+	value = (char *)xmlTextReaderGetAttribute(reader, BAD_CAST "version");
+	if (! value) {
+		ltfsmsg(LTFS_ERR, "17019E");
+		return -1;
+	}
+	if (_xml_parse_version(value, &ver) < 0) {
+		ltfsmsg(LTFS_ERR, "17020E", value);
+		return -LTFS_UNSUPPORTED_INDEX_VERSION;
+	}
+	if (ver < min_version || ver > max_version) {
+		ltfsmsg(LTFS_ERR, "17021E", top_name, value);
+		free(value);
+		return -LTFS_UNSUPPORTED_INDEX_VERSION;
+	}
+	*idx_version = ver;
+	free(value);
+
+	return 0;
+}
+
+/* Local functions for LTFS label parsing */
+
+/**
+ * Parse a partition location from a label.
+ */
+static int _xml_parse_label_location(xmlTextReaderPtr reader, struct ltfs_label *label)
+{
+	declare_parser_vars("location");
+	declare_tracking_arrays(1, 0);
+
+	while (true) {
+		get_next_tag();
+
+		if (! strcmp(name, "partition")) {
+			check_required_tag(0);
+			get_tag_text();
+			if (_xml_parse_partition(value) < 0)
+				return -1;
+			label->this_partition = value[0];
+			check_tag_end("partition");
+
+		} else
+			ignore_unrecognized_tag();
+	}
+
+	check_required_tags();
+	return 0;
+}
+
+/**
+ * Parse a partition map from an XML file, storing it in the given label structure.
+ */
+static int _xml_parse_partition_map(xmlTextReaderPtr reader, struct ltfs_label *label)
+{
+	declare_parser_vars("partitions");
+	declare_tracking_arrays(2, 0);
+
+	while (true) {
+		get_next_tag();
+
+		if (! strcmp(name, "index")) {
+			check_required_tag(0);
+			get_tag_text();
+			if (_xml_parse_partition(value) < 0)
+				return -1;
+			label->partid_ip = value[0];
+			check_tag_end("index");
+
+		} else if (! strcmp(name, "data")) {
+			check_required_tag(1);
+			get_tag_text();
+			if (_xml_parse_partition(value) < 0)
+				return -1;
+			label->partid_dp = value[0];
+			check_tag_end("data");
+
+		} else
+			ignore_unrecognized_tag();
+	}
+
+	check_required_tags();
+	return 0;
+}
+
+/**
+ * Parse an XML label, populating the given label data structure.
+ */
+static int _xml_parse_label(xmlTextReaderPtr reader, struct ltfs_label *label)
+{
+	int ret;
+	unsigned long long value_int;
+	declare_parser_vars("ltfslabel");
+	declare_tracking_arrays(7, 0);
+
+	/* start the parser: find top-level "label" tag, check version and encoding */
+	if (_xml_parser_init(reader, parent_tag, &label->version,
+						 LTFS_LABEL_VERSION_MIN, LTFS_LABEL_VERSION_MAX) < 0)
+		return -1;
+
+	/* parse label contents */
+	while (true) {
+		get_next_tag();
+
+		if (! strcmp(name, "creator")) {
+			check_required_tag(0);
+			get_tag_text();
+			if (label->creator)
+				free(label->creator);
+			label->creator = strdup(value);
+			if (! label->creator) {
+				ltfsmsg(LTFS_ERR, "10001E", name);
+				return -1;
+			}
+			check_tag_end("creator");
+
+		} else if (! strcmp(name, "formattime")) {
+			check_required_tag(1);
+			get_tag_text();
+			ret = xml_parse_time(true, value, &label->format_time);
+			if (ret < 0)
+				return -1;
+			else if (ret == LTFS_TIME_OUT_OF_RANGE)
+				ltfsmsg(LTFS_WARN, "17218W", "formattime", value);
+			check_tag_end("formattime");
+
+		} else if (! strcmp(name, "volumeuuid")) {
+			check_required_tag(2);
+			get_tag_text();
+			if (xml_parse_uuid(label->vol_uuid, value) < 0)
+				return -1;
+			check_tag_end("volumeuuid");
+
+		} else if (! strcmp(name, "location")) {
+			check_required_tag(3);
+			assert_not_empty();
+			if (_xml_parse_label_location(reader, label) < 0)
+				return -1;
+
+		} else if (! strcmp(name, "partitions")) {
+			check_required_tag(4);
+			assert_not_empty();
+			if (_xml_parse_partition_map(reader, label) < 0)
+				return -1;
+
+		} else if (! strcmp(name, "blocksize")) {
+			check_required_tag(5);
+			get_tag_text();
+			if (xml_parse_ull(&value_int, value) < 0 || value_int == 0) {
+				ltfsmsg(LTFS_ERR, "17022E", value);
+				return -1;
+			}
+			label->blocksize = value_int;
+			check_tag_end("blocksize");
+
+		} else if (! strcmp(name, "compression")) {
+			check_required_tag(6);
+			get_tag_text();
+			if (xml_parse_bool(&label->enable_compression, value) < 0)
+				return -1;
+			check_tag_end("compression");
+
+		} else
+			ignore_unrecognized_tag();
+	}
+
+	check_required_tags();
+	return 0;
+}
+
+/* Local functions for LTFS index parsing */
+
+/**
+ * Parse index partition criteria.
+ */
+static int _xml_parse_ip_criteria(xmlTextReaderPtr reader, struct ltfs_index *idx)
+{
+	int ret;
+	unsigned long long value_int;
+	char *glob_norm;
+	int num_patterns = 0;
+	declare_parser_vars("indexpartitioncriteria");
+	declare_tracking_arrays(1, 0);
+
+	/* clear the glob pattern list first */
+	index_criteria_free(&idx->original_criteria);
+	index_criteria_free(&idx->index_criteria);
+
+	/* We have a policy. */
+	idx->original_criteria.have_criteria = true;
+
+	while (true) {
+		get_next_tag();
+
+		if (! strcmp(name, "size")) {
+			check_required_tag(0);
+			get_tag_text();
+			if (xml_parse_ull(&value_int, value) < 0) {
+				ltfsmsg(LTFS_ERR, "17024E", value);
+				return -1;
+			}
+			idx->original_criteria.max_filesize_criteria = value_int;
+			check_tag_end("size");
+
+		} else if (! strcmp(name, "name")) {
+			get_tag_text();
+
+			if (pathname_validate_file(value) < 0) {
+				ltfsmsg(LTFS_ERR, "17098E", value);
+				return -1;
+			}
+
+			++num_patterns;
+			/* quite inefficient, but the number of patterns should be small. */
+			idx->original_criteria.glob_patterns = realloc(idx->original_criteria.glob_patterns,
+														   (num_patterns + 1) * sizeof(char *));
+			if (! idx->original_criteria.glob_patterns) {
+				ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+				return -1;
+			}
+			idx->original_criteria.glob_patterns[num_patterns] = NULL;
+
+			ret = pathname_normalize(value, &glob_norm);
+			if (ret < 0) {
+				ltfsmsg(LTFS_ERR, "17025E", ret);
+				return ret;
+			}
+			idx->original_criteria.glob_patterns[num_patterns - 1] = glob_norm;
+
+			check_tag_end("name");
+
+		} else
+			ignore_unrecognized_tag();
+	}
+
+	/* Make an active copy of these index criteria. The caller can override idx->index_criteria
+	 * later without affecting the criteria stored in future indexes (idx->original_criteria). */
+	if (index_criteria_dup_rules(&idx->index_criteria, &idx->original_criteria) < 0) {
+		/* Could not duplicate index criteria rules */
+		ltfsmsg(LTFS_ERR, "11301E");
+		return -1;
+	}
+
+	check_required_tags();
+	return 0;
+}
+
+/**
+ * Parse a data placement policy.
+ */
+static int _xml_parse_policy(xmlTextReaderPtr reader, struct ltfs_index *idx)
+{
+	declare_parser("dataplacementpolicy");
+	declare_tracking_arrays(1, 0);
+
+	/* parse the contents of the policy tag */
+	while (true) {
+		get_next_tag();
+
+		if (! strcmp(name, "indexpartitioncriteria")) {
+			check_required_tag(0);
+			assert_not_empty();
+			if (_xml_parse_ip_criteria(reader, idx) < 0)
+				return -1;
+
+		} else
+			ignore_unrecognized_tag();
+	}
+
+	check_required_tags();
+	return 0;
+}
+
+/**
+ * Parse an extent from an XML source, appending it to the given dentry's extent list.
+ */
+static int _xml_parse_one_extent(xmlTextReaderPtr reader, int idx_version, struct dentry *d)
+{
+	unsigned long long value_int;
+	struct extent_info *xt, *xt_last;
+	declare_parser_vars("extent");
+	declare_tracking_arrays(5, 0);
+
+	xt = calloc(1, sizeof(struct extent_info));
+	if (!xt) {
+		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		return -1;
+	}
+
+	while (true) {
+		get_next_tag();
+
+		if (! strcmp(name, "partition")) {
+			check_required_tag(0);
+			get_tag_text();
+			if (_xml_parse_partition(value) < 0) {
+				free(xt);
+				return -1;
+			}
+			xt->start.partition = value[0];
+			check_tag_end("partition");
+
+		} else if (! strcmp(name, "startblock")) {
+			check_required_tag(1);
+			get_tag_text();
+			if (xml_parse_ull(&value_int, value) < 0) {
+				free(xt);
+				return -1;
+			}
+			xt->start.block = value_int;
+			check_tag_end("startblock");
+
+		} else if (! strcmp(name, "byteoffset")) {
+			check_required_tag(2);
+			get_tag_text();
+			if (xml_parse_ull(&value_int, value) < 0) {
+				free(xt);
+				return -1;
+			}
+			xt->byteoffset = value_int;
+			check_tag_end("byteoffset");
+
+		} else if (! strcmp(name, "bytecount")) {
+			check_required_tag(3);
+			get_tag_text();
+			if (xml_parse_ull(&value_int, value) < 0) {
+				free(xt);
+				return -1;
+			}
+			xt->bytecount = value_int;
+			check_tag_end("bytecount");
+
+		} else if (idx_version >= IDX_VERSION_SPARSE && ! strcmp(name, "fileoffset")) {
+			check_required_tag(4);
+			get_tag_text();
+			if (xml_parse_ull(&value_int, value) < 0) {
+				free(xt);
+				return -1;
+			}
+			xt->fileoffset = value_int;
+			check_tag_end("fileoffset");
+
+		} else
+			ignore_unrecognized_tag();
+	}
+
+	/* For older index versions, set fileoffset at the end of the previous extent */
+	if (idx_version < IDX_VERSION_SPARSE) {
+		check_required_tag(4);
+		if (TAILQ_EMPTY(&d->extentlist))
+			xt->fileoffset = 0;
+		else {
+			xt_last = TAILQ_LAST(&d->extentlist, extent_struct);
+			xt->fileoffset = xt_last->fileoffset + xt_last->bytecount;
+		}
+	}
+
+	check_required_tags();
+
+	/* Add extent to the extent list, performing appropriate reordering if necessary.
+	 * Also make sure the new extent does not overlap with any existing extents. */
+	if (TAILQ_EMPTY(&d->extentlist))
+		TAILQ_INSERT_TAIL(&d->extentlist, xt, list);
+	else {
+		bool xt_used = false;
+		TAILQ_FOREACH_REVERSE(xt_last, &d->extentlist, extent_struct, list) {
+			if (xt_last->fileoffset + xt_last->bytecount <= xt->fileoffset) {
+				TAILQ_INSERT_AFTER(&d->extentlist, xt_last, xt, list);
+				xt_used = true;
+				break;
+			} else if (xt->fileoffset + xt->bytecount > xt_last->fileoffset) {
+				/* Overlap error */
+				ltfsmsg(LTFS_ERR, "17097E");
+				free(xt);
+				return -1;
+			}
+		}
+		if (! xt_used)
+			TAILQ_INSERT_HEAD(&d->extentlist, xt, list);
+	}
+
+	d->realsize += xt->bytecount;
+
+	if (d->vol) {
+		d->used_blocks += ((xt->byteoffset + xt->bytecount) / d->vol->label->blocksize);
+		if ((xt->byteoffset + xt->bytecount) % d->vol->label->blocksize)
+			d->used_blocks++;
+	}
+
+	return 0;
+}
+
+/**
+ * Parse a file's extent list.
+ */
+static int _xml_parse_extents(xmlTextReaderPtr reader, int idx_version, struct dentry *d)
+{
+	declare_parser("extentinfo");
+	declare_tracking_arrays(0, 0);
+
+	while (true) {
+		get_next_tag();
+
+		if (! strcmp(name, "extent")) {
+			assert_not_empty();
+			if (_xml_parse_one_extent(reader, idx_version, d) < 0)
+				return -1;
+
+		} else
+			ignore_unrecognized_tag();
+	}
+
+	check_required_tags();
+	return 0;
+}
+
+/**
+ * Parse a single extended attribute, appending it to the xattr list of the given dentry.
+ */
+static int _xml_parse_one_xattr(xmlTextReaderPtr reader, struct dentry *d)
+{
+	char *xattr_type;
+	struct xattr_info *xattr;
+	declare_parser_vars("xattr");
+	declare_tracking_arrays(2, 0);
+	char *encode;
+
+	xattr = calloc(1, sizeof(struct xattr_info));
+	if (! xattr) {
+		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		return -1;
+	}
+
+	while (true) {
+		get_next_tag();
+
+		if (! strcmp(name, "key")) {
+			check_required_tag(0);
+			encode = (char *)xmlTextReaderGetAttribute(reader, BAD_CAST "percentencoded");
+			if (encode && !strcmp(encode, "true")) {
+				xattr->encoded = true;
+			}
+
+			get_tag_text();
+			if (xml_parse_filename(&xattr->key, value) < 0) {
+				free(xattr);
+				return -1;
+			}
+
+			if (xattr->encoded) {
+				char *new_key;
+				decode_entry_name(&new_key, xattr->key);
+				strcpy(xattr->key, new_key);
+                free(new_key);
+			}
+
+			check_tag_end("key");
+
+		} else if (! strcmp(name, "value")) {
+			check_required_tag(1);
+
+			xattr_type = (char *)xmlTextReaderGetAttribute(reader, BAD_CAST "type");
+			if (xattr_type && strcmp(xattr_type, "text") && strcmp(xattr_type, "base64")) {
+				ltfsmsg(LTFS_ERR, "17027E", xattr_type);
+				free(xattr);
+				return -1;
+			}
+
+			check_empty();
+			if (empty == 0) {
+				if (xml_scan_text(reader, &value) < 0) {
+					free(xattr->key);
+					free(xattr);
+					return -1;
+				}
+				if (! xattr_type || ! strcmp(xattr_type, "text")) {
+					xattr->value = strdup(value);
+					if (! xattr->value) {
+						ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+						free(xattr->key);
+						free(xattr);
+						return -1;
+					}
+					xattr->size = strlen(value);
+				} else { /* base64 */
+					xattr->size = base64_decode(
+						(const unsigned char *)value,
+						strlen(value),
+						(unsigned char **)(&xattr->value));
+					if (xattr->size == 0) {
+						ltfsmsg(LTFS_ERR, "17028E");
+						free(xattr->key);
+						free(xattr);
+						return -1;
+					}
+				}
+				if (strlen(value) > 0)
+					check_tag_end("value");
+			} else {
+				xattr->value = NULL;
+				xattr->size = 0;
+			}
+			free(xattr_type);
+
+		} else
+			ignore_unrecognized_tag();
+	}
+
+	check_required_tags();
+	TAILQ_INSERT_TAIL(&d->xattrlist, xattr, list);
+
+	if (!strcmp(xattr->key, "ltfs.vendor.IBM.immutable") && !strcmp(xattr->value, "1") ) {
+		d->is_immutable = true;
+	}
+	if (!strcmp(xattr->key, "ltfs.vendor.IBM.appendonly") && !strcmp(xattr->value, "1") ) {
+		d->is_appendonly = true;
+	}
+
+	return 0;
+}
+
+/**
+ * Parse extended attributes for a file or directory.
+ */
+static int _xml_parse_xattrs(xmlTextReaderPtr reader, struct dentry *d)
+{
+	declare_parser("extendedattributes");
+	declare_tracking_arrays(0, 0);
+
+	while (true) {
+		get_next_tag();
+
+		if (! strcmp(name, "xattr")) {
+			assert_not_empty();
+			if (_xml_parse_one_xattr(reader, d) < 0)
+				return -1;
+
+		} else
+			ignore_unrecognized_tag();
+	}
+
+	check_required_tags();
+	return 0;
+}
+
+/**
+ * Parse a tape offset (a partition tag and a startblock tag) from an XML source.
+ * @param reader the XML source
+ * @param tag name of the tag containing the tape position. This function will read to the end
+ *            of that tag, so it is not suitable for reading an extent list (which has other
+ *            children that need to be parsed).
+ * @param pos pointer to a structure where the offset will be stored
+ * @return 0 on success or a negative value on error
+ */
+static int _xml_parse_tapepos(xmlTextReaderPtr reader, const char *tag, struct tape_offset *pos)
+{
+	unsigned long long value_int;
+	declare_parser_vars(tag);
+	declare_tracking_arrays(2, 0);
+
+	while (true) {
+		get_next_tag();
+
+		if (! strcmp(name, "partition")) {
+			check_required_tag(0);
+			get_tag_text();
+			if (_xml_parse_partition(value) < 0)
+				return -1;
+			pos->partition = value[0];
+			check_tag_end("partition");
+
+		} else if (! strcmp(name, "startblock")) {
+			check_required_tag(1);
+			get_tag_text();
+			if (xml_parse_ull(&value_int, value) < 0)
+				return -1;
+			pos->block = value_int;
+			check_tag_end("startblock");
+
+		} else
+			ignore_unrecognized_tag();
+	}
+
+	check_required_tags();
+	return 0;
+}
+
+/**
+ * Save conflict of symlink, the node which has both symlink and extent
+ */
+static int _xml_save_symlink_conflict( struct ltfs_index *idx, struct dentry *d)
+{
+	size_t c = idx->symerr_count + 1;
+	struct dentry **err_d;
+
+	err_d = realloc( idx->symlink_conflict, c * sizeof(size_t));
+	if (! err_d) {
+		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		return -1;
+	}
+	err_d[c-1] = d;
+
+	idx->symlink_conflict = err_d;
+	idx->symerr_count = c;
+
+	return 0;
+}
+
+/**
+ * Parse a file into the given directory.
+ */
+static int _xml_parse_file(xmlTextReaderPtr reader, struct ltfs_index *idx, struct dentry *dir, struct name_list *filename)
+{
+	int ret;
+	unsigned long long value_int;
+	struct dentry *file;
+	struct extent_info *xt_last;
+	declare_parser_vars("file");
+	declare_tracking_arrays(9, 4);
+	bool symlink_flag=false, extent_flag=false, openforwrite=false;
+	char *encode;
+
+	file = fs_allocate_dentry(dir, NULL, NULL, false, false, false, idx);
+	if (! file) {
+		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		return -1;
+	}
+
+	while (true) {
+		get_next_tag();
+
+		if (! strcmp(name, "name")) {
+			check_required_tag(0);
+			encode = (char *)xmlTextReaderGetAttribute(reader, BAD_CAST "percentencoded");
+			if (encode && !strcmp(encode, "true")) {
+				file->percent_encode = true;
+			}
+
+			get_tag_text();
+			if (xml_parse_filename(&file->name, value) < 0)
+				return -1;
+
+			if (file->percent_encode) {
+				char *new_name;
+				decode_entry_name(&new_name, file->name);
+				strcpy(file->name, new_name);
+                free(new_name);
+			}
+
+			filename->name = file->name;
+			filename->d = file;
+			check_tag_end("name");
+
+		} else if (!strcmp(name, "length")) {
+			check_required_tag(1);
+			get_tag_text();
+			if (xml_parse_ull(&value_int, value) < 0)
+				return -1;
+			file->size = value_int;
+			check_tag_end("length");
+
+		} else if (!strcmp(name, "readonly")) {
+			check_required_tag(2);
+			get_tag_text();
+			if (xml_parse_bool(&file->readonly, value) < 0)
+				return -1;
+			check_tag_end("readonly");
+
+		} else if (!strcmp(name, "modifytime")) {
+			check_required_tag(3);
+			get_tag_text();
+			ret = xml_parse_time(true, value, &file->modify_time);
+			if (ret < 0)
+				return -1;
+			else if (ret == LTFS_TIME_OUT_OF_RANGE)
+				ltfsmsg(LTFS_WARN, "17220W", "modifytime", file->name, file->uid, value);
+			check_tag_end("modifytime");
+
+		} else if (!strcmp(name, "creationtime")) {
+			check_required_tag(4);
+			get_tag_text();
+			ret = xml_parse_time(true, value, &file->creation_time);
+			if (ret < 0)
+				return -1;
+			else if (ret == LTFS_TIME_OUT_OF_RANGE)
+				ltfsmsg(LTFS_WARN, "17220W", "creationtime", file->name, file->uid, value);
+
+			check_tag_end("creationtime");
+
+		} else if (!strcmp(name, "accesstime")) {
+			check_required_tag(5);
+			get_tag_text();
+			ret = xml_parse_time(true, value, &file->access_time);
+			if (ret < 0)
+				return -1;
+			else if (ret == LTFS_TIME_OUT_OF_RANGE)
+				ltfsmsg(LTFS_WARN, "17220W", "accesstime", file->name, file->uid, value);
+			check_tag_end("accesstime");
+
+		} else if (!strcmp(name, "changetime")) {
+			check_required_tag(6);
+			get_tag_text();
+			ret = xml_parse_time(true, value, &file->change_time);
+			if (ret < 0)
+				return -1;
+			else if (ret == LTFS_TIME_OUT_OF_RANGE)
+				ltfsmsg(LTFS_WARN, "17220W", "changetime", file->name, file->uid, value);
+			check_tag_end("changetime");
+
+		} else if (!strcmp(name, "extendedattributes")) {
+			check_optional_tag(0);
+			check_empty();
+			if (empty == 0 && _xml_parse_xattrs(reader, file) < 0)
+				return -1;
+
+		} else if (!strcmp(name, "extentinfo")) {
+			check_optional_tag(1);
+			check_empty();
+			if (empty == 0 && _xml_parse_extents(reader, idx->version, file) < 0)
+				return -1;
+			else extent_flag = true;
+
+        } else if (!strcmp(name, "symlink")) {
+			check_optional_tag(2);
+			get_tag_text();
+			file->target = strdup(value);
+			file->isslink = true;
+			symlink_flag = true;
+
+			check_tag_end("symlink");
+
+		} else if (!strcmp(name, "openforwrite")) {
+			check_optional_tag(3);
+			get_tag_text();
+			if (xml_parse_bool(&openforwrite, value) < 0) {
+				ltfsmsg(LTFS_WARN, "17252W", value, "openforwrite", file->uid);
+			} else {
+				if (openforwrite)
+					ltfsmsg(LTFS_INFO, "17251I", file->name, file->uid);
+			}
+			check_tag_end("openforwrite");
+
+		} else if (idx->version >= IDX_VERSION_UID && ! strcmp(name, UID_TAGNAME)) {
+			check_required_tag(7);
+			get_tag_text();
+			if (xml_parse_ull(&value_int, value) < 0)
+				return -1;
+			file->uid = value_int;
+			if (file->uid > idx->uid_number)
+				idx->uid_number = file->uid;
+			filename->uid  = file->uid;
+			check_tag_end(UID_TAGNAME);
+		} else if (! strcmp(name, UID_TAGNAME)) {
+			ignore_unrecognized_tag();
+
+		} else if (idx->version >= IDX_VERSION_BACKUPTIME && ! strcmp(name, BACKUPTIME_TAGNAME)) {
+			check_required_tag(8);
+			get_tag_text();
+			ret = xml_parse_time(true, value, &file->backup_time);
+			if (ret < 0)
+				return -1;
+			else if (ret == LTFS_TIME_OUT_OF_RANGE)
+				ltfsmsg(LTFS_WARN, "17220W", "backuptime", file->name, file->uid, value);
+
+			check_tag_end(BACKUPTIME_TAGNAME);
+		} else if (! strcmp(name, BACKUPTIME_TAGNAME)) {
+			ignore_unrecognized_tag();
+
+		} else
+			preserve_unrecognized_tag(file);
+	}
+
+	/* For old index versions, allocate a UID */
+	if (idx->version < IDX_VERSION_UID) {
+		check_required_tag(7);
+		file->uid = fs_allocate_uid(idx);
+		if (file->uid > idx->uid_number)
+			idx->uid_number = file->uid;
+		filename->uid  = file->uid;
+	}
+
+	/* For old index versions, set backup time equal to creation time */
+	if (idx->version < IDX_VERSION_BACKUPTIME) {
+		check_required_tag(8);
+		file->backup_time = file->creation_time;
+	}
+
+	check_required_tags();
+
+	/* check that file size is not shorter than the extent list */
+	if (! TAILQ_EMPTY(&file->extentlist)) {
+		xt_last = TAILQ_LAST(&file->extentlist, extent_struct);
+		if (xt_last->fileoffset + xt_last->bytecount > file->size) {
+			ltfsmsg(LTFS_ERR, "17026E");
+			return -1;
+		}
+	}
+
+	/* Validate UID: must be nonzero (UID 0 is reserved for the root directory) */
+	if (file->uid == 0) {
+		ltfsmsg(LTFS_ERR, "17101E");
+		return -1;
+	}
+
+	if ( symlink_flag && extent_flag ) {
+		ltfsmsg(LTFS_ERR, "17180E", file->name);
+		if ( _xml_save_symlink_conflict( idx, file ) ) return -1;
+	}
+
+	return 0;
+}
+
+/**
+ * Parse a dir into the given directory.
+ */
+
+static int _xml_parse_dirtree(xmlTextReaderPtr reader, struct dentry *parent,
+							  struct ltfs_index *idx, struct ltfs_volume *vol,
+							  struct name_list *dirname); /* Forward reference */
+
+static int _xml_parse_dir_contents(xmlTextReaderPtr reader, struct dentry *dir, struct ltfs_index *idx)
+{
+	struct name_list *list = NULL, *entry_name = NULL;
+	CHECK_ARG_NULL(dir, -LTFS_NULL_ARG);
+	declare_parser("contents");
+	declare_tracking_arrays(0, 0);
+
+	errno = 0;
+
+	while (true) {
+		get_next_tag();
+
+		if (! strcmp(name, "file")) {
+			assert_not_empty();
+			entry_name = (struct name_list *)malloc(sizeof(struct name_list));
+			if (!entry_name) {
+				ltfsmsg(LTFS_ERR, "10001E", "_xml_parse_dir_contents: file");
+				return -LTFS_NO_MEMORY;
+			}
+			if (_xml_parse_file(reader, idx, dir, entry_name) < 0) {
+				free(entry_name);
+				return -1;
+			}
+
+		} else if (! strcmp(name, "directory")) {
+			assert_not_empty();
+			entry_name = (struct name_list *)malloc(sizeof(struct name_list));
+			if (!entry_name) {
+				ltfsmsg(LTFS_ERR, "10001E", "_xml_parse_dir_contents: dir");
+				return -LTFS_NO_MEMORY;
+			}
+			if (_xml_parse_dirtree(reader, dir, idx, dir->vol, entry_name) < 0) {
+				free(entry_name);
+				return -1;
+			}
+
+		} else {
+			ignore_unrecognized_tag();
+			entry_name = NULL;
+		}
+		if (!strcmp(name, "file") || (!strcmp(name, "directory") && !(!dir && idx->root))) {
+			/* Make temporal hash table whose key is dentry name */
+			HASH_ADD_KEYPTR(hh, list, entry_name->name, strlen(entry_name->name), entry_name);
+			if (errno == ENOMEM) {
+				struct name_list *list_ptr, *list_tmp;
+
+				HASH_ITER(hh, list, list_ptr, list_tmp) {
+					HASH_DEL(list, list_ptr);
+					free(list_ptr);
+				}
+
+				ltfsmsg(LTFS_ERR, "10001E", "_xml_parse_dir_contents: add key");
+				free(entry_name);
+
+				return -LTFS_NO_MEMORY;
+			}
+		} else {
+			free(entry_name);
+			entry_name = NULL;
+		}
+	}
+
+	/* At first, update platform_safe_name without replacing invalid chars in the directory.
+	   The file or directory of which name contains invalid char is skipped in this step.
+	   After that update platfrom_safe_name regarding skipped file or directory as the second
+	   step. These steps make a prioritization of name mangling.*/
+	if (fs_update_platform_safe_names(dir, idx, list)!=0) {
+		return -1;
+	}
+
+	check_required_tags();
+	return 0;
+}
+
+/**
+ * Parse a directory tree from the given XML source into the given index data structure.
+ * @param reader the XML source
+ * @param parent Directory where the new subdirectory should be created, or NULL to populate the
+ *               root dentry.
+ * @param idx LTFS index data
+ * @param vol LTFS volume to which the index belongs. May be NULL.
+ * @return 0 on success or a negative value on error
+ */
+static int _xml_parse_dirtree(xmlTextReaderPtr reader, struct dentry *parent,
+							  struct ltfs_index *idx, struct ltfs_volume *vol,
+							  struct name_list *dirname)
+{
+	int ret;
+	unsigned long long value_int;
+	struct dentry *dir;
+	char *encode;
+	declare_parser_vars("directory");
+	declare_tracking_arrays(9, 1);
+
+	if (! parent && idx->root) {
+		dir = idx->root;
+		dir->vol = vol;
+	} else {
+		dir = fs_allocate_dentry(parent, NULL, NULL, true, false, false, idx);
+		if (! dir) {
+			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			return -LTFS_NO_MEMORY;
+		}
+		if (! parent) {
+			idx->root = dir;
+			dir->vol = vol;
+			++dir->link_count;
+		}
+	}
+
+	while (true) {
+		get_next_tag();
+
+		if (!strcmp(name, "name")) {
+			check_required_tag(0);
+
+			encode = (char *)xmlTextReaderGetAttribute(reader, BAD_CAST "percentencoded");
+
+			if (parent) {
+				if (encode && !strcmp(encode, "true")) {
+					dir->percent_encode = true;
+				}
+
+				get_tag_text();
+				if (xml_parse_filename(&dir->name, value) < 0)
+					return -1;
+
+				if (dir->percent_encode) {
+					char *new_name;
+					decode_entry_name(&new_name, dir->name);
+					strcpy(dir->name, new_name);
+					free(new_name);
+				}
+
+				dirname->name = dir->name;
+				dirname->d = dir;
+				check_tag_end("name");
+			} else {
+				/* this is the root directory, so set the volume name */
+				check_empty();
+				if (empty > 0) {
+					value = NULL;
+				} else {
+					if (xml_scan_text(reader, &value) < 0)
+						return -1;
+				}
+
+				if (value && strlen(value) > 0) {
+					if (xml_parse_filename(&idx->volume_name, value) < 0)
+						return -1;
+					/* if the value is the empty string, then xml_scan_text consumed the "name"
+					 * element end */
+
+					if (encode && !strcmp(encode, "true")) {
+						char *new_name;
+						decode_entry_name(&new_name, idx->volume_name);
+						strcpy(idx->volume_name, new_name);
+						free(new_name);
+					}
+
+					check_tag_end("name");
+				} else
+					idx->volume_name = NULL;
+			}
+
+			if (encode)
+				free(encode);
+
+		} else if (!strcmp(name, "readonly")) {
+			check_required_tag(1);
+			get_tag_text();
+			if (xml_parse_bool(&dir->readonly, value) < 0)
+				return -1;
+			check_tag_end("readonly");
+
+		} else if (!strcmp(name, "modifytime")) {
+			check_required_tag(2);
+			get_tag_text();
+			ret = xml_parse_time(true, value, &dir->modify_time);
+			if (ret < 0)
+				return -1;
+			else if (ret == LTFS_TIME_OUT_OF_RANGE)
+				ltfsmsg(LTFS_WARN, "17220W", "updatetime", dir->name, dir->uid, value);
+
+			check_tag_end("modifytime");
+
+		} else if (!strcmp(name, "creationtime")) {
+			check_required_tag(3);
+			get_tag_text();
+			ret = xml_parse_time(true, value, &dir->creation_time);
+			if (ret < 0)
+				return -1;
+			else if (ret == LTFS_TIME_OUT_OF_RANGE)
+				ltfsmsg(LTFS_WARN, "17220W", "creationtime", dir->name, dir->uid, value);
+
+			check_tag_end("creationtime");
+
+		} else if (!strcmp(name, "accesstime")) {
+			check_required_tag(4);
+			get_tag_text();
+			ret = xml_parse_time(true, value, &dir->access_time);
+			if (ret < 0)
+				return -1;
+			else if (ret == LTFS_TIME_OUT_OF_RANGE)
+				ltfsmsg(LTFS_WARN, "17220W", "accesstime", dir->name, dir->uid, value);
+
+			check_tag_end("accesstime");
+
+		} else if (!strcmp(name, "changetime")) {
+			check_required_tag(5);
+			get_tag_text();
+			ret = xml_parse_time(true, value, &dir->change_time);
+			if (ret < 0)
+				return -1;
+			else if (ret == LTFS_TIME_OUT_OF_RANGE)
+				ltfsmsg(LTFS_WARN, "17220W", "changetime", dir->name, dir->uid, value);
+
+			check_tag_end("changetime");
+
+		} else if (! strcmp(name, "contents")) {
+			check_required_tag(6);
+			check_empty();
+			if (empty == 0 && _xml_parse_dir_contents(reader, dir, idx) < 0)
+				return -1;
+
+		} else if (!strcmp(name, "extendedattributes")) {
+			check_optional_tag(0);
+			check_empty();
+			if (empty == 0 && _xml_parse_xattrs(reader, dir) < 0)
+				return -1;
+
+		} else if (idx->version >= IDX_VERSION_UID && ! strcmp(name, UID_TAGNAME)) {
+			check_required_tag(7);
+			get_tag_text();
+			if (xml_parse_ull(&value_int, value) < 0)
+				return -1;
+			dir->uid = value_int;
+			if (dir->uid > idx->uid_number)
+				idx->uid_number = dir->uid;
+			if (parent) {
+				dirname->uid  = dir->uid;
+			}
+			check_tag_end(UID_TAGNAME);
+		} else if (! strcmp(name, UID_TAGNAME)) {
+			ignore_unrecognized_tag();
+
+		} else if (idx->version >= IDX_VERSION_BACKUPTIME && ! strcmp(name, BACKUPTIME_TAGNAME)) {
+			check_required_tag(8);
+			get_tag_text();
+			ret = xml_parse_time(true, value, &dir->backup_time);
+			if (ret < 0)
+				return -1;
+			else if (ret == LTFS_TIME_OUT_OF_RANGE)
+				ltfsmsg(LTFS_WARN, "17220W", "backuptime", dir->name, dir->uid, value);
+
+			check_tag_end(BACKUPTIME_TAGNAME);
+		} else if (! strcmp(name, BACKUPTIME_TAGNAME)) {
+			ignore_unrecognized_tag();
+
+		} else
+			preserve_unrecognized_tag(dir);
+	}
+
+	/* For old index versions, allocate a UID */
+	if (idx->version < IDX_VERSION_UID) {
+		check_required_tag(7);
+		if (parent) {
+			dir->uid = fs_allocate_uid(idx);
+			if (dir->uid > idx->uid_number)
+				idx->uid_number = dir->uid;
+			dirname->uid  = dir->uid;
+		}
+		/* root directory already got assigned UID 1 by fs_allocate_dentry */
+	}
+
+	/* For old index versions, set backup time equal to creation time */
+	if (idx->version < IDX_VERSION_BACKUPTIME) {
+		check_required_tag(8);
+		dir->backup_time = dir->creation_time;
+	}
+
+	check_required_tags();
+
+	/* Validate UID: root directory must have uid==1, other dentries must have nonzero UID */
+	/* TODO: would be nice to verify that there are no UID conflicts */
+	if (parent && dir->uid == 1) {
+		ltfsmsg(LTFS_ERR, "17101E");
+		return -1;
+	} else if (! parent && dir->uid != 1) {
+		ltfsmsg(LTFS_ERR, "17100E");
+		return -1;
+	} else if (dir->uid == 0) {
+		ltfsmsg(LTFS_ERR, "17106E");
+		return -1;
+	}
+
+	return 0;
+}
+
+/**
+ * Parse an index file from the given source and populate the priv->root virtual dentry tree.
+ * with the nodes found during the scanning.
+ * @param reader Source of XML data
+ * @param idx LTFS index
+ * @param vol LTFS volume to which the index belongs. May be NULL.
+ * @return 0 on success or a negative value on error.
+ */
+static int _xml_parse_schema(xmlTextReaderPtr reader, struct ltfs_index *idx, struct ltfs_volume *vol)
+{
+	int ret;
+	unsigned long long value_int;
+	declare_parser_vars("ltfsindex");
+	declare_tracking_arrays(8, 4);
+
+	/* start the parser: find top-level "index" tag, check version and encoding */
+	ret = _xml_parser_init(reader, parent_tag, &idx->version,
+						   LTFS_INDEX_VERSION_MIN, LTFS_INDEX_VERSION_MAX);
+	if (ret < 0)
+		return ret;
+
+	if (idx->version < LTFS_INDEX_VERSION)
+		ltfsmsg(LTFS_WARN, "17095W",
+				LTFS_INDEX_VERSION_STR,
+				LTFS_FORMAT_MAJOR(idx->version),
+				LTFS_FORMAT_MINOR(idx->version),
+				LTFS_FORMAT_REVISION(idx->version));
+	else if (idx->version / 100 > LTFS_INDEX_VERSION / 100)
+		ltfsmsg(LTFS_WARN, "17096W",
+				LTFS_INDEX_VERSION_STR,
+				LTFS_FORMAT_MAJOR(idx->version),
+				LTFS_FORMAT_MINOR(idx->version),
+				LTFS_FORMAT_REVISION(idx->version));
+	else if (idx->version > LTFS_INDEX_VERSION)
+		ltfsmsg(LTFS_WARN, "17234W",
+				LTFS_INDEX_VERSION_STR,
+				LTFS_FORMAT_MAJOR(idx->version),
+				LTFS_FORMAT_MINOR(idx->version),
+				LTFS_FORMAT_REVISION(idx->version));
+
+	if (idx->commit_message) {
+		free(idx->commit_message);
+		idx->commit_message = NULL;
+	}
+
+	/* parse index file contents */
+	while (true) {
+		get_next_tag();
+
+		if (! strcmp(name, "creator")) {
+			check_required_tag(0);
+			get_tag_text();
+			if (idx->creator)
+				free(idx->creator);
+			idx->creator = strdup(value);
+			if (! idx->creator) {
+				ltfsmsg(LTFS_ERR, "10001E", name);
+				return -1;
+			}
+			check_tag_end("creator");
+
+		} else if (! strcmp(name, "volumeuuid")) {
+			check_required_tag(1);
+			get_tag_text();
+			if (xml_parse_uuid(idx->vol_uuid, value) < 0)
+				return -1;
+			check_tag_end("volumeuuid");
+
+		} else if (! strcmp(name, "generationnumber")) {
+			check_required_tag(2);
+			get_tag_text();
+			if (xml_parse_ull(&value_int, value) < 0) {
+				ltfsmsg(LTFS_ERR, "17023E", value);
+				return -1;
+			}
+			idx->generation = value_int;
+			check_tag_end("generationnumber");
+
+		} else if (! strcmp(name, "updatetime")) {
+			check_required_tag(3);
+			get_tag_text();
+			ret = xml_parse_time(true, value, &idx->mod_time);
+			if (ret < 0)
+				return -1;
+			else if (ret == LTFS_TIME_OUT_OF_RANGE)
+				ltfsmsg(LTFS_WARN, "17219W", "updatetime", value);
+
+			check_tag_end("updatetime");
+
+		} else if (! strcmp(name, "location")) {
+			check_required_tag(4);
+			assert_not_empty();
+			if (_xml_parse_tapepos(reader, "location", &idx->selfptr) < 0)
+				return -1;
+
+		} else if (! strcmp(name, "allowpolicyupdate")) {
+			check_required_tag(5);
+			get_tag_text();
+			if (xml_parse_bool(&idx->criteria_allow_update, value) < 0)
+				return -1;
+			check_tag_end("allowpolicyupdate");
+
+		} else if (! strcmp(name, "directory")) {
+			check_required_tag(6);
+			assert_not_empty();
+			if (_xml_parse_dirtree(reader, NULL, idx, vol, NULL) < 0)
+				return -1;
+
+		} else if (! strcmp(name, "previousgenerationlocation")) {
+			check_optional_tag(0);
+			assert_not_empty();
+			if (_xml_parse_tapepos(reader, "previousgenerationlocation", &idx->backptr) < 0)
+				return -1;
+
+		} else if (! strcmp(name, "dataplacementpolicy")) {
+			check_optional_tag(1);
+			assert_not_empty();
+			if (_xml_parse_policy(reader, idx) < 0)
+				return -1;
+
+		} else if (! strcmp(name, "comment")) {
+			check_optional_tag(2);
+			get_tag_text();
+			if (strlen(value) > INDEX_MAX_COMMENT_LEN) {
+				ltfsmsg(LTFS_ERR, "17094E");
+				return -1;
+			}
+			idx->commit_message = strdup(value);
+			if (! idx->commit_message) {
+				ltfsmsg(LTFS_ERR, "10001E", "_xml_parse_schema: index comment");
+				return -1;
+			}
+			check_tag_end("comment");
+		} else if (! strcmp(name, "volumelockstate")) {
+			check_optional_tag(3);
+			get_tag_text();
+
+			if (!strcmp(value, "unlocked")) {
+				idx->vollock = VOLUME_UNLOCKED;
+			} else if (!strcmp(value, "locked")) {
+				idx->vollock = VOLUME_LOCKED;
+			} else if (!strcmp(value, "permlocked")) {
+				idx->vollock = VOLUME_PERM_LOCKED;
+			}
+			check_tag_end("volumelockstate");
+		} else if (idx->version >= IDX_VERSION_UID && ! strcmp(name, NEXTUID_TAGNAME)) {
+			check_required_tag(7);
+			get_tag_text();
+			if (xml_parse_ull(&value_int, value) < 0)
+				return -1;
+			if (value_int > idx->uid_number)
+				idx->uid_number = value_int;
+			check_tag_end(NEXTUID_TAGNAME);
+		} else if (! strcmp(name, NEXTUID_TAGNAME)) {
+			ignore_unrecognized_tag();
+
+		} else
+			preserve_unrecognized_tag(idx);
+	}
+
+	/* For older index versions, assume we handle UIDs correctly.
+	 * The idx->uid_number field is automatically initialized to 1, so it will be set correctly
+	 * once all files and directories are parsed. */
+	if (idx->version < IDX_VERSION_UID)
+		check_required_tag(7);
+
+	check_required_tags();
+
+	if ( idx->symerr_count != 0 ) {
+		return -LTFS_SYMLINK_CONFLICT;
+	}
+
+	return 0;
+}
+
+/* Local functions for parsing dcache */
+static int _xml_parse_symlink_target(xmlTextReaderPtr reader, int idx_version, struct dentry *d)
+{
+	declare_parser_vars_symlinknode("symlink");
+	declare_tracking_arrays(1, 0);
+
+	while (true) {
+		get_next_tag();
+
+		if (! strcmp(name, "target")) {
+			get_tag_text();
+			d->isslink = true;
+			d->target = strdup(value);
+		} else
+			ignore_unrecognized_tag();
+	}
+
+	return 0;
+}
+
+static int _xml_symlinkinfo_from_file(const char *filename, struct dentry *d)
+{
+	declare_parser_vars_symlink("symlink");
+	xmlTextReaderPtr reader;
+	xmlDocPtr doc;
+	int ret = 0;
+
+	CHECK_ARG_NULL(filename, -LTFS_NULL_ARG);
+	CHECK_ARG_NULL(d, -LTFS_NULL_ARG);
+
+	reader = xmlReaderForFile(filename, NULL, XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
+	if (! reader) {
+		ltfsmsg(LTFS_ERR, "17011E", filename);
+		return -1;
+	}
+
+	/* Workaround for old libxml2 version on OS X 10.5: the method used to preserve
+	 * unknown tags modifies the behavior of xmlFreeTextReader so that an additional
+	 * xmlDocFree call is required to free all memory. */
+	doc = xmlTextReaderCurrentDoc(reader);
+
+	while (true) {
+		get_next_tag();
+		if (! strcmp(name, "symlink")) {
+			ret = _xml_parse_symlink_target(reader, IDX_VERSION_SPARSE, d);
+			if (ret < 0) {
+				/* XML parser: failed to read extent list from file (%d) */
+				ltfsmsg(LTFS_ERR, "17084E", ret);
+			}
+		}
+		break;
+	}
+
+	if (doc)
+		xmlFreeDoc(doc);
+	xmlFreeTextReader(reader);
+
+	return ret;
+}
+
+/**
+ * Parse an extent list from a file and populate provided dentry with the extents read during
+ * the scanning.
+ *
+ * @param filename File name from where to read the extent list from.
+ * @param d Dentry where the extents are to be appended to.
+ * @return 0 on success or a negative value on error.
+ */
+static int _xml_extentlist_from_file(const char *filename, struct dentry *d)
+{
+	declare_extent_parser_vars("extentinfo");
+	xmlTextReaderPtr reader;
+	xmlDocPtr doc;
+	int ret = 0;
+
+	CHECK_ARG_NULL(filename, -LTFS_NULL_ARG);
+	CHECK_ARG_NULL(d, -LTFS_NULL_ARG);
+
+	reader = xmlReaderForFile(filename, NULL, XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
+	if (! reader) {
+		ltfsmsg(LTFS_ERR, "17011E", filename);
+		return -1;
+	}
+
+	/* Workaround for old libxml2 version on OS X 10.5: the method used to preserve
+	 * unknown tags modifies the behavior of xmlFreeTextReader so that an additional
+	 * xmlDocFree call is required to free all memory. */
+	doc = xmlTextReaderCurrentDoc(reader);
+
+	while (true) { /* BEAM: loop doesn't iterate - Because get_next_tag() macro uses "break", at most once loop is needed here. */
+		get_next_tag();
+		if (! strcmp(name, "extentinfo")) {
+			ret = _xml_parse_extents(reader, IDX_VERSION_SPARSE, d);
+			if (ret < 0) {
+				/* XML parser: failed to read extent list from file (%d) */
+				ltfsmsg(LTFS_ERR, "17084E", ret);
+			}
+		}
+		break;
+	}
+
+	if (doc)
+		xmlFreeDoc(doc);
+	xmlFreeTextReader(reader);
+
+	return ret;
+}
+
+/**************************************************************************************
+ * Global Functions
+ **************************************************************************************/
 
 int xml_label_from_file(const char *filename, struct ltfs_label *label)
 {
@@ -299,113 +1808,12 @@ int xml_schema_from_tape(uint64_t eod_pos, struct ltfs_volume *vol)
 	return ret;
 }
 
-static int _xml_parse_symlink_target(xmlTextReaderPtr reader, int idx_version, struct dentry *d)
-{
-	declare_parser_vars_symlinknode("symlink");
-	declare_tracking_arrays(1, 0);
-
-	while (true) {
-		get_next_tag();
-
-		if (! strcmp(name, "target")) {
-			get_tag_text();
-			d->isslink = true;
-			d->target = strdup(value);
-		} else
-			ignore_unrecognized_tag();
-	}
-
-	return 0;
-}
-
-static int xml_symlinkinfo_from_file(const char *filename, struct dentry *d)
-{
-	declare_parser_vars_symlink("symlink");
-	xmlTextReaderPtr reader;
-	xmlDocPtr doc;
-	int ret = 0;
-
-	CHECK_ARG_NULL(filename, -LTFS_NULL_ARG);
-	CHECK_ARG_NULL(d, -LTFS_NULL_ARG);
-
-	reader = xmlReaderForFile(filename, NULL, XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
-	if (! reader) {
-		ltfsmsg(LTFS_ERR, "17011E", filename);
-		return -1;
-	}
-
-	/* Workaround for old libxml2 version on OS X 10.5: the method used to preserve
-	 * unknown tags modifies the behavior of xmlFreeTextReader so that an additional
-	 * xmlDocFree call is required to free all memory. */
-	doc = xmlTextReaderCurrentDoc(reader);
-
-	while (true) {
-		get_next_tag();
-		if (! strcmp(name, "symlink")) {
-			ret = _xml_parse_symlink_target(reader, IDX_VERSION_SPARSE, d);
-			if (ret < 0) {
-				/* XML parser: failed to read extent list from file (%d) */
-				ltfsmsg(LTFS_ERR, "17084E", ret);
-			}
-		}
-		break;
-	}
-
-	if (doc)
-		xmlFreeDoc(doc);
-	xmlFreeTextReader(reader);
-
-	return ret;
-}
-
 /**
- * Parse an extent list from a file and populate provided dentry with the extents read during
- * the scanning.
- *
- * @param filename File name from where to read the extent list from.
- * @param d Dentry where the extents are to be appended to.
+ * Parse an XML file for dcache and reconstruct dentry
+ * @param filename file name for dentry.
+ * @param dentry dentry to reconstruct
  * @return 0 on success or a negative value on error.
  */
-static int xml_extentlist_from_file(const char *filename, struct dentry *d)
-{
-	declare_extent_parser_vars("extentinfo");
-	xmlTextReaderPtr reader;
-	xmlDocPtr doc;
-	int ret = 0;
-
-	CHECK_ARG_NULL(filename, -LTFS_NULL_ARG);
-	CHECK_ARG_NULL(d, -LTFS_NULL_ARG);
-
-	reader = xmlReaderForFile(filename, NULL, XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
-	if (! reader) {
-		ltfsmsg(LTFS_ERR, "17011E", filename);
-		return -1;
-	}
-
-	/* Workaround for old libxml2 version on OS X 10.5: the method used to preserve
-	 * unknown tags modifies the behavior of xmlFreeTextReader so that an additional
-	 * xmlDocFree call is required to free all memory. */
-	doc = xmlTextReaderCurrentDoc(reader);
-
-	while (true) { /* BEAM: loop doesn't iterate - Because get_next_tag() macro uses "break", at most once loop is needed here. */
-		get_next_tag();
-		if (! strcmp(name, "extentinfo")) {
-			ret = _xml_parse_extents(reader, IDX_VERSION_SPARSE, d);
-			if (ret < 0) {
-				/* XML parser: failed to read extent list from file (%d) */
-				ltfsmsg(LTFS_ERR, "17084E", ret);
-			}
-		}
-		break;
-	}
-
-	if (doc)
-		xmlFreeDoc(doc);
-	xmlFreeTextReader(reader);
-
-	return ret;
-}
-
 int xml_extent_symlink_info_from_file(const char *filename, struct dentry *d)
 {
 	int ret;
@@ -413,1410 +1821,11 @@ int xml_extent_symlink_info_from_file(const char *filename, struct dentry *d)
 	CHECK_ARG_NULL(filename, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(d, -LTFS_NULL_ARG);
 
-	ret = xml_extentlist_from_file(filename, d);
+	ret = _xml_extentlist_from_file(filename, d);
 
 	if (d->realsize==0) {
-		ret = xml_symlinkinfo_from_file(filename, d);
+		ret = _xml_symlinkinfo_from_file(filename, d);
 	}
 
 	return ret;
-}
-
-/**
- * Start parsing an XML stream by checking the encoding and version.
- */
-int _xml_parser_init(xmlTextReaderPtr reader, const char *top_name, int *idx_version,
-	int min_version, int max_version)
-{
-	const char *name, *encoding;
-	char *value;
-	int type, ver;
-
-	if (xml_next_tag(reader, "", &name, &type) < 0)
-		return -1;
-	if (strcmp(name, top_name)) {
-		ltfsmsg(LTFS_ERR, "17017E", name);
-		return -1;
-	}
-
-	/* reject this XML file if it isn't UTF-8 */
-	encoding = (const char *)xmlTextReaderConstEncoding(reader);
-	if (! encoding || strcmp(encoding, "UTF-8")) {
-		ltfsmsg(LTFS_ERR, "17018E", encoding);
-		return -1;
-	}
-
-	/* check the version attribute of the top-level tag */
-	value = (char *)xmlTextReaderGetAttribute(reader, BAD_CAST "version");
-	if (! value) {
-		ltfsmsg(LTFS_ERR, "17019E");
-		return -1;
-	}
-	if (_xml_parse_version(value, &ver) < 0) {
-		ltfsmsg(LTFS_ERR, "17020E", value);
-		return -LTFS_UNSUPPORTED_INDEX_VERSION;
-	}
-	if (ver < min_version || ver > max_version) {
-		ltfsmsg(LTFS_ERR, "17021E", top_name, value);
-		free(value);
-		return -LTFS_UNSUPPORTED_INDEX_VERSION;
-	}
-	*idx_version = ver;
-	free(value);
-
-	return 0;
-}
-
-/**
- * Parse an XML label, populating the given label data structure.
- */
-int _xml_parse_label(xmlTextReaderPtr reader, struct ltfs_label *label)
-{
-	int ret;
-	unsigned long long value_int;
-	declare_parser_vars("ltfslabel");
-	declare_tracking_arrays(7, 0);
-
-	/* start the parser: find top-level "label" tag, check version and encoding */
-	if (_xml_parser_init(reader, parent_tag, &label->version,
-		LTFS_LABEL_VERSION_MIN, LTFS_LABEL_VERSION_MAX) < 0)
-		return -1;
-
-	/* parse label contents */
-	while (true) {
-		get_next_tag();
-
-		if (! strcmp(name, "creator")) {
-			check_required_tag(0);
-			get_tag_text();
-			if (label->creator)
-				free(label->creator);
-			label->creator = strdup(value);
-			if (! label->creator) {
-				ltfsmsg(LTFS_ERR, "10001E", name);
-				return -1;
-			}
-			check_tag_end("creator");
-
-		} else if (! strcmp(name, "formattime")) {
-			check_required_tag(1);
-			get_tag_text();
-			ret = xml_parse_time(true, value, &label->format_time);
-			if (ret < 0)
-				return -1;
-			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17218W", "formattime", value);
-			check_tag_end("formattime");
-
-		} else if (! strcmp(name, "volumeuuid")) {
-			check_required_tag(2);
-			get_tag_text();
-			if (xml_parse_uuid(label->vol_uuid, value) < 0)
-				return -1;
-			check_tag_end("volumeuuid");
-
-		} else if (! strcmp(name, "location")) {
-			check_required_tag(3);
-			assert_not_empty();
-			if (_xml_parse_label_location(reader, label) < 0)
-				return -1;
-
-		} else if (! strcmp(name, "partitions")) {
-			check_required_tag(4);
-			assert_not_empty();
-			if (_xml_parse_partition_map(reader, label) < 0)
-				return -1;
-
-		} else if (! strcmp(name, "blocksize")) {
-			check_required_tag(5);
-			get_tag_text();
-			if (xml_parse_ull(&value_int, value) < 0 || value_int == 0) {
-				ltfsmsg(LTFS_ERR, "17022E", value);
-				return -1;
-			}
-			label->blocksize = value_int;
-			check_tag_end("blocksize");
-
-		} else if (! strcmp(name, "compression")) {
-			check_required_tag(6);
-			get_tag_text();
-			if (xml_parse_bool(&label->enable_compression, value) < 0)
-				return -1;
-			check_tag_end("compression");
-
-		} else
-			ignore_unrecognized_tag();
-	}
-
-	check_required_tags();
-	return 0;
-}
-
-/**
- * Parse a partition location from a label.
- */
-int _xml_parse_label_location(xmlTextReaderPtr reader, struct ltfs_label *label)
-{
-	declare_parser_vars("location");
-	declare_tracking_arrays(1, 0);
-
-	while (true) {
-		get_next_tag();
-
-		if (! strcmp(name, "partition")) {
-			check_required_tag(0);
-			get_tag_text();
-			if (_xml_parse_partition(value) < 0)
-				return -1;
-			label->this_partition = value[0];
-			check_tag_end("partition");
-
-		} else
-			ignore_unrecognized_tag();
-	}
-
-	check_required_tags();
-	return 0;
-}
-
-/**
- * Parse a partition map from an XML file, storing it in the given label structure.
- */
-int _xml_parse_partition_map(xmlTextReaderPtr reader, struct ltfs_label *label)
-{
-	declare_parser_vars("partitions");
-	declare_tracking_arrays(2, 0);
-
-	while (true) {
-		get_next_tag();
-
-		if (! strcmp(name, "index")) {
-			check_required_tag(0);
-			get_tag_text();
-			if (_xml_parse_partition(value) < 0)
-				return -1;
-			label->partid_ip = value[0];
-			check_tag_end("index");
-
-		} else if (! strcmp(name, "data")) {
-			check_required_tag(1);
-			get_tag_text();
-			if (_xml_parse_partition(value) < 0)
-				return -1;
-			label->partid_dp = value[0];
-			check_tag_end("data");
-
-		} else
-			ignore_unrecognized_tag();
-	}
-
-	check_required_tags();
-	return 0;
-}
-
-/**
- * Parse an index file from the given source and populate the priv->root virtual dentry tree.
- * with the nodes found during the scanning.
- * @param reader Source of XML data
- * @param idx LTFS index
- * @param vol LTFS volume to which the index belongs. May be NULL.
- * @return 0 on success or a negative value on error.
- */
-int _xml_parse_schema(xmlTextReaderPtr reader, struct ltfs_index *idx, struct ltfs_volume *vol)
-{
-	int ret;
-	unsigned long long value_int;
-	declare_parser_vars("ltfsindex");
-	declare_tracking_arrays(8, 4);
-
-	/* start the parser: find top-level "index" tag, check version and encoding */
-	ret = _xml_parser_init(reader, parent_tag, &idx->version,
-						   LTFS_INDEX_VERSION_MIN, LTFS_INDEX_VERSION_MAX);
-	if (ret < 0)
-		return ret;
-
-	if (idx->version < LTFS_INDEX_VERSION)
-		ltfsmsg(LTFS_WARN, "17095W",
-				LTFS_INDEX_VERSION_STR,
-				LTFS_FORMAT_MAJOR(idx->version),
-				LTFS_FORMAT_MINOR(idx->version),
-				LTFS_FORMAT_REVISION(idx->version));
-	else if (idx->version / 100 > LTFS_INDEX_VERSION / 100)
-		ltfsmsg(LTFS_WARN, "17096W",
-				LTFS_INDEX_VERSION_STR,
-				LTFS_FORMAT_MAJOR(idx->version),
-				LTFS_FORMAT_MINOR(idx->version),
-				LTFS_FORMAT_REVISION(idx->version));
-	else if (idx->version > LTFS_INDEX_VERSION)
-		ltfsmsg(LTFS_WARN, "17234W",
-				LTFS_INDEX_VERSION_STR,
-				LTFS_FORMAT_MAJOR(idx->version),
-				LTFS_FORMAT_MINOR(idx->version),
-				LTFS_FORMAT_REVISION(idx->version));
-
-	if (idx->commit_message) {
-		free(idx->commit_message);
-		idx->commit_message = NULL;
-	}
-
-	/* parse index file contents */
-	while (true) {
-		get_next_tag();
-
-		if (! strcmp(name, "creator")) {
-			check_required_tag(0);
-			get_tag_text();
-			if (idx->creator)
-				free(idx->creator);
-			idx->creator = strdup(value);
-			if (! idx->creator) {
-				ltfsmsg(LTFS_ERR, "10001E", name);
-				return -1;
-			}
-			check_tag_end("creator");
-
-		} else if (! strcmp(name, "volumeuuid")) {
-			check_required_tag(1);
-			get_tag_text();
-			if (xml_parse_uuid(idx->vol_uuid, value) < 0)
-				return -1;
-			check_tag_end("volumeuuid");
-
-		} else if (! strcmp(name, "generationnumber")) {
-			check_required_tag(2);
-			get_tag_text();
-			if (xml_parse_ull(&value_int, value) < 0) {
-				ltfsmsg(LTFS_ERR, "17023E", value);
-				return -1;
-			}
-			idx->generation = value_int;
-			check_tag_end("generationnumber");
-
-		} else if (! strcmp(name, "updatetime")) {
-			check_required_tag(3);
-			get_tag_text();
-			ret = xml_parse_time(true, value, &idx->mod_time);
-			if (ret < 0)
-				return -1;
-			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17219W", "updatetime", value);
-
-			check_tag_end("updatetime");
-
-		} else if (! strcmp(name, "location")) {
-			check_required_tag(4);
-			assert_not_empty();
-			if (_xml_scan_tapepos(reader, "location", &idx->selfptr) < 0)
-				return -1;
-
-		} else if (! strcmp(name, "allowpolicyupdate")) {
-			check_required_tag(5);
-			get_tag_text();
-			if (xml_parse_bool(&idx->criteria_allow_update, value) < 0)
-				return -1;
-			check_tag_end("allowpolicyupdate");
-
-		} else if (! strcmp(name, "directory")) {
-			check_required_tag(6);
-			assert_not_empty();
-			if (_xml_parse_dirtree(reader, NULL, idx, vol, NULL) < 0)
-				return -1;
-
-		} else if (! strcmp(name, "previousgenerationlocation")) {
-			check_optional_tag(0);
-			assert_not_empty();
-			if (_xml_scan_tapepos(reader, "previousgenerationlocation", &idx->backptr) < 0)
-				return -1;
-
-		} else if (! strcmp(name, "dataplacementpolicy")) {
-			check_optional_tag(1);
-			assert_not_empty();
-			if (_xml_parse_policy(reader, idx) < 0)
-				return -1;
-
-		} else if (! strcmp(name, "comment")) {
-			check_optional_tag(2);
-			get_tag_text();
-			if (strlen(value) > INDEX_MAX_COMMENT_LEN) {
-				ltfsmsg(LTFS_ERR, "17094E");
-				return -1;
-			}
-			idx->commit_message = strdup(value);
-			if (! idx->commit_message) {
-				ltfsmsg(LTFS_ERR, "10001E", "_xml_parse_schema: index comment");
-				return -1;
-			}
-			check_tag_end("comment");
-		} else if (! strcmp(name, "volumelockstate")) {
-			check_optional_tag(3);
-			get_tag_text();
-
-			if (!strcmp(value, "unlocked")) {
-				idx->vollock = VOLUME_UNLOCKED;
-			} else if (!strcmp(value, "locked")) {
-				idx->vollock = VOLUME_LOCKED;
-			} else if (!strcmp(value, "permlocked")) {
-				idx->vollock = VOLUME_PERM_LOCKED;
-			}
-			check_tag_end("volumelockstate");
-		} else if (idx->version >= IDX_VERSION_UID && ! strcmp(name, NEXTUID_TAGNAME)) {
-			check_required_tag(7);
-			get_tag_text();
-			if (xml_parse_ull(&value_int, value) < 0)
-				return -1;
-			if (value_int > idx->uid_number)
-				idx->uid_number = value_int;
-			check_tag_end(NEXTUID_TAGNAME);
-		} else if (! strcmp(name, NEXTUID_TAGNAME)) {
-			ignore_unrecognized_tag();
-
-		} else
-			preserve_unrecognized_tag(idx);
-	}
-
-	/* For older index versions, assume we handle UIDs correctly.
-	 * The idx->uid_number field is automatically initialized to 1, so it will be set correctly
-	 * once all files and directories are parsed. */
-	if (idx->version < IDX_VERSION_UID)
-		check_required_tag(7);
-
-	check_required_tags();
-
-	if ( idx->symerr_count != 0 ) {
-		return -LTFS_SYMLINK_CONFLICT;
-	}
-
-
-	return 0;
-}
-
-/**
- * Parse a data placement policy.
- */
-int _xml_parse_policy(xmlTextReaderPtr reader, struct ltfs_index *idx)
-{
-	declare_parser("dataplacementpolicy");
-	declare_tracking_arrays(1, 0);
-
-	/* parse the contents of the policy tag */
-	while (true) {
-		get_next_tag();
-
-		if (! strcmp(name, "indexpartitioncriteria")) {
-			check_required_tag(0);
-			assert_not_empty();
-			if (_xml_parse_ip_criteria(reader, idx) < 0)
-				return -1;
-
-		} else
-			ignore_unrecognized_tag();
-	}
-
-	check_required_tags();
-	return 0;
-}
-
-/**
- * Parse index partition criteria.
- */
-int _xml_parse_ip_criteria(xmlTextReaderPtr reader, struct ltfs_index *idx)
-{
-	int ret;
-	unsigned long long value_int;
-	char *glob_norm;
-	int num_patterns = 0;
-	declare_parser_vars("indexpartitioncriteria");
-	declare_tracking_arrays(1, 0);
-
-	/* clear the glob pattern list first */
-	index_criteria_free(&idx->original_criteria);
-	index_criteria_free(&idx->index_criteria);
-
-	/* We have a policy. */
-	idx->original_criteria.have_criteria = true;
-
-	while (true) {
-		get_next_tag();
-
-		if (! strcmp(name, "size")) {
-			check_required_tag(0);
-			get_tag_text();
-			if (xml_parse_ull(&value_int, value) < 0) {
-				ltfsmsg(LTFS_ERR, "17024E", value);
-				return -1;
-			}
-			idx->original_criteria.max_filesize_criteria = value_int;
-			check_tag_end("size");
-
-		} else if (! strcmp(name, "name")) {
-			get_tag_text();
-
-			if (pathname_validate_file(value) < 0) {
-				ltfsmsg(LTFS_ERR, "17098E", value);
-				return -1;
-			}
-
-			++num_patterns;
-			/* quite inefficient, but the number of patterns should be small. */
-			idx->original_criteria.glob_patterns = realloc(idx->original_criteria.glob_patterns,
-				(num_patterns + 1) * sizeof(char *));
-			if (! idx->original_criteria.glob_patterns) {
-				ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
-				return -1;
-			}
-			idx->original_criteria.glob_patterns[num_patterns] = NULL;
-
-			ret = pathname_normalize(value, &glob_norm);
-			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "17025E", ret);
-				return ret;
-			}
-			idx->original_criteria.glob_patterns[num_patterns - 1] = glob_norm;
-
-			check_tag_end("name");
-
-		} else
-			ignore_unrecognized_tag();
-	}
-
-	/* Make an active copy of these index criteria. The caller can override idx->index_criteria
-	 * later without affecting the criteria stored in future indexes (idx->original_criteria). */
-	if (index_criteria_dup_rules(&idx->index_criteria, &idx->original_criteria) < 0) {
-		/* Could not duplicate index criteria rules */
-		ltfsmsg(LTFS_ERR, "11301E");
-		return -1;
-	}
-
-	check_required_tags();
-	return 0;
-}
-
-static int decode_entry_name(char **new_name, const char *name)
-{
-	int len;
-	char *tmp_name;
-	char buf_decode[3];
-	bool encoded = false;
-	int i = 0, j = 0;
-
-	CHECK_ARG_NULL(name, -LTFS_NULL_ARG);
-
-	len = strlen(name);
-	tmp_name = malloc(len * sizeof(UChar));
-	buf_decode[2] = '\0';
-
-	while (i < len) {
-		if (name[i] == '%') {
-			encoded = true;
-			i++;
-			continue;
-		}
-
-		if (encoded) {
-			buf_decode[0] = name[i];
-			buf_decode[1] = name[i+1];
-			tmp_name[j] = (int)strtol(buf_decode, NULL, 16);
-			encoded = false;
-			i+=2;
-		} else {
-			tmp_name[j] = name[i];
-			i++;
-		}
-		j++;
-	}
-	tmp_name[j] = '\0';
-
-	*new_name = strdup(tmp_name);
-	free(tmp_name);
-
-	return 0;
-}
-
-/**
- * Parse a directory tree from the given XML source into the given index data structure.
- * @param reader the XML source
- * @param parent Directory where the new subdirectory should be created, or NULL to populate the
- *               root dentry.
- * @param idx LTFS index data
- * @param vol LTFS volume to which the index belongs. May be NULL.
- * @return 0 on success or a negative value on error
- */
-int _xml_parse_dirtree(xmlTextReaderPtr reader, struct dentry *parent,
-	struct ltfs_index *idx, struct ltfs_volume *vol, struct name_list *dirname)
-{
-	int ret;
-	unsigned long long value_int;
-	struct dentry *dir;
-	char *encode;
-	declare_parser_vars("directory");
-	declare_tracking_arrays(9, 1);
-
-	if (! parent && idx->root) {
-		dir = idx->root;
-		dir->vol = vol;
-	} else {
-		dir = fs_allocate_dentry(parent, NULL, NULL, true, false, false, idx);
-		if (! dir) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
-			return -LTFS_NO_MEMORY;
-		}
-		if (! parent) {
-			idx->root = dir;
-			dir->vol = vol;
-			++dir->link_count;
-		}
-	}
-
-	while (true) {
-		get_next_tag();
-
-		if (!strcmp(name, "name")) {
-			check_required_tag(0);
-
-			encode = (char *)xmlTextReaderGetAttribute(reader, BAD_CAST "percentencoded");
-
-			if (parent) {
-				if (encode && !strcmp(encode, "true")) {
-					dir->percent_encode = true;
-				}
-
-				get_tag_text();
-				if (xml_parse_filename(&dir->name, value) < 0)
-					return -1;
-
-				if (dir->percent_encode) {
-					char *new_name;
-					decode_entry_name(&new_name, dir->name);
-					strcpy(dir->name, new_name);
-					free(new_name);
-				}
-
-				dirname->name = dir->name;
-				dirname->d = dir;
-				check_tag_end("name");
-			} else {
-				/* this is the root directory, so set the volume name */
-				check_empty();
-				if (empty > 0) {
-					value = NULL;
-				} else {
-					if (xml_scan_text(reader, &value) < 0)
-						return -1;
-				}
-
-				if (value && strlen(value) > 0) {
-					if (xml_parse_filename(&idx->volume_name, value) < 0)
-						return -1;
-					/* if the value is the empty string, then xml_scan_text consumed the "name"
-					 * element end */
-
-					if (encode && !strcmp(encode, "true")) {
-						char *new_name;
-						decode_entry_name(&new_name, idx->volume_name);
-						strcpy(idx->volume_name, new_name);
-						free(new_name);
-					}
-
-					check_tag_end("name");
-				} else
-					idx->volume_name = NULL;
-			}
-
-			if (encode)
-				free(encode);
-
-		} else if (!strcmp(name, "readonly")) {
-			check_required_tag(1);
-			get_tag_text();
-			if (xml_parse_bool(&dir->readonly, value) < 0)
-				return -1;
-			check_tag_end("readonly");
-
-		} else if (!strcmp(name, "modifytime")) {
-			check_required_tag(2);
-			get_tag_text();
-			ret = xml_parse_time(true, value, &dir->modify_time);
-			if (ret < 0)
-				return -1;
-			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "updatetime", dir->name, dir->uid, value);
-
-			check_tag_end("modifytime");
-
-		} else if (!strcmp(name, "creationtime")) {
-			check_required_tag(3);
-			get_tag_text();
-			ret = xml_parse_time(true, value, &dir->creation_time);
-			if (ret < 0)
-				return -1;
-			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "creationtime", dir->name, dir->uid, value);
-
-			check_tag_end("creationtime");
-
-		} else if (!strcmp(name, "accesstime")) {
-			check_required_tag(4);
-			get_tag_text();
-			ret = xml_parse_time(true, value, &dir->access_time);
-			if (ret < 0)
-				return -1;
-			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "accesstime", dir->name, dir->uid, value);
-
-			check_tag_end("accesstime");
-
-		} else if (!strcmp(name, "changetime")) {
-			check_required_tag(5);
-			get_tag_text();
-			ret = xml_parse_time(true, value, &dir->change_time);
-			if (ret < 0)
-				return -1;
-			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "changetime", dir->name, dir->uid, value);
-
-			check_tag_end("changetime");
-
-		} else if (! strcmp(name, "contents")) {
-			check_required_tag(6);
-			check_empty();
-			if (empty == 0 && _xml_parse_dir_contents(reader, dir, idx) < 0)
-				return -1;
-
-		} else if (!strcmp(name, "extendedattributes")) {
-			check_optional_tag(0);
-			check_empty();
-			if (empty == 0 && _xml_parse_xattrs(reader, dir) < 0)
-					return -1;
-
-		} else if (idx->version >= IDX_VERSION_UID && ! strcmp(name, UID_TAGNAME)) {
-			check_required_tag(7);
-			get_tag_text();
-			if (xml_parse_ull(&value_int, value) < 0)
-				return -1;
-			dir->uid = value_int;
-			if (dir->uid > idx->uid_number)
-				idx->uid_number = dir->uid;
-			if (parent) {
-				dirname->uid  = dir->uid;
-			}
-			check_tag_end(UID_TAGNAME);
-		} else if (! strcmp(name, UID_TAGNAME)) {
-			ignore_unrecognized_tag();
-
-		} else if (idx->version >= IDX_VERSION_BACKUPTIME && ! strcmp(name, BACKUPTIME_TAGNAME)) {
-			check_required_tag(8);
-			get_tag_text();
-			ret = xml_parse_time(true, value, &dir->backup_time);
-			if (ret < 0)
-				return -1;
-			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "backuptime", dir->name, dir->uid, value);
-
-			check_tag_end(BACKUPTIME_TAGNAME);
-		} else if (! strcmp(name, BACKUPTIME_TAGNAME)) {
-			ignore_unrecognized_tag();
-
-		} else
-			preserve_unrecognized_tag(dir);
-	}
-
-	/* For old index versions, allocate a UID */
-	if (idx->version < IDX_VERSION_UID) {
-		check_required_tag(7);
-		if (parent) {
-			dir->uid = fs_allocate_uid(idx);
-			if (dir->uid > idx->uid_number)
-				idx->uid_number = dir->uid;
-			dirname->uid  = dir->uid;
-		}
-		/* root directory already got assigned UID 1 by fs_allocate_dentry */
-	}
-
-	/* For old index versions, set backup time equal to creation time */
-	if (idx->version < IDX_VERSION_BACKUPTIME) {
-		check_required_tag(8);
-		dir->backup_time = dir->creation_time;
-	}
-
-	check_required_tags();
-
-	/* Validate UID: root directory must have uid==1, other dentries must have nonzero UID */
-	/* TODO: would be nice to verify that there are no UID conflicts */
-	if (parent && dir->uid == 1) {
-		ltfsmsg(LTFS_ERR, "17101E");
-		return -1;
-	} else if (! parent && dir->uid != 1) {
-		ltfsmsg(LTFS_ERR, "17100E");
-		return -1;
-	} else if (dir->uid == 0) {
-		ltfsmsg(LTFS_ERR, "17106E");
-		return -1;
-	}
-
-	return 0;
-}
-
-int _xml_parse_dir_contents(xmlTextReaderPtr reader, struct dentry *dir, struct ltfs_index *idx)
-{
-	struct name_list *list = NULL, *entry_name = NULL;
-	CHECK_ARG_NULL(dir, -LTFS_NULL_ARG);
-	declare_parser("contents");
-	declare_tracking_arrays(0, 0);
-
-	errno = 0;
-
-	while (true) {
-		get_next_tag();
-
-		if (! strcmp(name, "file")) {
-			assert_not_empty();
-			entry_name = (struct name_list *)malloc(sizeof(struct name_list));
-			if (!entry_name) {
-				ltfsmsg(LTFS_ERR, "10001E", "_xml_parse_dir_contents: file");
-				return -LTFS_NO_MEMORY;
-			}
-			if (_xml_parse_file(reader, idx, dir, entry_name) < 0) {
-				free(entry_name);
-				return -1;
-			}
-
-		} else if (! strcmp(name, "directory")) {
-			assert_not_empty();
-			entry_name = (struct name_list *)malloc(sizeof(struct name_list));
-			if (!entry_name) {
-				ltfsmsg(LTFS_ERR, "10001E", "_xml_parse_dir_contents: dir");
-				return -LTFS_NO_MEMORY;
-			}
-			if (_xml_parse_dirtree(reader, dir, idx, dir->vol, entry_name) < 0) {
-				free(entry_name);
-				return -1;
-			}
-
-		} else {
-			ignore_unrecognized_tag();
-			entry_name = NULL;
-		}
-		if (!strcmp(name, "file") || (!strcmp(name, "directory") && !(!dir && idx->root))) {
-			/* Make temporal hash table whose key is dentry name */
-			HASH_ADD_KEYPTR(hh, list, entry_name->name, strlen(entry_name->name), entry_name);
-			if (errno == ENOMEM) {
-				struct name_list *list_ptr, *list_tmp;
-
-				HASH_ITER(hh, list, list_ptr, list_tmp) {
-					HASH_DEL(list, list_ptr);
-					free(list_ptr);
-				}
-
-				ltfsmsg(LTFS_ERR, "10001E", "_xml_parse_dir_contents: add key");
-				free(entry_name);
-
-				return -LTFS_NO_MEMORY;
-			}
-		} else {
-			free(entry_name);
-			entry_name = NULL;
-		}
-	}
-
-	/* At first, update platform_safe_name without replacing invalid chars in the directory.
-	   The file or directory of which name contains invalid char is skipped in this step.
-	   After that update platfrom_safe_name regarding skipped file or directory as the second
-	   step. These steps make a prioritization of name mangling.*/
-	if (fs_update_platform_safe_names(dir, idx, list)!=0) {
-		return -1;
-	}
-
-	check_required_tags();
-	return 0;
-}
-
-/**
- * Parse a file into the given directory.
- */
-int _xml_parse_file(xmlTextReaderPtr reader, struct ltfs_index *idx, struct dentry *dir, struct name_list *filename)
-{
-	int ret;
-	unsigned long long value_int;
-	struct dentry *file;
-	struct extent_info *xt_last;
-	declare_parser_vars("file");
-	declare_tracking_arrays(9, 4);
-	bool symlink_flag=false, extent_flag=false, openforwrite=false;
-	char *encode;
-
-	file = fs_allocate_dentry(dir, NULL, NULL, false, false, false, idx);
-	if (! file) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
-		return -1;
-	}
-
-	while (true) {
-		get_next_tag();
-
-		if (! strcmp(name, "name")) {
-			check_required_tag(0);
-			encode = (char *)xmlTextReaderGetAttribute(reader, BAD_CAST "percentencoded");
-			if (encode && !strcmp(encode, "true")) {
-				file->percent_encode = true;
-			}
-
-			get_tag_text();
-			if (xml_parse_filename(&file->name, value) < 0)
-				return -1;
-
-			if (file->percent_encode) {
-				char *new_name;
-				decode_entry_name(&new_name, file->name);
-				strcpy(file->name, new_name);
-                free(new_name);
-			}
-
-			filename->name = file->name;
-			filename->d = file;
-			check_tag_end("name");
-
-		} else if (!strcmp(name, "length")) {
-			check_required_tag(1);
-			get_tag_text();
-			if (xml_parse_ull(&value_int, value) < 0)
-				return -1;
-			file->size = value_int;
-			check_tag_end("length");
-
-		} else if (!strcmp(name, "readonly")) {
-			check_required_tag(2);
-			get_tag_text();
-			if (xml_parse_bool(&file->readonly, value) < 0)
-				return -1;
-			check_tag_end("readonly");
-
-		} else if (!strcmp(name, "modifytime")) {
-			check_required_tag(3);
-			get_tag_text();
-			ret = xml_parse_time(true, value, &file->modify_time);
-			if (ret < 0)
-				return -1;
-			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "modifytime", file->name, file->uid, value);
-			check_tag_end("modifytime");
-
-		} else if (!strcmp(name, "creationtime")) {
-			check_required_tag(4);
-			get_tag_text();
-			ret = xml_parse_time(true, value, &file->creation_time);
-			if (ret < 0)
-				return -1;
-			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "creationtime", file->name, file->uid, value);
-
-			check_tag_end("creationtime");
-
-		} else if (!strcmp(name, "accesstime")) {
-			check_required_tag(5);
-			get_tag_text();
-			ret = xml_parse_time(true, value, &file->access_time);
-			if (ret < 0)
-				return -1;
-			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "accesstime", file->name, file->uid, value);
-			check_tag_end("accesstime");
-
-		} else if (!strcmp(name, "changetime")) {
-			check_required_tag(6);
-			get_tag_text();
-			ret = xml_parse_time(true, value, &file->change_time);
-			if (ret < 0)
-				return -1;
-			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "changetime", file->name, file->uid, value);
-			check_tag_end("changetime");
-
-		} else if (!strcmp(name, "extendedattributes")) {
-			check_optional_tag(0);
-			check_empty();
-			if (empty == 0 && _xml_parse_xattrs(reader, file) < 0)
-					return -1;
-
-		} else if (!strcmp(name, "extentinfo")) {
-			check_optional_tag(1);
-			check_empty();
-			if (empty == 0 && _xml_parse_extents(reader, idx->version, file) < 0)
-					return -1;
-			else extent_flag = true;
-
-        } else if (!strcmp(name, "symlink")) {
-			check_optional_tag(2);
-			get_tag_text();
-			file->target = strdup(value);
-			file->isslink = true;
-			symlink_flag = true;
-
-			check_tag_end("symlink");
-
-		} else if (!strcmp(name, "openforwrite")) {
-			check_optional_tag(3);
-			get_tag_text();
-			if (xml_parse_bool(&openforwrite, value) < 0) {
-				ltfsmsg(LTFS_WARN, "17252W", value, "openforwrite", file->uid);
-			} else {
-				if (openforwrite)
-					ltfsmsg(LTFS_INFO, "17251I", file->name, file->uid);
-			}
-			check_tag_end("openforwrite");
-
-		} else if (idx->version >= IDX_VERSION_UID && ! strcmp(name, UID_TAGNAME)) {
-			check_required_tag(7);
-			get_tag_text();
-			if (xml_parse_ull(&value_int, value) < 0)
-				return -1;
-			file->uid = value_int;
-			if (file->uid > idx->uid_number)
-				idx->uid_number = file->uid;
-			filename->uid  = file->uid;
-			check_tag_end(UID_TAGNAME);
-		} else if (! strcmp(name, UID_TAGNAME)) {
-			ignore_unrecognized_tag();
-
-		} else if (idx->version >= IDX_VERSION_BACKUPTIME && ! strcmp(name, BACKUPTIME_TAGNAME)) {
-			check_required_tag(8);
-			get_tag_text();
-			ret = xml_parse_time(true, value, &file->backup_time);
-			if (ret < 0)
-				return -1;
-			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "backuptime", file->name, file->uid, value);
-
-			check_tag_end(BACKUPTIME_TAGNAME);
-		} else if (! strcmp(name, BACKUPTIME_TAGNAME)) {
-			ignore_unrecognized_tag();
-
-		} else
-			preserve_unrecognized_tag(file);
-	}
-
-	/* For old index versions, allocate a UID */
-	if (idx->version < IDX_VERSION_UID) {
-		check_required_tag(7);
-		file->uid = fs_allocate_uid(idx);
-		if (file->uid > idx->uid_number)
-			idx->uid_number = file->uid;
-		filename->uid  = file->uid;
-	}
-
-	/* For old index versions, set backup time equal to creation time */
-	if (idx->version < IDX_VERSION_BACKUPTIME) {
-		check_required_tag(8);
-		file->backup_time = file->creation_time;
-	}
-
-	check_required_tags();
-
-	/* check that file size is not shorter than the extent list */
-	if (! TAILQ_EMPTY(&file->extentlist)) {
-		xt_last = TAILQ_LAST(&file->extentlist, extent_struct);
-		if (xt_last->fileoffset + xt_last->bytecount > file->size) {
-			ltfsmsg(LTFS_ERR, "17026E");
-			return -1;
-		}
-	}
-
-	/* Validate UID: must be nonzero (UID 0 is reserved for the root directory) */
-	if (file->uid == 0) {
-		ltfsmsg(LTFS_ERR, "17101E");
-		return -1;
-	}
-
-	if ( symlink_flag && extent_flag ) {
-		ltfsmsg(LTFS_ERR, "17180E", file->name);
-		if ( _xml_save_symlink_conflict( idx, file ) ) return -1;
-	}
-
-	return 0;
-}
-
-/**
- * Parse a file's extent list.
- */
-int _xml_parse_extents(xmlTextReaderPtr reader, int idx_version, struct dentry *d)
-{
-	declare_parser("extentinfo");
-	declare_tracking_arrays(0, 0);
-
-	while (true) {
-		get_next_tag();
-
-		if (! strcmp(name, "extent")) {
-			assert_not_empty();
-			if (_xml_parse_one_extent(reader, idx_version, d) < 0)
-				return -1;
-
-		} else
-			ignore_unrecognized_tag();
-	}
-
-	check_required_tags();
-	return 0;
-}
-
-/**
- * Parse an extent from an XML source, appending it to the given dentry's extent list.
- */
-int _xml_parse_one_extent(xmlTextReaderPtr reader, int idx_version, struct dentry *d)
-{
-	unsigned long long value_int;
-	struct extent_info *xt, *xt_last;
-	declare_parser_vars("extent");
-	declare_tracking_arrays(5, 0);
-
-	xt = calloc(1, sizeof(struct extent_info));
-	if (!xt) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
-		return -1;
-	}
-
-	while (true) {
-		get_next_tag();
-
-		if (! strcmp(name, "partition")) {
-			check_required_tag(0);
-			get_tag_text();
-			if (_xml_parse_partition(value) < 0) {
-				free(xt);
-				return -1;
-			}
-			xt->start.partition = value[0];
-			check_tag_end("partition");
-
-		} else if (! strcmp(name, "startblock")) {
-			check_required_tag(1);
-			get_tag_text();
-			if (xml_parse_ull(&value_int, value) < 0) {
-				free(xt);
-				return -1;
-			}
-			xt->start.block = value_int;
-			check_tag_end("startblock");
-
-		} else if (! strcmp(name, "byteoffset")) {
-			check_required_tag(2);
-			get_tag_text();
-			if (xml_parse_ull(&value_int, value) < 0) {
-				free(xt);
-				return -1;
-			}
-			xt->byteoffset = value_int;
-			check_tag_end("byteoffset");
-
-		} else if (! strcmp(name, "bytecount")) {
-			check_required_tag(3);
-			get_tag_text();
-			if (xml_parse_ull(&value_int, value) < 0) {
-				free(xt);
-				return -1;
-			}
-			xt->bytecount = value_int;
-			check_tag_end("bytecount");
-
-		} else if (idx_version >= IDX_VERSION_SPARSE && ! strcmp(name, "fileoffset")) {
-			check_required_tag(4);
-			get_tag_text();
-			if (xml_parse_ull(&value_int, value) < 0) {
-				free(xt);
-				return -1;
-			}
-			xt->fileoffset = value_int;
-			check_tag_end("fileoffset");
-
-		} else
-			ignore_unrecognized_tag();
-	}
-
-	/* For older index versions, set fileoffset at the end of the previous extent */
-	if (idx_version < IDX_VERSION_SPARSE) {
-		check_required_tag(4);
-		if (TAILQ_EMPTY(&d->extentlist))
-			xt->fileoffset = 0;
-		else {
-			xt_last = TAILQ_LAST(&d->extentlist, extent_struct);
-			xt->fileoffset = xt_last->fileoffset + xt_last->bytecount;
-		}
-	}
-
-	check_required_tags();
-
-	/* Add extent to the extent list, performing appropriate reordering if necessary.
-	 * Also make sure the new extent does not overlap with any existing extents. */
-	if (TAILQ_EMPTY(&d->extentlist))
-		TAILQ_INSERT_TAIL(&d->extentlist, xt, list);
-	else {
-		bool xt_used = false;
-		TAILQ_FOREACH_REVERSE(xt_last, &d->extentlist, extent_struct, list) {
-			if (xt_last->fileoffset + xt_last->bytecount <= xt->fileoffset) {
-				TAILQ_INSERT_AFTER(&d->extentlist, xt_last, xt, list);
-				xt_used = true;
-				break;
-			} else if (xt->fileoffset + xt->bytecount > xt_last->fileoffset) {
-				/* Overlap error */
-				ltfsmsg(LTFS_ERR, "17097E");
-				free(xt);
-				return -1;
-			}
-		}
-		if (! xt_used)
-			TAILQ_INSERT_HEAD(&d->extentlist, xt, list);
-	}
-
-	d->realsize += xt->bytecount;
-
-	if (d->vol) {
-		d->used_blocks += ((xt->byteoffset + xt->bytecount) / d->vol->label->blocksize);
-		if ((xt->byteoffset + xt->bytecount) % d->vol->label->blocksize)
-			d->used_blocks++;
-	}
-
-	return 0;
-}
-
-/**
- * Parse extended attributes for a file or directory.
- */
-int _xml_parse_xattrs(xmlTextReaderPtr reader, struct dentry *d)
-{
-	declare_parser("extendedattributes");
-	declare_tracking_arrays(0, 0);
-
-	while (true) {
-		get_next_tag();
-
-		if (! strcmp(name, "xattr")) {
-			assert_not_empty();
-			if (_xml_parse_one_xattr(reader, d) < 0)
-				return -1;
-
-		} else
-			ignore_unrecognized_tag();
-	}
-
-	check_required_tags();
-	return 0;
-}
-
-/**
- * Parse a single extended attribute, appending it to the xattr list of the given dentry.
- */
-int _xml_parse_one_xattr(xmlTextReaderPtr reader, struct dentry *d)
-{
-	char *xattr_type;
-	struct xattr_info *xattr;
-	declare_parser_vars("xattr");
-	declare_tracking_arrays(2, 0);
-	char *encode;
-
-	xattr = calloc(1, sizeof(struct xattr_info));
-	if (! xattr) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
-		return -1;
-	}
-
-	while (true) {
-		get_next_tag();
-
-		if (! strcmp(name, "key")) {
-			check_required_tag(0);
-			encode = (char *)xmlTextReaderGetAttribute(reader, BAD_CAST "percentencoded");
-			if (encode && !strcmp(encode, "true")) {
-				xattr->encoded = true;
-			}
-
-			get_tag_text();
-			if (xml_parse_filename(&xattr->key, value) < 0) {
-				free(xattr);
-				return -1;
-			}
-
-			if (xattr->encoded) {
-				char *new_key;
-				decode_entry_name(&new_key, xattr->key);
-				strcpy(xattr->key, new_key);
-                free(new_key);
-			}
-
-			check_tag_end("key");
-
-		} else if (! strcmp(name, "value")) {
-			check_required_tag(1);
-
-			xattr_type = (char *)xmlTextReaderGetAttribute(reader, BAD_CAST "type");
-			if (xattr_type && strcmp(xattr_type, "text") && strcmp(xattr_type, "base64")) {
-				ltfsmsg(LTFS_ERR, "17027E", xattr_type);
-				free(xattr);
-				return -1;
-			}
-
-			check_empty();
-			if (empty == 0) {
-				if (xml_scan_text(reader, &value) < 0) {
-					free(xattr->key);
-					free(xattr);
-					return -1;
-				}
-				if (! xattr_type || ! strcmp(xattr_type, "text")) {
-					xattr->value = strdup(value);
-					if (! xattr->value) {
-						ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
-						free(xattr->key);
-						free(xattr);
-						return -1;
-					}
-					xattr->size = strlen(value);
-				} else { /* base64 */
-					xattr->size = base64_decode(
-						(const unsigned char *)value,
-						strlen(value),
-						(unsigned char **)(&xattr->value));
-					if (xattr->size == 0) {
-						ltfsmsg(LTFS_ERR, "17028E");
-						free(xattr->key);
-						free(xattr);
-						return -1;
-					}
-				}
-				if (strlen(value) > 0)
-					check_tag_end("value");
-			} else {
-				xattr->value = NULL;
-				xattr->size = 0;
-			}
-			free(xattr_type);
-
-		} else
-			ignore_unrecognized_tag();
-	}
-
-	check_required_tags();
-	TAILQ_INSERT_TAIL(&d->xattrlist, xattr, list);
-
-	if (!strcmp(xattr->key, "ltfs.vendor.IBM.immutable") && !strcmp(xattr->value, "1") ) {
-		d->is_immutable = true;
-	}
-	if (!strcmp(xattr->key, "ltfs.vendor.IBM.appendonly") && !strcmp(xattr->value, "1") ) {
-		d->is_appendonly = true;
-	}
-
-	return 0;
-}
-
-/**
- * Parse a version number of the form X.Y from a string.
- * @param version_str String to parse
- * @param major Outputs the major version number X
- * @param minor Outputs the minor version number Y
- * @return 0 on success or a negative value on error.
- */
-int _xml_parse_version(const char *version_str, int *version_int)
-{
-	const char *y_str, *z_str, *tmp;
-
-	CHECK_ARG_NULL(version_str, -LTFS_NULL_ARG);
-	CHECK_ARG_NULL(version_int, -LTFS_NULL_ARG);
-
-	/* Legacy index version 1.0 */
-	if (! strcmp(version_str, "1.0")) {
-		*version_int = MAKE_LTFS_VERSION(1,0,0);
-		return 0;
-	}
-
-	tmp = version_str;
-	while (*tmp && *tmp >= '0' && *tmp <= '9')
-		++tmp;
-	if (tmp == version_str || *tmp != '.')
-		return -LTFS_BAD_ARG;
-	y_str = ++tmp;
-	while (*tmp && *tmp >= '0' && *tmp <= '9')
-		++tmp;
-	if (tmp == y_str || *tmp != '.')
-		return -LTFS_BAD_ARG;
-	z_str = ++tmp;
-	while (*tmp && *tmp >= '0' && *tmp <= '9')
-		++tmp;
-	if (tmp == z_str || *tmp != '\0')
-		return -LTFS_BAD_ARG;
-
-	*version_int = MAKE_LTFS_VERSION(atoi(version_str), atoi(y_str), atoi(z_str));
-	return 0;
-}
-
-/**
- * Verify that a given string really does represent a partition (single character, a-z).
- */
-int _xml_parse_partition(const char *val)
-{
-	CHECK_ARG_NULL(val, -LTFS_NULL_ARG);
-
-	if (strlen(val) != 1 || val[0] < 'a' || val[0] > 'z') {
-		ltfsmsg(LTFS_ERR, "17033E", val);
-		return -1;
-	}
-
-	return 0;
-}
-
-/**
- * Scan a tape offset (a partition tag and a startblock tag) from an XML source.
- * @param reader the XML source
- * @param tag name of the tag containing the tape position. This function will read to the end
- *            of that tag, so it is not suitable for reading an extent list (which has other
- *            children that need to be parsed).
- * @param pos pointer to a structure where the offset will be stored
- * @return 0 on success or a negative value on error
- */
-int _xml_scan_tapepos(xmlTextReaderPtr reader, const char *tag, struct tape_offset *pos)
-{
-	unsigned long long value_int;
-	declare_parser_vars(tag);
-	declare_tracking_arrays(2, 0);
-
-	while (true) {
-		get_next_tag();
-
-		if (! strcmp(name, "partition")) {
-			check_required_tag(0);
-			get_tag_text();
-			if (_xml_parse_partition(value) < 0)
-				return -1;
-			pos->partition = value[0];
-			check_tag_end("partition");
-
-		} else if (! strcmp(name, "startblock")) {
-			check_required_tag(1);
-			get_tag_text();
-			if (xml_parse_ull(&value_int, value) < 0)
-				return -1;
-			pos->block = value_int;
-			check_tag_end("startblock");
-
-		} else
-			ignore_unrecognized_tag();
-	}
-
-	check_required_tags();
-	return 0;
-}
-
-int _xml_save_symlink_conflict( struct ltfs_index *idx, struct dentry *d)
-{
-	size_t c = idx->symerr_count + 1;
-	struct dentry **err_d;
-
-	err_d = realloc( idx->symlink_conflict, c * sizeof(size_t));
-	if (! err_d) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
-		return -1;
-	}
-	err_d[c-1] = d;
-
-	idx->symlink_conflict = err_d;
-	idx->symerr_count = c;
-
-	return 0;
 }

--- a/src/libltfs/xml_writer_libltfs.c
+++ b/src/libltfs/xml_writer_libltfs.c
@@ -69,13 +69,550 @@ struct ltfsee_cache
 	uint64_t count; /* File count to write */
 };
 
-int _xml_write_schema(xmlTextWriterPtr writer, const char *creator,
-	const struct ltfs_index *idx);
-int _xml_write_dirtree(xmlTextWriterPtr writer, struct dentry *dir,
-					   const struct ltfs_index *idx, struct ltfsee_cache* offset_c, struct ltfsee_cache* sync_list);
-int _xml_write_file(xmlTextWriterPtr writer, struct dentry *file, struct ltfsee_cache* offset_c, struct ltfsee_cache* sync_list);
-int _xml_write_dentry_times(xmlTextWriterPtr writer, const struct dentry *d);
-int _xml_write_xattr(xmlTextWriterPtr writer, const struct dentry *file);
+/**************************************************************************************
+ * Local Functions
+ **************************************************************************************/
+
+static int encode_entry_name(char **new_name, const char *name)
+{
+	int len;
+	UChar32 c;
+	static char invalid_chars[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+-." ;
+	char *tmp_name;
+	char buf_encode[3];
+	int i=0, count=0, prev=0, j=0;
+
+	CHECK_ARG_NULL(name, -LTFS_NULL_ARG);
+
+	len = strlen(name);
+
+	tmp_name = malloc(len * 3 * sizeof(UChar));
+	buf_encode[2] = '\0';
+
+	while (i < len) {
+		count = 0;
+		prev = i;
+
+		U8_NEXT(name, i, len, c);
+		if (c < 0) {
+			ltfsmsg(LTFS_ERR, "11235E");
+			free(tmp_name);
+			return -LTFS_ICU_ERROR;
+		}
+
+        if (strchr(invalid_chars, name[prev])) {
+			// encode is not needed.
+			tmp_name[j] = name[prev];
+			j++;
+			continue;
+		}
+
+		while (count < i - prev) {
+			sprintf(buf_encode, "%02X", name[prev+count] & 0xFF);
+			tmp_name[j] = '%';
+			tmp_name[j+1] = buf_encode[0];
+			tmp_name[j+2] = buf_encode[1];
+			j += 3;
+			count++;
+		}
+	}
+
+	tmp_name[j] = '\0';
+
+	*new_name = strdup(tmp_name);
+	free(tmp_name);
+
+	return 0;
+}
+
+/**
+ * Write time info into an XML stream.
+ * @param write output pointer
+ * @param d dentry to get times from
+ * @return 0 on success or a negative value on error.
+ */
+static int _xml_write_dentry_times(xmlTextWriterPtr writer, const struct dentry *d)
+{
+	int ret;
+	char *mtime;
+
+	ret = xml_format_time(d->creation_time, &mtime);
+	if (!mtime)
+		return -1;
+	else if (ret == LTFS_TIME_OUT_OF_RANGE)
+		ltfsmsg(LTFS_WARN, "17225W", "creationtime", d->creation_time.tv_sec);
+	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "creationtime", BAD_CAST mtime), -1);
+	free(mtime);
+
+	ret = xml_format_time(d->change_time, &mtime);
+	if (!mtime)
+		return -1;
+	else if (ret == LTFS_TIME_OUT_OF_RANGE)
+		ltfsmsg(LTFS_WARN, "17225W", "changetime", d->change_time.tv_sec);
+	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "changetime", BAD_CAST mtime), -1);
+	free(mtime);
+
+	ret = xml_format_time(d->modify_time, &mtime);
+	if (!mtime)
+		return -1;
+	else if (ret == LTFS_TIME_OUT_OF_RANGE)
+		ltfsmsg(LTFS_WARN, "17225W", "modifytime", d->modify_time.tv_sec);
+	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "modifytime", BAD_CAST mtime), -1);
+	free(mtime);
+
+	ret = xml_format_time(d->access_time, &mtime);
+	if (!mtime)
+		return -1;
+	else if (ret == LTFS_TIME_OUT_OF_RANGE)
+		ltfsmsg(LTFS_WARN, "17225W", "accesstime", d->access_time.tv_sec);
+	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "accesstime", BAD_CAST mtime), -1);
+	free(mtime);
+
+	ret = xml_format_time(d->backup_time, &mtime);
+	if (!mtime)
+		return -1;
+	else if (ret == LTFS_TIME_OUT_OF_RANGE)
+		ltfsmsg(LTFS_WARN, "17225W", "backuptime", d->backup_time.tv_sec);
+	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "backuptime", BAD_CAST mtime), -1);
+	free(mtime);
+
+	return 0;
+}
+
+/**
+ * Write extended attributes from the given file or directory.
+ * @param writer output pointer
+ * @param file the dentry to take xattrs from
+ * @return 0 on success or -1 on failure
+ */
+static int _xml_write_xattr(xmlTextWriterPtr writer, const struct dentry *file)
+{
+	int ret;
+	struct xattr_info *xattr;
+
+	if (! TAILQ_EMPTY(&file->xattrlist)) {
+		xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "extendedattributes"), -1);
+		TAILQ_FOREACH(xattr, &file->xattrlist, list) {
+			xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "xattr"), -1);
+
+			if (xattr->encoded) {
+				char *encoded_key;
+				encode_entry_name(&encoded_key, xattr->key);
+				xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "key"), -1);
+				xml_mktag(xmlTextWriterWriteAttribute(writer, BAD_CAST "percentencoded", BAD_CAST "true"), -1);
+				xml_mktag(xmlTextWriterWriteString(writer, BAD_CAST encoded_key), -1);
+				xml_mktag(xmlTextWriterEndElement(writer), -1);
+				free(encoded_key);
+			}
+			else {
+				xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "key", BAD_CAST xattr->key), -1);
+			}
+
+			if (xattr->value) {
+				ret = pathname_validate_xattr_value(xattr->value, xattr->size);
+				if (ret < 0) {
+					ltfsmsg(LTFS_ERR, "17059E", ret);
+					return -1;
+				} else if (ret > 0) {
+					xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "value"), -1);
+					xml_mktag(
+						xmlTextWriterWriteAttribute(writer, BAD_CAST "type", BAD_CAST "base64"),
+						-1);
+					xml_mktag(xmlTextWriterWriteBase64(writer, xattr->value, 0, xattr->size), -1);
+					xml_mktag(xmlTextWriterEndElement(writer), -1);
+				} else {
+					xml_mktag(xmlTextWriterWriteFormatElement(
+						writer, BAD_CAST "value", "%.*s", (int)xattr->size, xattr->value), -1);
+				}
+			} else { /* write empty value tag */
+				xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "value"), -1);
+				xml_mktag(xmlTextWriterEndElement(writer), -1);
+			}
+			xml_mktag(xmlTextWriterEndElement(writer), -1);
+		}
+		xml_mktag(xmlTextWriterEndElement(writer), -1);
+	}
+
+	return 0;
+}
+
+/**
+ * Write file info to an XML stream.
+ * @param writer output pointer
+ * @param file the file to write
+ * @return 0 on success or -1 on failure
+ */
+static int _xml_write_file(xmlTextWriterPtr writer, struct dentry *file, struct ltfsee_cache* offset_c, struct ltfsee_cache* sync_list)
+{
+	struct extent_info *extent;
+	bool write_offset = false;
+	size_t i;
+
+	if (file->isdir) {
+		ltfsmsg(LTFS_ERR, "17062E");
+		return -1;
+	}
+
+	/* write standard attributes */
+	xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "file"), -1);
+
+	if (file->percent_encode) {
+		char *encoded_name;
+		encode_entry_name(&encoded_name, file->name);
+		xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "name"), -1);
+		xml_mktag(xmlTextWriterWriteAttribute(writer, BAD_CAST "percentencoded", BAD_CAST "true"), -1);
+		xml_mktag(xmlTextWriterWriteString(writer, BAD_CAST encoded_name), -1);
+		xml_mktag(xmlTextWriterEndElement(writer), -1);
+		free(encoded_name);
+	}
+	else {
+		xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "name", BAD_CAST file->name), -1);
+	}
+
+	xml_mktag(xmlTextWriterWriteFormatElement(
+		writer, BAD_CAST "length", "%"PRIu64, file->size), -1);
+	xml_mktag(xmlTextWriterWriteElement(
+		writer, BAD_CAST "readonly", BAD_CAST (file->readonly ? "true" : "false")), -1);
+	xml_mktag(_xml_write_dentry_times(writer, file), -1);
+	xml_mktag(xmlTextWriterWriteFormatElement(
+		writer, BAD_CAST UID_TAGNAME, "%"PRIu64, file->uid), -1);
+
+	/* write extended attributes */
+	xml_mktag(_xml_write_xattr(writer, file), -1);
+
+	/* write extents */
+    if (file->isslink) {
+        xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "symlink", BAD_CAST file->target), -1);
+    } else if (! TAILQ_EMPTY(&file->extentlist)) {
+		xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "extentinfo"), -1);
+		TAILQ_FOREACH(extent, &file->extentlist, list) {
+			/* Write file offset cache */
+			if (offset_c->fp && ! write_offset) {
+				fprintf(offset_c->fp, "%s,%"PRIu64"\n", file->name, extent->start.block);
+				write_offset = true;
+				offset_c->count++;
+			}
+			xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "extent"), -1);
+			xml_mktag(xmlTextWriterWriteFormatElement(
+				writer, BAD_CAST "fileoffset", "%"PRIu64, extent->fileoffset), -1);
+			xml_mktag(xmlTextWriterWriteFormatElement(
+				writer, BAD_CAST "partition", "%c", extent->start.partition), -1);
+			xml_mktag(xmlTextWriterWriteFormatElement(
+				writer, BAD_CAST "startblock", "%"PRIu64, extent->start.block), -1);
+			xml_mktag(xmlTextWriterWriteFormatElement(
+				writer, BAD_CAST "byteoffset", "%"PRIu32, extent->byteoffset), -1);
+			xml_mktag(xmlTextWriterWriteFormatElement(
+				writer, BAD_CAST "bytecount", "%"PRIu64, extent->bytecount), -1);
+			xml_mktag(xmlTextWriterEndElement(writer), -1);
+		}
+		xml_mktag(xmlTextWriterEndElement(writer), -1);
+	} else {
+		/* Write file offset cache */
+		if (offset_c->fp) {
+			fprintf(offset_c->fp, "%s,%"PRIu64"\n", file->name, (uint64_t)0);
+			offset_c->count++;
+		}
+	}
+
+	/* Save unrecognized tags */
+	if (file->tag_count > 0) {
+		for (i=0; i<file->tag_count; ++i) {
+			if (xmlTextWriterWriteRaw(writer, file->preserved_tags[i]) < 0) {
+				ltfsmsg(LTFS_ERR, "17092E", __FUNCTION__);
+				return -1;
+			}
+		}
+	}
+
+	xml_mktag(xmlTextWriterEndElement(writer), -1);
+
+	/* Write dirty file list */
+	if (sync_list->fp && file->dirty) {
+		fprintf(sync_list->fp, "%s,%"PRIu64"\n", file->name, file->size);
+		file->dirty = false;
+		sync_list->count++;
+	}
+
+	return 0;
+}
+
+/**
+ * Write XML tags representing the current directory tree to the given destination.
+ * @param writer output pointer
+ * @param dir directory to process
+ * @param idx pointer to ltfs index structure
+ * @param offset_c file pointer to write offest cache
+ * @param sync_list file pointer to write sync file list
+ * @return 0 on success or negative on failure
+ */
+static int _xml_write_dirtree(xmlTextWriterPtr writer, struct dentry *dir,
+					   const struct ltfs_index *idx, struct ltfsee_cache* offset_c, struct ltfsee_cache* sync_list)
+{
+	size_t i;
+	char *offset_name, *sync_name;
+	struct ltfsee_cache *offset = offset_c, *sync = sync_list;
+	struct name_list *list_ptr, *list_tmp;
+	int ret;
+
+	if (!dir)
+		return 0; /* nothing to do */
+
+	/* write standard attributes */
+	xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "directory"), -1);
+	if (dir == idx->root) {
+		if (idx->volume_name) {
+			if (fs_is_percent_encode_required(idx->volume_name)) {
+				char *encoded_name;
+				encode_entry_name(&encoded_name, idx->volume_name);
+				xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "name"), -1);
+				xml_mktag(xmlTextWriterWriteAttribute(writer, BAD_CAST "percentencoded", BAD_CAST "true"), -1);
+				xml_mktag(xmlTextWriterWriteString(writer, BAD_CAST encoded_name), -1);
+				xml_mktag(xmlTextWriterEndElement(writer), -1);
+				free(encoded_name);
+			}
+			else
+				xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "name", BAD_CAST idx->volume_name), -1);
+		} else {
+			xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "name"), -1);
+			xml_mktag(xmlTextWriterEndElement(writer), -1);
+		}
+	} else if (dir->percent_encode) {
+		char *encoded_name;
+		encode_entry_name(&encoded_name, dir->name);
+		xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "name"), -1);
+		xml_mktag(xmlTextWriterWriteAttribute(writer, BAD_CAST "percentencoded", BAD_CAST "true"), -1);
+		xml_mktag(xmlTextWriterWriteString(writer, BAD_CAST encoded_name), -1);
+		xml_mktag(xmlTextWriterEndElement(writer), -1);
+		free(encoded_name);
+	} else {
+		xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "name", BAD_CAST dir->name), -1);
+	}
+
+	xml_mktag(xmlTextWriterWriteElement(
+		writer, BAD_CAST "readonly", BAD_CAST (dir->readonly ? "true" : "false")), -1);
+	xml_mktag(_xml_write_dentry_times(writer, dir), -1);
+	xml_mktag(xmlTextWriterWriteFormatElement(
+		writer, BAD_CAST UID_TAGNAME, "%"PRIu64, dir->uid), -1);
+
+	/* write extended attributes */
+	xml_mktag(_xml_write_xattr(writer, dir), -1);
+
+	/* write children */
+	xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "contents"), -1);
+	/* Sort dentries by UID before generating xml */
+	HASH_SORT(dir->child_list, fs_hash_sort_by_uid);
+
+	HASH_ITER(hh, dir->child_list, list_ptr, list_tmp) {
+		if (list_ptr->d->isdir) {
+
+			if (list_ptr->d->vol->index_cache_path && !strcmp(list_ptr->d->name, ".LTFSEE_DATA")) {
+				ret = asprintf(&offset_name, "%s.%s", list_ptr->d->vol->index_cache_path, "offsetcache");
+				if (ret > 0) {
+					offset->fp = fopen(offset_name, "w");
+					free(offset_name);
+					if (!offset->fp)
+						ltfsmsg(LTFS_WARN, "17248W", "offset cache", list_ptr->d->vol->index_cache_path);
+				} else
+					ltfsmsg(LTFS_WARN, "17247W", "offset cache", list_ptr->d->vol->index_cache_path);
+
+				ret = asprintf(&sync_name, "%s.%s", list_ptr->d->vol->index_cache_path, "synclist");
+				if (ret > 0) {
+					sync->fp = fopen(sync_name, "w");
+					free(sync_name);
+					if (!sync->fp)
+						ltfsmsg(LTFS_WARN, "17248W", "sync list", list_ptr->d->vol->index_cache_path);
+				} else
+					ltfsmsg(LTFS_WARN, "17247W", "sync list", list_ptr->d->vol->index_cache_path);
+			}
+
+			xml_mktag(_xml_write_dirtree(writer, list_ptr->d, idx, offset, sync), -1);
+
+			if (offset->fp) {
+				fflush(offset->fp);
+				fsync(fileno(offset->fp));
+				fclose(offset->fp);
+				offset->fp = NULL;
+			}
+			if (sync->fp) {
+				fflush(sync->fp);
+				fsync(fileno(sync->fp));
+				fclose(sync->fp);
+				sync->fp = NULL;
+			}
+
+		} else
+			xml_mktag(_xml_write_file(writer, list_ptr->d, offset_c, sync_list), -1);
+	}
+
+	xml_mktag(xmlTextWriterEndElement(writer), -1);
+
+	/* Save unrecognized tags */
+	if (dir->tag_count > 0) {
+		for (i=0; i<dir->tag_count; ++i) {
+			if (xmlTextWriterWriteRaw(writer, dir->preserved_tags[i]) < 0) {
+				ltfsmsg(LTFS_ERR, "17092E", __FUNCTION__);
+				return -1;
+			}
+		}
+	}
+
+	xml_mktag(xmlTextWriterEndElement(writer), -1);
+
+	return 0;
+}
+
+/**
+ * Generate an XML schema, sending it to a user-provided output (memory or file).
+ * Note: this function does very little input validation; any user-provided information
+ * must be verified by the caller.
+ * @param writer the XML writer to send output to
+ * @param priv LTFS data
+ * @param pos position on tape where the schema will be written
+ * @return 0 on success, negative on failure
+ */
+static int _xml_write_schema(xmlTextWriterPtr writer, const char *creator,
+	const struct ltfs_index *idx)
+{
+	int ret;
+	size_t i;
+	char *update_time, **name_criteria;
+	char *offset_name = NULL, *sync_name = NULL;
+	struct ltfsee_cache offset = {NULL, 0};  /* Cache structure for file offset cache */
+	struct ltfsee_cache list = {NULL, 0};    /* Cache structure for sync list */
+
+	ret = xml_format_time(idx->mod_time, &update_time);
+	if (!update_time)
+		return -1;
+	else if (ret == LTFS_TIME_OUT_OF_RANGE)
+		ltfsmsg(LTFS_WARN, "17224W", "modifytime", idx->mod_time.tv_sec);
+
+	ret = xmlTextWriterStartDocument(writer, NULL, "UTF-8", NULL);
+	if (ret < 0) {
+		ltfsmsg(LTFS_ERR, "17057E", ret);
+		return -1;
+	}
+
+	xmlTextWriterSetIndent(writer, 1);
+	/* Define INDENT_INDEXES to write Indexes to tape with full indentation.
+	 * This is normally a waste of space, but it may be useful for debugging. */
+#ifdef INDENT_INDEXES
+	xmlTextWriterSetIndentString(writer, BAD_CAST "    ");
+#else
+	xmlTextWriterSetIndentString(writer, BAD_CAST "");
+#endif
+
+	/* write index properties */
+	xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "ltfsindex"), -1);
+	xml_mktag(xmlTextWriterWriteAttribute(writer, BAD_CAST "version",
+		BAD_CAST LTFS_INDEX_VERSION_STR), -1);
+	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "creator", BAD_CAST creator), -1);
+	if (idx->commit_message && strlen(idx->commit_message)) {
+		xml_mktag(xmlTextWriterWriteFormatElement(writer, BAD_CAST "comment",
+			"%s", BAD_CAST (idx->commit_message)), -1);
+	}
+	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "volumeuuid", BAD_CAST idx->vol_uuid), -1);
+	xml_mktag(xmlTextWriterWriteFormatElement(
+		writer, BAD_CAST "generationnumber", "%u", idx->generation), -1);
+	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "updatetime", BAD_CAST update_time), -1);
+	xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "location"), -1);
+	xml_mktag(xmlTextWriterWriteFormatElement(
+		writer, BAD_CAST "partition", "%c", idx->selfptr.partition), -1);
+	xml_mktag(xmlTextWriterWriteFormatElement(
+		writer, BAD_CAST "startblock", "%"PRIu64, idx->selfptr.block), -1);
+	xml_mktag(xmlTextWriterEndElement(writer), -1);
+	if (idx->backptr.block) {
+		xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "previousgenerationlocation"), -1);
+		xml_mktag(xmlTextWriterWriteFormatElement(
+			writer, BAD_CAST "partition", "%c", idx->backptr.partition), -1);
+		xml_mktag(xmlTextWriterWriteFormatElement(
+			writer, BAD_CAST "startblock", "%"PRIu64, idx->backptr.block), -1);
+		xml_mktag(xmlTextWriterEndElement(writer), -1);
+	}
+	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "allowpolicyupdate",
+		BAD_CAST (idx->criteria_allow_update ? "true" : "false")), -1);
+	if (idx->original_criteria.have_criteria) {
+		xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "dataplacementpolicy"), -1);
+		xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "indexpartitioncriteria"), -1);
+		xml_mktag(xmlTextWriterWriteFormatElement(writer, BAD_CAST "size", "%"PRIu64,
+			idx->original_criteria.max_filesize_criteria), -1);
+		if (idx->original_criteria.glob_patterns) {
+			name_criteria = idx->original_criteria.glob_patterns;
+			while (*name_criteria && **name_criteria) {
+				xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "name",
+					BAD_CAST (*name_criteria)), -1);
+				++name_criteria;
+			}
+		}
+		xml_mktag(xmlTextWriterEndElement(writer), -1);
+		xml_mktag(xmlTextWriterEndElement(writer), -1);
+	}
+	xml_mktag(xmlTextWriterWriteFormatElement(
+		writer, BAD_CAST NEXTUID_TAGNAME, "%"PRIu64, idx->uid_number), -1);
+
+	{
+		char *value = NULL;
+
+		switch (idx->vollock) {
+			case VOLUME_LOCKED:
+				asprintf(&value, "locked");
+				break;
+			case VOLUME_PERM_LOCKED:
+				asprintf(&value, "permlocked");
+				break;
+			default:
+				asprintf(&value, "unlocked");
+				break;
+		}
+
+		if (value)
+			xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "volumelockstate", BAD_CAST value), -1);
+
+		free(value);
+	}
+
+	/* unlink offset cache and sync list before rewriting index */
+	ret = asprintf(&offset_name, "%s.%s", idx->root->vol->index_cache_path, "offsetcache");
+	if (ret > 0) {
+		unlink(offset_name);
+		free(offset_name);
+	}
+
+	ret = asprintf(&sync_name, "%s.%s", idx->root->vol->index_cache_path, "synclist");
+	if (ret > 0) {
+		unlink(sync_name);
+		free(sync_name);
+	}
+
+	xml_mktag(_xml_write_dirtree(writer, idx->root, idx, &offset, &list), -1);
+	if (offset.count)
+		ltfsmsg(LTFS_INFO, "17249I", offset.count);
+	if (list.count)
+		ltfsmsg(LTFS_INFO, "17250I", list.count);
+
+	/* Save unrecognized tags */
+	if (idx->tag_count > 0) {
+		for (i=0; i<idx->tag_count; ++i) {
+			if (xmlTextWriterWriteRaw(writer, idx->preserved_tags[i]) < 0) {
+				ltfsmsg(LTFS_ERR, "17092E", __FUNCTION__);
+				return -1;
+			}
+		}
+	}
+
+	xml_mktag(xmlTextWriterEndElement(writer), -1);
+	ret = xmlTextWriterEndDocument(writer);
+	if (ret < 0) {
+		ltfsmsg(LTFS_ERR, "17058E", ret);
+		return -1;
+	}
+
+	free(update_time);
+	return 0;
+}
+
+/**************************************************************************************
+ * Global Functions
+ **************************************************************************************/
 
 /**
  * Generate an XML tape label.
@@ -84,7 +621,7 @@ int _xml_write_xattr(xmlTextWriterPtr writer, const struct dentry *file);
  * @return buffer containing the label, which the caller should free using xmlBufferFree
  */
 xmlBufferPtr xml_make_label(const char *creator, tape_partition_t partition,
-	const struct ltfs_label *label)
+							const struct ltfs_label *label)
 {
 	int ret;
 	char *fmt_time;
@@ -324,541 +861,4 @@ int xml_schema_to_tape(char *reason, struct ltfs_volume *vol)
 	}
 
 	return ret;
-}
-
-/**
- * Generate an XML schema, sending it to a user-provided output (memory or file).
- * Note: this function does very little input validation; any user-provided information
- * must be verified by the caller.
- * @param writer the XML writer to send output to
- * @param priv LTFS data
- * @param pos position on tape where the schema will be written
- * @return 0 on success, negative on failure
- */
-int _xml_write_schema(xmlTextWriterPtr writer, const char *creator,
-	const struct ltfs_index *idx)
-{
-	int ret;
-	size_t i;
-	char *update_time, **name_criteria;
-	char *offset_name = NULL, *sync_name = NULL;
-	struct ltfsee_cache offset = {NULL, 0};  /* Cache structure for file offset cache */
-	struct ltfsee_cache list = {NULL, 0};    /* Cache structure for sync list */
-
-	ret = xml_format_time(idx->mod_time, &update_time);
-	if (!update_time)
-		return -1;
-	else if (ret == LTFS_TIME_OUT_OF_RANGE)
-		ltfsmsg(LTFS_WARN, "17224W", "modifytime", idx->mod_time.tv_sec);
-
-	ret = xmlTextWriterStartDocument(writer, NULL, "UTF-8", NULL);
-	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17057E", ret);
-		return -1;
-	}
-
-	xmlTextWriterSetIndent(writer, 1);
-	/* Define INDENT_INDEXES to write Indexes to tape with full indentation.
-	 * This is normally a waste of space, but it may be useful for debugging. */
-#ifdef INDENT_INDEXES
-	xmlTextWriterSetIndentString(writer, BAD_CAST "    ");
-#else
-	xmlTextWriterSetIndentString(writer, BAD_CAST "");
-#endif
-
-	/* write index properties */
-	xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "ltfsindex"), -1);
-	xml_mktag(xmlTextWriterWriteAttribute(writer, BAD_CAST "version",
-		BAD_CAST LTFS_INDEX_VERSION_STR), -1);
-	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "creator", BAD_CAST creator), -1);
-	if (idx->commit_message && strlen(idx->commit_message)) {
-		xml_mktag(xmlTextWriterWriteFormatElement(writer, BAD_CAST "comment",
-			"%s", BAD_CAST (idx->commit_message)), -1);
-	}
-	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "volumeuuid", BAD_CAST idx->vol_uuid), -1);
-	xml_mktag(xmlTextWriterWriteFormatElement(
-		writer, BAD_CAST "generationnumber", "%u", idx->generation), -1);
-	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "updatetime", BAD_CAST update_time), -1);
-	xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "location"), -1);
-	xml_mktag(xmlTextWriterWriteFormatElement(
-		writer, BAD_CAST "partition", "%c", idx->selfptr.partition), -1);
-	xml_mktag(xmlTextWriterWriteFormatElement(
-		writer, BAD_CAST "startblock", "%"PRIu64, idx->selfptr.block), -1);
-	xml_mktag(xmlTextWriterEndElement(writer), -1);
-	if (idx->backptr.block) {
-		xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "previousgenerationlocation"), -1);
-		xml_mktag(xmlTextWriterWriteFormatElement(
-			writer, BAD_CAST "partition", "%c", idx->backptr.partition), -1);
-		xml_mktag(xmlTextWriterWriteFormatElement(
-			writer, BAD_CAST "startblock", "%"PRIu64, idx->backptr.block), -1);
-		xml_mktag(xmlTextWriterEndElement(writer), -1);
-	}
-	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "allowpolicyupdate",
-		BAD_CAST (idx->criteria_allow_update ? "true" : "false")), -1);
-	if (idx->original_criteria.have_criteria) {
-		xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "dataplacementpolicy"), -1);
-		xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "indexpartitioncriteria"), -1);
-		xml_mktag(xmlTextWriterWriteFormatElement(writer, BAD_CAST "size", "%"PRIu64,
-			idx->original_criteria.max_filesize_criteria), -1);
-		if (idx->original_criteria.glob_patterns) {
-			name_criteria = idx->original_criteria.glob_patterns;
-			while (*name_criteria && **name_criteria) {
-				xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "name",
-					BAD_CAST (*name_criteria)), -1);
-				++name_criteria;
-			}
-		}
-		xml_mktag(xmlTextWriterEndElement(writer), -1);
-		xml_mktag(xmlTextWriterEndElement(writer), -1);
-	}
-	xml_mktag(xmlTextWriterWriteFormatElement(
-		writer, BAD_CAST NEXTUID_TAGNAME, "%"PRIu64, idx->uid_number), -1);
-
-	{
-		char *value = NULL;
-
-		switch (idx->vollock) {
-			case VOLUME_LOCKED:
-				asprintf(&value, "locked");
-				break;
-			case VOLUME_PERM_LOCKED:
-				asprintf(&value, "permlocked");
-				break;
-			default:
-				asprintf(&value, "unlocked");
-				break;
-		}
-
-		if (value)
-			xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "volumelockstate", BAD_CAST value), -1);
-
-		free(value);
-	}
-
-	/* unlink offset cache and sync list before rewriting index */
-	ret = asprintf(&offset_name, "%s.%s", idx->root->vol->index_cache_path, "offsetcache");
-	if (ret > 0) {
-		unlink(offset_name);
-		free(offset_name);
-	}
-
-	ret = asprintf(&sync_name, "%s.%s", idx->root->vol->index_cache_path, "synclist");
-	if (ret > 0) {
-		unlink(sync_name);
-		free(sync_name);
-	}
-
-	xml_mktag(_xml_write_dirtree(writer, idx->root, idx, &offset, &list), -1);
-	if (offset.count)
-		ltfsmsg(LTFS_INFO, "17249I", offset.count);
-	if (list.count)
-		ltfsmsg(LTFS_INFO, "17250I", list.count);
-
-	/* Save unrecognized tags */
-	if (idx->tag_count > 0) {
-		for (i=0; i<idx->tag_count; ++i) {
-			if (xmlTextWriterWriteRaw(writer, idx->preserved_tags[i]) < 0) {
-				ltfsmsg(LTFS_ERR, "17092E", __FUNCTION__);
-				return -1;
-			}
-		}
-	}
-
-	xml_mktag(xmlTextWriterEndElement(writer), -1);
-	ret = xmlTextWriterEndDocument(writer);
-	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17058E", ret);
-		return -1;
-	}
-
-	free(update_time);
-	return 0;
-}
-
-static int encode_entry_name(char **new_name, const char *name)
-{
-	int len;
-	UChar32 c;
-	static char invalid_chars[] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz+-." ;
-	char *tmp_name;
-	char buf_encode[3];
-	int i=0, count=0, prev=0, j=0;
-
-	CHECK_ARG_NULL(name, -LTFS_NULL_ARG);
-
-	len = strlen(name);
-
-	tmp_name = malloc(len * 3 * sizeof(UChar));
-	buf_encode[2] = '\0';
-
-	while (i < len) {
-		count = 0;
-		prev = i;
-
-		U8_NEXT(name, i, len, c);
-		if (c < 0) {
-			ltfsmsg(LTFS_ERR, "11235E");
-			free(tmp_name);
-			return -LTFS_ICU_ERROR;
-		}
-
-        if (strchr(invalid_chars, name[prev])) {
-			// encode is not needed.
-			tmp_name[j] = name[prev];
-			j++;
-			continue;
-		}
-
-		while (count < i - prev) {
-			sprintf(buf_encode, "%02X", name[prev+count] & 0xFF);
-			tmp_name[j] = '%';
-			tmp_name[j+1] = buf_encode[0];
-			tmp_name[j+2] = buf_encode[1];
-			j += 3;
-			count++;
-		}
-	}
-
-	tmp_name[j] = '\0';
-
-	*new_name = strdup(tmp_name);
-	free(tmp_name);
-
-	return 0;
-}
-
-/**
- * Write XML tags representing the current directory tree to the given destination.
- * @param writer output pointer
- * @param dir directory to process
- * @param idx pointer to ltfs index structure
- * @param offset_c file pointer to write offest cache
- * @param sync_list file pointer to write sync file list
- * @return 0 on success or negative on failure
- */
-int _xml_write_dirtree(xmlTextWriterPtr writer, struct dentry *dir,
-					   const struct ltfs_index *idx, struct ltfsee_cache* offset_c, struct ltfsee_cache* sync_list)
-{
-	size_t i;
-	char *offset_name, *sync_name;
-	struct ltfsee_cache *offset = offset_c, *sync = sync_list;
-	struct name_list *list_ptr, *list_tmp;
-	int ret;
-
-	if (!dir)
-		return 0; /* nothing to do */
-
-	/* write standard attributes */
-	xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "directory"), -1);
-	if (dir == idx->root) {
-		if (idx->volume_name) {
-			if (fs_is_percent_encode_required(idx->volume_name)) {
-				char *encoded_name;
-				encode_entry_name(&encoded_name, idx->volume_name);
-				xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "name"), -1);
-				xml_mktag(xmlTextWriterWriteAttribute(writer, BAD_CAST "percentencoded", BAD_CAST "true"), -1);
-				xml_mktag(xmlTextWriterWriteString(writer, BAD_CAST encoded_name), -1);
-				xml_mktag(xmlTextWriterEndElement(writer), -1);
-				free(encoded_name);
-			}
-			else 
-				xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "name", BAD_CAST idx->volume_name), -1);
-		} else {
-			xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "name"), -1);
-			xml_mktag(xmlTextWriterEndElement(writer), -1);
-		}
-	} else if (dir->percent_encode) {
-		char *encoded_name;
-		encode_entry_name(&encoded_name, dir->name);
-		xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "name"), -1);
-		xml_mktag(xmlTextWriterWriteAttribute(writer, BAD_CAST "percentencoded", BAD_CAST "true"), -1);
-		xml_mktag(xmlTextWriterWriteString(writer, BAD_CAST encoded_name), -1);
-		xml_mktag(xmlTextWriterEndElement(writer), -1);
-		free(encoded_name);
-	} else {
-		xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "name", BAD_CAST dir->name), -1);
-	}
-
-	xml_mktag(xmlTextWriterWriteElement(
-		writer, BAD_CAST "readonly", BAD_CAST (dir->readonly ? "true" : "false")), -1);
-	xml_mktag(_xml_write_dentry_times(writer, dir), -1);
-	xml_mktag(xmlTextWriterWriteFormatElement(
-		writer, BAD_CAST UID_TAGNAME, "%"PRIu64, dir->uid), -1);
-
-	/* write extended attributes */
-	xml_mktag(_xml_write_xattr(writer, dir), -1);
-
-	/* write children */
-	xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "contents"), -1);
-	/* Sort dentries by UID before generating xml */
-	HASH_SORT(dir->child_list, fs_hash_sort_by_uid);
-
-	HASH_ITER(hh, dir->child_list, list_ptr, list_tmp) {
-		if (list_ptr->d->isdir) {
-
-			if (list_ptr->d->vol->index_cache_path && !strcmp(list_ptr->d->name, ".LTFSEE_DATA")) {
-				ret = asprintf(&offset_name, "%s.%s", list_ptr->d->vol->index_cache_path, "offsetcache");
-				if (ret > 0) {
-					offset->fp = fopen(offset_name, "w");
-					free(offset_name);
-					if (!offset->fp)
-						ltfsmsg(LTFS_WARN, "17248W", "offset cache", list_ptr->d->vol->index_cache_path);
-				} else
-					ltfsmsg(LTFS_WARN, "17247W", "offset cache", list_ptr->d->vol->index_cache_path);
-
-				ret = asprintf(&sync_name, "%s.%s", list_ptr->d->vol->index_cache_path, "synclist");
-				if (ret > 0) {
-					sync->fp = fopen(sync_name, "w");
-					free(sync_name);
-					if (!sync->fp)
-						ltfsmsg(LTFS_WARN, "17248W", "sync list", list_ptr->d->vol->index_cache_path);
-				} else
-					ltfsmsg(LTFS_WARN, "17247W", "sync list", list_ptr->d->vol->index_cache_path);
-			}
-
-			xml_mktag(_xml_write_dirtree(writer, list_ptr->d, idx, offset, sync), -1);
-
-			if (offset->fp) {
-				fflush(offset->fp);
-				fsync(fileno(offset->fp));
-				fclose(offset->fp);
-				offset->fp = NULL;
-			}
-			if (sync->fp) {
-				fflush(sync->fp);
-				fsync(fileno(sync->fp));
-				fclose(sync->fp);
-				sync->fp = NULL;
-			}
-
-		} else
-			xml_mktag(_xml_write_file(writer, list_ptr->d, offset_c, sync_list), -1);
-	}
-
-	xml_mktag(xmlTextWriterEndElement(writer), -1);
-
-	/* Save unrecognized tags */
-	if (dir->tag_count > 0) {
-		for (i=0; i<dir->tag_count; ++i) {
-			if (xmlTextWriterWriteRaw(writer, dir->preserved_tags[i]) < 0) {
-				ltfsmsg(LTFS_ERR, "17092E", __FUNCTION__);
-				return -1;
-			}
-		}
-	}
-
-	xml_mktag(xmlTextWriterEndElement(writer), -1);
-
-	return 0;
-}
-
-/**
- * Write file info to an XML stream.
- * @param writer output pointer
- * @param file the file to write
- * @return 0 on success or -1 on failure
- */
-int _xml_write_file(xmlTextWriterPtr writer, struct dentry *file, struct ltfsee_cache* offset_c, struct ltfsee_cache* sync_list)
-{
-	struct extent_info *extent;
-	bool write_offset = false;
-	size_t i;
-
-	if (file->isdir) {
-		ltfsmsg(LTFS_ERR, "17062E");
-		return -1;
-	}
-
-	/* write standard attributes */
-	xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "file"), -1);
-
-	if (file->percent_encode) {
-		char *encoded_name;
-		encode_entry_name(&encoded_name, file->name);
-		xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "name"), -1);
-		xml_mktag(xmlTextWriterWriteAttribute(writer, BAD_CAST "percentencoded", BAD_CAST "true"), -1);
-		xml_mktag(xmlTextWriterWriteString(writer, BAD_CAST encoded_name), -1);
-		xml_mktag(xmlTextWriterEndElement(writer), -1);
-		free(encoded_name);
-	}
-	else {
-		xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "name", BAD_CAST file->name), -1);
-	}
-
-	xml_mktag(xmlTextWriterWriteFormatElement(
-		writer, BAD_CAST "length", "%"PRIu64, file->size), -1);
-	xml_mktag(xmlTextWriterWriteElement(
-		writer, BAD_CAST "readonly", BAD_CAST (file->readonly ? "true" : "false")), -1);
-	xml_mktag(_xml_write_dentry_times(writer, file), -1);
-	xml_mktag(xmlTextWriterWriteFormatElement(
-		writer, BAD_CAST UID_TAGNAME, "%"PRIu64, file->uid), -1);
-
-	/* write extended attributes */
-	xml_mktag(_xml_write_xattr(writer, file), -1);
-
-	/* write extents */
-    if (file->isslink) {
-        xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "symlink", BAD_CAST file->target), -1);
-    } else if (! TAILQ_EMPTY(&file->extentlist)) {
-		xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "extentinfo"), -1);
-		TAILQ_FOREACH(extent, &file->extentlist, list) {
-			/* Write file offset cache */
-			if (offset_c->fp && ! write_offset) {
-				fprintf(offset_c->fp, "%s,%"PRIu64"\n", file->name, extent->start.block);
-				write_offset = true;
-				offset_c->count++;
-			}
-			xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "extent"), -1);
-			xml_mktag(xmlTextWriterWriteFormatElement(
-				writer, BAD_CAST "fileoffset", "%"PRIu64, extent->fileoffset), -1);
-			xml_mktag(xmlTextWriterWriteFormatElement(
-				writer, BAD_CAST "partition", "%c", extent->start.partition), -1);
-			xml_mktag(xmlTextWriterWriteFormatElement(
-				writer, BAD_CAST "startblock", "%"PRIu64, extent->start.block), -1);
-			xml_mktag(xmlTextWriterWriteFormatElement(
-				writer, BAD_CAST "byteoffset", "%"PRIu32, extent->byteoffset), -1);
-			xml_mktag(xmlTextWriterWriteFormatElement(
-				writer, BAD_CAST "bytecount", "%"PRIu64, extent->bytecount), -1);
-			xml_mktag(xmlTextWriterEndElement(writer), -1);
-		}
-		xml_mktag(xmlTextWriterEndElement(writer), -1);
-	} else {
-		/* Write file offset cache */
-		if (offset_c->fp) {
-			fprintf(offset_c->fp, "%s,%"PRIu64"\n", file->name, (uint64_t)0);
-			offset_c->count++;
-		}
-	}
-
-	/* Save unrecognized tags */
-	if (file->tag_count > 0) {
-		for (i=0; i<file->tag_count; ++i) {
-			if (xmlTextWriterWriteRaw(writer, file->preserved_tags[i]) < 0) {
-				ltfsmsg(LTFS_ERR, "17092E", __FUNCTION__);
-				return -1;
-			}
-		}
-	}
-
-	xml_mktag(xmlTextWriterEndElement(writer), -1);
-
-	/* Write dirty file list */
-	if (sync_list->fp && file->dirty) {
-		fprintf(sync_list->fp, "%s,%"PRIu64"\n", file->name, file->size);
-		file->dirty = false;
-		sync_list->count++;
-	}
-
-	return 0;
-}
-
-/**
- * Write time info into an XML stream.
- * @param write output pointer
- * @param d dentry to get times from
- * @return 0 on success or a negative value on error.
- */
-int _xml_write_dentry_times(xmlTextWriterPtr writer, const struct dentry *d)
-{
-	int ret;
-	char *mtime;
-
-	ret = xml_format_time(d->creation_time, &mtime);
-	if (!mtime)
-		return -1;
-	else if (ret == LTFS_TIME_OUT_OF_RANGE)
-		ltfsmsg(LTFS_WARN, "17225W", "creationtime", d->creation_time.tv_sec);
-	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "creationtime", BAD_CAST mtime), -1);
-	free(mtime);
-
-	ret = xml_format_time(d->change_time, &mtime);
-	if (!mtime)
-		return -1;
-	else if (ret == LTFS_TIME_OUT_OF_RANGE)
-		ltfsmsg(LTFS_WARN, "17225W", "changetime", d->change_time.tv_sec);
-	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "changetime", BAD_CAST mtime), -1);
-	free(mtime);
-
-	ret = xml_format_time(d->modify_time, &mtime);
-	if (!mtime)
-		return -1;
-	else if (ret == LTFS_TIME_OUT_OF_RANGE)
-		ltfsmsg(LTFS_WARN, "17225W", "modifytime", d->modify_time.tv_sec);
-	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "modifytime", BAD_CAST mtime), -1);
-	free(mtime);
-
-	ret = xml_format_time(d->access_time, &mtime);
-	if (!mtime)
-		return -1;
-	else if (ret == LTFS_TIME_OUT_OF_RANGE)
-		ltfsmsg(LTFS_WARN, "17225W", "accesstime", d->access_time.tv_sec);
-	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "accesstime", BAD_CAST mtime), -1);
-	free(mtime);
-
-	ret = xml_format_time(d->backup_time, &mtime);
-	if (!mtime)
-		return -1;
-	else if (ret == LTFS_TIME_OUT_OF_RANGE)
-		ltfsmsg(LTFS_WARN, "17225W", "backuptime", d->backup_time.tv_sec);
-	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "backuptime", BAD_CAST mtime), -1);
-	free(mtime);
-
-	return 0;
-}
-
-/**
- * Write extended attributes from the given file or directory.
- * @param writer output pointer
- * @param file the dentry to take xattrs from
- * @return 0 on success or -1 on failure
- */
-int _xml_write_xattr(xmlTextWriterPtr writer, const struct dentry *file)
-{
-	int ret;
-	struct xattr_info *xattr;
-
-	if (! TAILQ_EMPTY(&file->xattrlist)) {
-		xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "extendedattributes"), -1);
-		TAILQ_FOREACH(xattr, &file->xattrlist, list) {
-			xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "xattr"), -1);
-
-			if (xattr->encoded) {
-				char *encoded_key;
-				encode_entry_name(&encoded_key, xattr->key);
-				xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "key"), -1);
-				xml_mktag(xmlTextWriterWriteAttribute(writer, BAD_CAST "percentencoded", BAD_CAST "true"), -1);
-				xml_mktag(xmlTextWriterWriteString(writer, BAD_CAST encoded_key), -1);
-				xml_mktag(xmlTextWriterEndElement(writer), -1);
-				free(encoded_key);
-			}
-			else {
-				xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "key", BAD_CAST xattr->key), -1);
-			}
-
-			if (xattr->value) {
-				ret = pathname_validate_xattr_value(xattr->value, xattr->size);
-				if (ret < 0) {
-					ltfsmsg(LTFS_ERR, "17059E", ret);
-					return -1;
-				} else if (ret > 0) {
-					xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "value"), -1);
-					xml_mktag(
-						xmlTextWriterWriteAttribute(writer, BAD_CAST "type", BAD_CAST "base64"),
-						-1);
-					xml_mktag(xmlTextWriterWriteBase64(writer, xattr->value, 0, xattr->size), -1);
-					xml_mktag(xmlTextWriterEndElement(writer), -1);
-				} else {
-					xml_mktag(xmlTextWriterWriteFormatElement(
-						writer, BAD_CAST "value", "%.*s", (int)xattr->size, xattr->value), -1);
-				}
-			} else { /* write empty value tag */
-				xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "value"), -1);
-				xml_mktag(xmlTextWriterEndElement(writer), -1);
-			}
-			xml_mktag(xmlTextWriterEndElement(writer), -1);
-		}
-		xml_mktag(xmlTextWriterEndElement(writer), -1);
-	}
-
-	return 0;
 }


### PR DESCRIPTION
# Summary: Cleaning LTFS label and LTFS index parser

# Description

Cleaning LTFS parser here to have clean fix for missing "percentencoded" attribute in the LTFS index.

The changes are
  - Add `static` to the local functions in the LTFS label parser
  - Add `static` to the local functions in the LTFS index parser
  - Change function order to reduce forward reference as much as possible

Preparation of #4 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [X] Cleaning the code

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
