### PR TITLE
Specify char as "signed char" explicitly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -304,7 +304,7 @@ dnl Update flags
 dnl Sets CFLAGS to force optimization and debugging options, which isn't quite kosher
 dnl
 AM_CPPFLAGS="-D_GNU_SOURCE -I\$(top_srcdir)/src -DLTFS_CONFIG_FILE='\"${sysconfdir}/ltfs.conf\"' -DLTFS_BASE_DIR='\"${prefix}\"'"
-AM_CFLAGS="-Wall -Wsign-compare ${FUSE_MODULE_CFLAGS} ${UUID_MODULE_CFLAGS} ${LIBXML2_MODULE_CFLAGS} ${ICU_MODULE_CFLAGS} ${SNMP_ENABLE} ${SNMP_MODULE_CFLAGS}"
+AM_CFLAGS="-Wall -Wsign-compare -fsigned-char ${FUSE_MODULE_CFLAGS} ${UUID_MODULE_CFLAGS} ${LIBXML2_MODULE_CFLAGS} ${ICU_MODULE_CFLAGS} ${SNMP_ENABLE} ${SNMP_MODULE_CFLAGS}"
 
 if test "x$use_fast" = "xyes"
 then


### PR DESCRIPTION
# Summary of changes

The standard of the C language does not specify plain 'char' is unsigned
or signed. In gcc(x86_64) it is signed, but it is unsigned in
gcc(ppc64le) by default.

This change specifies the plain 'char' is signed in compiler option.

# Description

This specification is needed to run LTFS on ppc64le machine.

## Type of change

Please delete items that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
