### PR TITLE
Fix of build break on macOS

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1164,8 +1164,8 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 	/*
 	 *  Set the volume name (logical) when LTFS runs on OS X
 	 */
-	if (priv->data->index->volume_name) {
-		ret = asprintf(&opt_volname, "-ovolname=%s(%s)", priv->data->index->volume_name, "ltfs");
+	if (priv->data->index->volume_name.name) {
+		ret = asprintf(&opt_volname, "-ovolname=%s(%s)", priv->data->index->volume_name.name, "ltfs");
 		if (ret < 0) {
 			/* Memory allocation failed */
 			ltfsmsg(LTFS_ERR, "10001E", "option string for volume name");

--- a/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
+++ b/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
@@ -69,6 +69,9 @@
 #include "ibm_tape.h"
 
 /* iokit functions */
+#ifdef VERSION
+#undef VERSION // Undef VERSION because it is conflicted into the header in IOKit
+#endif
 #include "iokit_service.h"
 #include "iokit_scsi.h"
 


### PR DESCRIPTION
# Summary of changes

- Build on macOS is failed because of introducing struct ltfs_name.
- Undef VERSION in iokit backend because VERSION is defined in both config.h and IOKit

# Description

Fix of build break on macOS

## Type of change

Please delete items that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
