### PR TITLE
Clip the initial IBM LTO8 drive's FW level

### DIFF
--- a/messages/tape_common/root.txt
+++ b/messages/tape_common/root.txt
@@ -51,5 +51,7 @@ root:table {
 		39809D:string { "WORM cartridge is loaded." }
 		39810W:string { "No IP address was found. Use host name based reservation key." }
 		39811W:string { "Cannot fetch network I/F information. Use host name based reservation key. (%d)" }
+		39812W:string { "Drive firmware must be updated. Upgrading to %s or later is recommended." }
+		39813W:string { "Drive firmware level does not correctly detect the EOD status." }
 	}
 }

--- a/messages/tape_iokit_ibmtape/root.txt
+++ b/messages/tape_iokit_ibmtape/root.txt
@@ -93,8 +93,8 @@ root:table {
 		//unused 30848
 		//unused 30849
 		//unused 30850
-		30851W:string { "Drive firmware must be upgraded to %s or later." }
-		30852W:string { "Drive firmware level does not correctly detect the EOD status." }
+		//unused (moved) 30851W:string { "Drive firmware must be upgraded to %s or later." }
+		//unused (moved) 30852W:string { "Drive firmware level does not correctly detect the EOD status." }
 		30853I:string { "Logical block protection is enabled." }
 		30854I:string { "Logical block protection is disabled." }
 		30855I:string { "Saving drive dump to %s." }

--- a/messages/tape_linux_lin_tape/root.txt
+++ b/messages/tape_linux_lin_tape/root.txt
@@ -63,8 +63,8 @@ root:table {
 		30418I:string { "Parsing log page: buffer too small, copying %zu bytes from %lx." }
 		30419I:string { "Option parsing for the ibmtape backend failed (%d)." }
 		30420E:string { "Invalid scsi_lbprotect option: %s." }
-		30421W:string { "Drive firmware must be updated. Upgrading to %s or later is recommended." }
-		30422W:string { "Drive firmware level does not correctly detect the EOD status." }
+		// Unused (Moved) 30421W:string { "Drive firmware must be updated. Upgrading to %s or later is recommended." }
+		// Unused (Moved) 30422W:string { "Drive firmware level does not correctly detect the EOD status." }
 		30423I:string { "Opening a device through ibmtape driver (%s)." }
 		30424E:string { "%s: medium is already mounted or in use." }
 		30425I:string { "Cannot open device \'%s\' (%d)." }

--- a/messages/tape_linux_sg_ibmtape/root.txt
+++ b/messages/tape_linux_sg_ibmtape/root.txt
@@ -88,8 +88,8 @@ root:table {
 		//unused 30246
 		//unused 30247
 		//unused 30248
-		30249W:string { "Drive firmware must be upgraded to %s or later." }
-		30250W:string { "Drive firmware level does not correctly detect the EOD status." }
+		//unused (moved) 30249W:string { "Drive firmware must be upgraded to %s or later." }
+		//unused (moved) 30250W:string { "Drive firmware level does not correctly detect the EOD status." }
 		30251I:string { "Logical block protection is enabled." }
 		30252I:string { "Logical block protection is disabled." }
 		30253I:string { "Saving drive dump to %s." }

--- a/src/tape_drivers/ibm_tape.h
+++ b/src/tape_drivers/ibm_tape.h
@@ -65,6 +65,10 @@
 extern "C" {
 #endif
 
+static const char base_firmware_level_lto5[] = "B170";
+static const char base_firmware_level_lto8[] = "HB81";
+static const char base_firmware_level_ts1140[] = "3694";
+
 extern struct error_table standard_tape_errors[];
 extern struct error_table ibm_tape_errors[];
 
@@ -268,6 +272,7 @@ struct reservation_info {
 
 int ibmtape_genkey(unsigned char *key);
 int ibmtape_parsekey(unsigned char *key, struct reservation_info *r);
+bool ibmtape_is_supported_firmware(int drive_type, const unsigned char * const revision);
 
 extern struct supported_device *ibm_supported_drives[];
 extern struct supported_device *usb_supported_drives[];

--- a/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
+++ b/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
@@ -877,35 +877,6 @@ int lin_tape_ibmtape_parse_opts(void *device, void *opt_args)
 	return 0;
 }
 
-static bool is_supported_firmware(int drive_type, const unsigned char * const revision)
-{
-	const uint32_t rev = ltfs_betou32(revision);
-	return true; /* temporary by nishida */
-
-	switch (drive_type) {
-	case DRIVE_LTO5:
-	case DRIVE_LTO5_HH:
-		if (rev < ltfs_betou32(base_firmware_level_lto5)) {
-			ltfsmsg(LTFS_WARN, "30421W", base_firmware_level_lto5);
-			ltfsmsg(LTFS_WARN, "30422W");
-		}
-		break;
-	case DRIVE_TS1140:
-		if (rev < ltfs_betou32(base_firmware_level_ts1140)) {
-			ltfsmsg(LTFS_WARN, "30421W", base_firmware_level_ts1140);
-			return false;
-		}
-		break;
-	case DRIVE_LTO6:
-	case DRIVE_LTO6_HH:
-	case DRIVE_TS1150:
-	default:
-		break;
-	}
-
-	return true;
-}
-
 /**
  * Get inquiry data from a specific page
  * @param device tape device
@@ -1094,7 +1065,7 @@ int lin_tape_ibmtape_open(const char *devname, void **handle)
 	}
 
 	ltfsmsg(LTFS_INFO, "30432I", inq_data.revision);
-	if (! is_supported_firmware(priv->drive_type, inq_data.revision)) {
+	if (! ibmtape_is_supported_firmware(priv->drive_type, (unsigned char*)inq_data.revision)) {
 		ltfsmsg(LTFS_INFO, "30430I", "firmware");
 		close(priv->fd);
 		free(priv);

--- a/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
+++ b/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
@@ -169,34 +169,6 @@ static int null_parser(void *priv, const char *arg, int key, struct fuse_args *o
 	return 1;
 }
 
-static bool is_supported_firmware(int drive_type, scsi_device_identifier *id_data)
-{
-	const uint32_t rev = ltfs_betou32(id_data->product_rev);
-
-	switch (drive_type) {
-		case DRIVE_LTO5:
-		case DRIVE_LTO5_HH:
-			if (rev < ltfs_betou32(base_firmware_level_lto5)) {
-				ltfsmsg(LTFS_WARN, "30851W", base_firmware_level_lto5);
-				ltfsmsg(LTFS_WARN, "30852W");
-			}
-			break;
-		case DRIVE_TS1140:
-			if (rev < ltfs_betou32(base_firmware_level_ts1140)) {
-				ltfsmsg(LTFS_WARN, "30851W", base_firmware_level_ts1140);
-				return false;
-			}
-			break;
-		case DRIVE_LTO6:
-		case DRIVE_LTO6_HH:
-		case DRIVE_TS1150:
-		default:
-			break;
-	}
-
-	return true;
-}
-
 #define LBP_DISABLE             (0x00)
 #define REED_SOLOMON_CRC        (0x01)
 #define CRC32C_CRC              (0x02)
@@ -807,7 +779,7 @@ int iokit_ibmtape_open(const char *devname, void **handle)
 	}
 
 	if(drive_type > 0) {
-		if (!is_supported_firmware(drive_type, &id_data)) {
+		if (!ibmtape_is_supported_firmware(drive_type, (unsigned char*)id_data.product_rev)) {
 			iokit_release_exclusive_access(&priv->dev);
 			ret = -EDEV_UNSUPPORTED_FIRMWARE;
 			goto free;
@@ -905,7 +877,7 @@ int iokit_ibmtape_reopen(const char *devname, void *device)
 	}
 
 	if(drive_type > 0) {
-		if (!is_supported_firmware(drive_type, &id_data)) {
+		if (!ibmtape_is_supported_firmware(drive_type, (unsigned char*)id_data.product_rev)) {
 			iokit_release_exclusive_access(&priv->dev);
 			ret = -EDEV_UNSUPPORTED_FIRMWARE;
 		} else

--- a/src/tape_drivers/tape_drivers.h
+++ b/src/tape_drivers/tape_drivers.h
@@ -73,9 +73,6 @@
 #define MASK_WITH_SENSE_KEY    (0xFFFFFF)
 #define MASK_WITHOUT_SENSE_KEY (0x00FFFF)
 
-static const char base_firmware_level_lto5[] = "B170";
-static const char base_firmware_level_ts1140[] = "3694";
-
 typedef void  (*crc_enc)(void *buf, size_t n);
 typedef int   (*crc_check)(void *buf, size_t n);
 typedef void* (*memcpy_crc_enc)(void *dest, const void *src, size_t n);


### PR DESCRIPTION
# Summary of changes

To secure the M8 formatted tape's density code, reject initial F/W of IBM LTO8 drive.

- Fix of issue #19
- Move the functions to control FW level rejection to common area

# Description

To secure the M8 formatted tape's density code, reject initial F/W of IBM LTO8 drive. If all FW level is accepted, LTFS changes M8 tape back to L7 tape at format operation in the initial IBM LTO8 FW level.

Fixes #19

## Type of change

Please delete items that are not relevant.

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
