### PR TITLE
Introduce massage checker and cleaning messages

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -82,6 +82,17 @@ AC_ARG_ENABLE([debug],
 AC_MSG_RESULT([$use_debug])
 
 dnl
+dnl Handle --enable-message-checker (default:no)
+dnl
+AC_MSG_CHECKING([whether to compile in message checking mode])
+AC_ARG_ENABLE([message-checker],
+	[AS_HELP_STRING([--enable-message-checker],[compile in message checking mode (may be binary is defunct)])],
+	[use_msg_check=$enableval],
+	[use_msg_check=no]
+)
+AC_MSG_RESULT([$use_msg_check])
+
+dnl
 dnl Handle --enable-fast (default:no)
 dnl
 AC_MSG_CHECKING([whether to enable optimizations])
@@ -318,6 +329,11 @@ else
 	fi
 fi
 
+if test "x$use_msg_check" = "xyes"
+then
+    AM_CPPFLAGS="${AM_CPPFLAGS} -DMSG_CHECK"
+fi
+
 if test "x$livelink" = "xno"
 then
 	AM_CPPFLAGS="${AM_CPPFLAGS} -DPOSIXLINK_ONLY"
@@ -377,6 +393,8 @@ AM_CFLAGS=`echo ${AM_CFLAGS} | ${SED} 's|-D_FORTIFY_SOURCE=. ||g'`
 AM_LDFLAGS="${AM_LDFLAGS} ${FUSE_MODULE_LIBS} ${UUID_MODULE_LIBS} ${LIBXML2_MODULE_LIBS} ${ICU_MODULE_LIBS} ${SNMP_MODULE_LIBS_A} ${SNMP_MODULE_LIBS}"
 CFLAGS="${CFLAGS} ${OPT_FLAGS}"
 
+
+
 dnl
 dnl Define options
 dnl
@@ -384,6 +402,7 @@ AM_CONDITIONAL([PLATFORM_LINUX], [test "x${host_linux}" = "xyes"])
 AM_CONDITIONAL([ENABLE_LIN_TAPE], [test "x${lintape}" = "xyes"])
 AM_CONDITIONAL([PLATFORM_MAC], [test "x${host_mac}" = "xyes"])
 AM_CONDITIONAL([OSS], [true])
+AM_CONDITIONAL([CHK_MESSAGE], [test "x${use_msg_check}" = "xyes"])
 
 AC_SUBST(CFLAGS)
 AC_SUBST(CRC_OPTIMIZE)

--- a/messages/Makefile.am
+++ b/messages/Makefile.am
@@ -64,10 +64,20 @@ RESOURCES = \
 	internal_error_dat.o
 
 .PHONY: all $(RESOURCES) clean-local
+if CHK_MESSAGE
+all: $(RESOURCES) ../src/ltfsmsg.h
+else
 all: $(RESOURCES)
+endif
 
 $(RESOURCES):
 	@./make_message_src.sh $@
 
+if CHK_MESSAGE
+../src/ltfsmsg.h: $(RESOURCES)
+	./print_error_messages.py > ../src/ltfsmsg.h
+endif
+
 clean-local:
 	rm -rf $(RESOURCES) */work
+	rm -f ../src/ltfsmsg.h

--- a/messages/bin_ltfs/root.txt
+++ b/messages/bin_ltfs/root.txt
@@ -194,10 +194,7 @@ root:table {
 		14424I:string { "    -o fulltrace              Enable full call tracing (same as verbose=4)" }
 		14425I:string { "    -o eject                  Eject the cartridge after unmount" }
 		// Reserved 14426I
-		14427I:string { "    -o sync_type=<type>       Specify sync type (default: time@5)\n"
-				        "                              <type> should be specified as follows:\n"
-						"                              time@min:  LTFS attempts to write an index each 'min' minutes.\n"
-						"                                         min should be a decimal number from 1 to %ld\n"
+		14427I:string { "    -o sync_type=<type>       Specify sync type (default: time@5)\n                              <type> should be specified as follows:\n                              time@min:  LTFS attempts to write an index each 'min' minutes.\n                                         min should be a decimal number from 1 to %ld\n"
 						"                                         It is equivalent to \"-o sync_type=unmount\" when 0 is specified\n"
 						"                                         (default: min=5)\n"
 						"                              close:     LTFS attempts to write an index when a file is closed\n"

--- a/messages/kmi_flatfile/root.txt
+++ b/messages/kmi_flatfile/root.txt
@@ -39,30 +39,29 @@
 // ID is allocated here.
 root:table {
 	messages:table {
-		start_id:int { 15500 }
-		end_id:int { 15999 }
+		start_id:int { 15550 }
+		end_id:int { 15599 }
 
-		// Message IDs 15500-15009 are reserved for the cropto direct plugins.
+		// Message IDs 15500-15009 are reserved for the crypto direct plugins.
 		// DO NOT add messages with those IDs to this file.
 
-		15510D:string { "Flat File plug-in initialized." }
-		15511D:string { "Flat File plug-in uninitialized." }
-		15512E:string { "Flat File plug-in failed to parse options." }
-		15513E:string { "Flat File plug-in failed to open the file (%d,%d)." }
-		15514E:string { "Flat File plug-in detected key format violation." }
+		15550D:string { "Flat File plug-in initialized." }
+		15551D:string { "Flat File plug-in uninitialized." }
+		15552E:string { "Flat File plug-in failed to parse options." }
+		15553E:string { "Flat File plug-in failed to open the file (%s, %d)." }
+		15554E:string { "Flat File plug-in detected key format violation." }
 
 		// for LTFS specific format
-		15600E:string { "Encryption key format violation (%s): %s." }
-		15603E:string { "Cannot find data key." }
-		15604E:string { "Option parsing for the key manager interface backend failed (%d)." }
-		15605E:string { "Invalid sequence error (%d,%d): %s." }
-		15606E:string { "Failed to parse data key and/or data key identifier." }
-		15607E:string { "Cannot find data key of the data key identifier." }
-		15608I:string { "Key manager interface flatfile plug-in options:\n"
+		15562E:string { "Encryption key format violation (%s): %s." }
+		15563E:string { "Cannot find data key." }
+		15564E:string { "Option parsing for the key manager interface backend failed (%d)." }
+		15565E:string { "Invalid sequence error (%d,%d): %s." }
+		15566E:string { "Failed to parse data key and/or data key identifier." }
+		15567E:string { "Cannot find data key of the data key identifier." }
+		15568I:string { "Key manager interface flatfile plug-in options:\n"
 						"    -o kmi_dki_for_format=<DKi>\n"
 						"                              Data key identifier to format a cartridge\n"
 						"    -o kmi_dk_list=FILE\n"
 						"                              Data key and data key identifier pairs' list file\n\n." }
 	}
 }
-

--- a/messages/kmi_simple/root.txt
+++ b/messages/kmi_simple/root.txt
@@ -40,22 +40,17 @@
 root:table {
 	messages:table {
 		start_id:int { 15500 }
-		end_id:int { 15999 }
+		end_id:int { 15549 }
 
 		15500D:string { "Simple plug-in initialized." }
 		15501D:string { "Simple plug-in uninitialized." }
-
-		// Message IDs 15510-15529 are reserved for the cropto flatfile plugins.
-		// DO NOT add messages with those IDs to this file.
-
-		// for LTFS specific format
-		15600E:string { "Encryption key format violation (%s): %s." }
-		15603E:string { "Cannot find data key." }
-		15604E:string { "Option parsing for the key manager interface backend failed (%d)." }
-		15605E:string { "Invalid sequence error (%d,%d): %s." }
-		15606E:string { "Failed to parse data key and/or data key identifier." }
-		15607E:string { "Cannot find data key of the data key identifier." }
-		15608I:string { "Key manager interface simple plug-in options:\n"
+		15502E:string { "Encryption key format violation (%s): %s." }
+		15503E:string { "Cannot find data key." }
+		15504E:string { "Option parsing for the key manager interface backend failed (%d)." }
+		15505E:string { "Invalid sequence error (%d,%d): %s." }
+		15506E:string { "Failed to parse data key and/or data key identifier." }
+		15507E:string { "Cannot find data key of the data key identifier." }
+		15508I:string { "Key manager interface simple plug-in options:\n"
 			"    -o kmi_dk=<DK>\n"
 			"                              Data key\n"
 			"    -o kmi_dki=<DKi>\n"
@@ -68,4 +63,3 @@ root:table {
 			"                              Data key and data key identifier pairs' list\n\n." }
 	}
 }
-

--- a/messages/libltfs/root.txt
+++ b/messages/libltfs/root.txt
@@ -346,9 +346,9 @@ root:table {
 		11249E:string { "Cannot convert system locale to UTF-16: failed to fill output buffer (%d) for '%s'." }
 		11250E:string { "Cannot convert UTF-8 to system locale: failed to get output buffer size (%d)." }
 		11251E:string { "Cannot convert UTF-8 to system locale: failed to fill output buffer (%d)." }
-		11252D:string { "libltfs write to \'%s\': offset = %lld, count = %u." }
+		11252D:string { "libltfs write to \'%s\': offset = %lld, count = %llu." }
 		11253E:string { "No index found in the medium." }
-		11254D:string { "libltfs read from \'%s\': offset = %lld, count = %u." }
+		11254D:string { "libltfs read from \'%s\': offset = %lld, count = %llu." }
 		11255I:string { "Appending a file mark to the data partition." }
 		11256I:string { "Appending a file mark to the index partition." }
 		11257I:string { "No index found in the index partition." }
@@ -427,8 +427,8 @@ root:table {
 		11330I:string { "Loading cartridge." }
 		11331E:string { "Failed to load the cartridge (%s)." }
 		11332I:string { "Load successful." }
-		11333I:string { "A cartridge with a write-perm error is detected. Seek the newest index (%d, %d)." }
-		11334I:string { "Remove extent : %s (%d, %d)." }
+		11333I:string { "A cartridge with a write-perm error is detected. Seek the newest index (%llu, %llu)." }
+		11334I:string { "Remove extent : %s (%llu, %llu)." }
 		11335D:string { "Get physical block position (%d - %d)." }
 		11336I:string { "The attribute does not exist. Ignore the expected error." }
 		11337I:string { "Update index-dirty flag (%d) - %s (0x%p)." }
@@ -750,7 +750,7 @@ root:table {
 		17203W:string { "Truncate the tape attribute: %s (%s) to %d bytes." }
 		17204W:string { "Cannot set: unkown tape attribute type(0x%04x): %s." }
 		17205E:string { "Cannot set the tape attribute (type: 0x%04x): %s ." }
-		17206E:string { "Cannot write XML data to file descriptor (%s, %d, %ld)." }
+		17206E:string { "Cannot write XML data to file descriptor (%s, %d, %lu)." }
 		17207E:string { "Use the ltfsck command with the --salvage-rollback-points option and select the latest index from the list\n           Then use the ltfs command with the -o rollback-mount-no-eod option by specifying the generation." }
 		17208I:string { "Encountered the last data on the tape (%d). The last read index generation is %d." }
 		17217W:string { "%s is out of range in setting time (%s:%llu sec=%lld)." }
@@ -782,7 +782,7 @@ root:table {
 		17243W:string { "Failed to release the advisory lock (%d)." }
 		17244E:string { "XML writer: failed to write a block to the disk (%d)." }
 		17245E:string { "XML writer: failed to flush cached data to the disk (%d)." }
-		17246E:string { "Failed to % (%d)." }
+		17246E:string { "Failed to %s (%d)." }
 		17247W:string { "Failed to create the path of %s (%s)." }
 		17248W:string { "Failed to open %s (%s)." }
 		17249I:string { "Information of %lld files are written to the offset cache." }

--- a/messages/print_error_messages.py
+++ b/messages/print_error_messages.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python2.7
+
+import os
+import re
+
+re_msgid_bundle   = r'(^|[^0-9])(?P<id>(?P<val>[0-9]{4,5})[^0-9]):string { (?P<msg>".*")'
+
+msg_ids = dict()
+
+# List the messages defined in the message bundles
+for d, dirs, files in os.walk('.'):
+	if d == 'messages':
+		continue
+	if d == "messages/internal_error":
+		continue
+	msg_list = dict()
+	for f in files:
+		start_id = 0
+		end_id = 1000000
+		if re.search(r'\.txt$', f):
+			with file(os.path.join(d, f), 'r') as fd:
+				linenum = 1
+				for line in fd:
+					m = re.search(r'start_id:int\s*{\s*(?P<val>[0-9]+)\s*}', line)
+					if m is not None:
+						start_id = int(m.group('val'))
+					m = re.search(r'end_id:int\s*{\s*(?P<val>[0-9]+)\s*}', line)
+					if m is not None:
+						end_id = int(m.group('val'))
+						if end_id < start_id:
+							print 'Warning: strange message ID range (%d-%d) in %s' % (
+								start_id, end_id, os.path.join(d, f))
+
+					m = re.search(r'^(?P<val>.*)//', line)
+					if m is not None:
+						m = re.search(re_msgid_bundle, m.group('val'))
+					else:
+						m = re.search(re_msgid_bundle, line)
+					if m is not None:
+						val = int(m.group('val'))
+						if val < start_id or val > end_id:
+							print 'Message ID %s out of range (%d-%d) at %s:%d' % (
+								m.group('id'), start_id, end_id, os.path.join(d, f), linenum)
+						else:
+							msg_list[m.group('id')] = m.group('msg')
+					linenum += 1
+	if len(msg_list) > 0:
+		msg_ids[os.path.basename(d)] = msg_list
+
+# Find unused and nonexistent message IDs
+for module in msg_ids:
+    for id in msg_ids[module]:
+        print "#define LTFS%s %s" % (id, msg_ids[module][id])

--- a/messages/tape_generic_file/root.txt
+++ b/messages/tape_generic_file/root.txt
@@ -145,8 +145,7 @@ root:table {
 		30196D:string { "Backend %s: %llu." }
 		30197D:string { "Backend %s: (%llu, %llu)." }
 		30198D:string { "Backend %s: (%llu, %llu) FM = %llu." }
-		30199I:string { "FILE backend options:\n"
-						"    -o devname=<dev>          LTFS emulation directory (default=%s)\n"
+		30199I:string { "FILE backend options:\n    -o devname=<dev>          LTFS emulation directory (default=%s)\n"
 						"    -o emulate_delays         Emulate delays on seeks\n"
 						"    -o file_readonly          Emulate operation in read-only mode\n"
 						"    -o file_p0_warning=<num>  Set early warning position partition 0\n"

--- a/messages/tape_generic_itdtimg/root.txt
+++ b/messages/tape_generic_itdtimg/root.txt
@@ -42,10 +42,10 @@ root:table {
 		end_id:int { 31199 }
 
 		31000I:string { "Opening a device through generic itdtimage driver (%s)." }
-		31001E:string { "Failed to open %s: %s (%d)." }
-		31002E:string { "Failed to seek to %lld (%s, %d)." }
+		31001E:string { "Failed to open %s: %s (%llu)." }
+		31002E:string { "Failed to seek to %lld (%s, %lld)." }
 		31003I:string { "Closing device through generic itdtimage driver (%s)." }
-		31004D:string { "Backend read: %u bytes (from position=(%u, %llu), FMs %llu)." }
+		31004D:string { "Backend read: %llu bytes (from position=(%u, %llu), FMs %llu)." }
 		31005E:string { "Cannot read: unit not ready." }
 		31006E:string { "Cannot rewind: unit not ready." }
 		31007E:string { "Cannot locate: unit not ready." }

--- a/messages/tape_linux_lin_tape/root.txt
+++ b/messages/tape_linux_lin_tape/root.txt
@@ -137,8 +137,7 @@ root:table {
 		30596D:string { "Backend %s: %zu %s." }
 		30597D:string { "Backend %s: (%llu, %llu) %s." }
 		30598D:string { "Backend %s: (%llu, %llu) FM = %llu %s." }
-		30599I:string { "IBMTAPE backend options:\n"
-						"    -o devname=<dev>           tape device (default=%s)\n"
+		30599I:string { "IBMTAPE backend options:\n    -o devname=<dev>           tape device (default=%s)\n"
 						"    -o autodump                enable autodump (default)\n"
 						"    -o noautodump              disable autodump\n"
 						"    -o scsi_lbprotect=<on|off> enable drive logical block protection (default=off)\n." }

--- a/messages/tape_linux_sg_ibmtape/root.txt
+++ b/messages/tape_linux_sg_ibmtape/root.txt
@@ -116,8 +116,7 @@ root:table {
 		30396D:string { "Backend %s: %llu %s." }
 		30397D:string { "Backend %s: (%llu, %llu) %s." }
 		30398D:string { "Backend %s: (%llu, %llu) FM = %llu %s." }
-		30399I:string { "sg tape backend for IBM tape options:\n"
-						"    -o devname=<dev>           tape device (default=%s)\n"
+		30399I:string { "sg tape backend for IBM tape options:\n    -o devname=<dev>           tape device (default=%s)\n"
 						"    -o autodump                enable autodump (default)\n"
 						"    -o noautodump              disable autodump\n"
 						"    -o scsi_lbprotect=<on|off> enable drive logical block protection (default=off)\n." }

--- a/src/iosched/cache_manager.c
+++ b/src/iosched/cache_manager.c
@@ -93,12 +93,12 @@ struct cache_object *_cache_manager_create_object(struct cache_pool *pool)
 	int ret;
 	struct cache_object *object = calloc(1, sizeof(struct cache_object));
 	if (! object) {
-		ltfsmsg(LTFS_ERR, "10001E", "cache manager: object");
+		ltfsmsg(LTFS_ERR, 10001E, "cache manager: object");
 		return NULL;
 	}
 	object->data = calloc(1, pool->object_size + LTFS_CRC_SIZE); /* Allocate extra 4-bytes for SCSI logical block protection */
 	if (! object->data) {
-		ltfsmsg(LTFS_ERR, "10001E", "cache manager: object data");
+		ltfsmsg(LTFS_ERR, 10001E, "cache manager: object data");
 		free(object);
 		return NULL;
 	}
@@ -106,7 +106,7 @@ struct cache_object *_cache_manager_create_object(struct cache_pool *pool)
 	object->refcount = 1;
 	ret = ltfs_mutex_init(&object->lock);
 	if (ret) {
-		ltfsmsg(LTFS_ERR, "10002E", ret);
+		ltfsmsg(LTFS_ERR, 10002E, ret);
 		free(object->data);
 		free(object);
 		return NULL;
@@ -129,7 +129,7 @@ void *cache_manager_init(size_t object_size, size_t initial_capacity, size_t max
 
 	pool = (struct cache_pool *) calloc(1, sizeof (struct cache_pool));
 	if (! pool) {
-		ltfsmsg(LTFS_ERR, "10001E", "cache manager: pool");
+		ltfsmsg(LTFS_ERR, 10001E, "cache manager: pool");
 		return NULL;
 	}
 	pool->object_size = object_size;
@@ -141,7 +141,7 @@ void *cache_manager_init(size_t object_size, size_t initial_capacity, size_t max
 	for (i=0; i<initial_capacity; ++i) {
 		struct cache_object *object = _cache_manager_create_object(pool);
 		if (! object) {
-			ltfsmsg(LTFS_ERR, "11114E");
+			ltfsmsg(LTFS_ERR, 11114E);
 			cache_manager_destroy(pool);
 			return NULL;
 		}
@@ -159,7 +159,7 @@ void cache_manager_destroy(void *cache)
 	struct cache_object *object, *aux;
 	struct cache_pool *pool = (struct cache_pool *) cache;
 	if (! pool) {
-		ltfsmsg(LTFS_WARN, "10006W", "pool", __FUNCTION__);
+		ltfsmsg(LTFS_WARN, 10006W, "pool", __FUNCTION__);
 		return;
 	}
 
@@ -233,7 +233,7 @@ void *cache_manager_allocate_object(void *cache)
 		struct cache_object *object = _cache_manager_create_object(pool);
 		if (! object) {
 			/* Luckily we might have increased the size of the cache by a few entries.. */
-			ltfsmsg(LTFS_WARN, "11115W");
+			ltfsmsg(LTFS_WARN, 11115W);
 			break;
 		}
 		last_object = object;
@@ -242,7 +242,7 @@ void *cache_manager_allocate_object(void *cache)
 
 	if (! last_object) {
 		/* If we couldn't grow the cache any further return failure */
-		ltfsmsg(LTFS_ERR, "11116E");
+		ltfsmsg(LTFS_ERR, 11116E);
 		return NULL;
 	}
 
@@ -278,7 +278,7 @@ void cache_manager_free_object(void *cache_object, size_t count)
 	struct cache_pool *pool;
 	struct cache_object *object = (struct cache_object *) cache_object;
 	if (! object) {
-		ltfsmsg(LTFS_WARN, "10006W", "object", __FUNCTION__);
+		ltfsmsg(LTFS_WARN, 10006W, "object", __FUNCTION__);
 		return;
 	}
 

--- a/src/iosched/fcfs.c
+++ b/src/iosched/fcfs.c
@@ -70,17 +70,17 @@ void *fcfs_init(struct ltfs_volume *vol)
 	int ret;
 	struct fcfs_data *priv = calloc(1, sizeof(struct fcfs_data));
 	if (! priv) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return NULL;
 	}
 	ret = ltfs_mutex_init(&priv->sched_lock);
 	if (ret) {
-		ltfsmsg(LTFS_ERR, "10002E", ret);
+		ltfsmsg(LTFS_ERR, 10002E, ret);
 		free(priv);
 		return NULL;
 	}
 	priv->vol = vol;
-	ltfsmsg(LTFS_INFO, "13019I");
+	ltfsmsg(LTFS_INFO, 13019I);
 	return priv;
 }
 
@@ -96,7 +96,7 @@ int fcfs_destroy(void *iosched_handle)
 
 	ltfs_mutex_destroy(&priv->sched_lock);
 	free(priv);
-	ltfsmsg(LTFS_INFO, "13020I");
+	ltfsmsg(LTFS_INFO, 13020I);
 	return 0;
 }
 

--- a/src/iosched/unified.c
+++ b/src/iosched/unified.c
@@ -273,7 +273,7 @@ void *unified_init(struct ltfs_volume *vol)
 
 	priv = (struct unified_data *) calloc(1, sizeof(struct unified_data));
 	if (! priv) {
-		ltfsmsg(LTFS_ERR, "10001E", "unified_init: scheduler private data");
+		ltfsmsg(LTFS_ERR, 10001E, "unified_init: scheduler private data");
 		return NULL;
 	}
 
@@ -283,7 +283,7 @@ void *unified_init(struct ltfs_volume *vol)
 	priv->pool = cache_manager_init(cache_size, pool_size, max_pool_size);
 	if (! priv->pool) {
 		/* Cannot initialize scheduler: failed to initialize cache manager */
-		ltfsmsg(LTFS_ERR, "13005E");
+		ltfsmsg(LTFS_ERR, 13005E);
 		free(priv);
 		return NULL;
 	}
@@ -293,7 +293,7 @@ void *unified_init(struct ltfs_volume *vol)
 	ret = ltfs_thread_mutex_init(&priv->cache_lock);
 	if (ret) {
 		/* Cannot initialize scheduler: failed to initialize mutex %s (%d) */
-		ltfsmsg(LTFS_ERR, "13006E", "cache_lock", ret);
+		ltfsmsg(LTFS_ERR, 13006E, "cache_lock", ret);
 		cache_manager_destroy(priv->pool);
 		free(priv);
 		return NULL;
@@ -301,7 +301,7 @@ void *unified_init(struct ltfs_volume *vol)
 	ret = ltfs_thread_cond_init(&priv->cache_cond);
 	if (ret) {
 		/* Cannot initialize scheduler: failed to initialize condition variable %s (%d) */
-		ltfsmsg(LTFS_ERR, "13007E", "cache_cond", ret);
+		ltfsmsg(LTFS_ERR, 13007E, "cache_cond", ret);
 		ltfs_thread_mutex_destroy(&priv->cache_lock);
 		cache_manager_destroy(priv->pool);
 		free(priv);
@@ -310,7 +310,7 @@ void *unified_init(struct ltfs_volume *vol)
 	ret = ltfs_thread_mutex_init(&priv->queue_lock);
 	if (ret) {
 		/* Cannot initialize scheduler: failed to initialize mutex %s (%d) */
-		ltfsmsg(LTFS_ERR, "13006E", "queue_lock", ret);
+		ltfsmsg(LTFS_ERR, 13006E, "queue_lock", ret);
 		ltfs_thread_cond_destroy(&priv->cache_cond);
 		ltfs_thread_mutex_destroy(&priv->cache_lock);
 		cache_manager_destroy(priv->pool);
@@ -320,7 +320,7 @@ void *unified_init(struct ltfs_volume *vol)
 	ret = ltfs_thread_cond_init(&priv->queue_cond);
 	if (ret) {
 		/* Cannot initialize scheduler: failed to initialize condition variable %s (%d) */
-		ltfsmsg(LTFS_ERR, "13007E", "queue_cond", ret);
+		ltfsmsg(LTFS_ERR, 13007E, "queue_cond", ret);
 		ltfs_thread_mutex_destroy(&priv->queue_lock);
 		ltfs_thread_cond_destroy(&priv->cache_cond);
 		ltfs_thread_mutex_destroy(&priv->cache_lock);
@@ -331,7 +331,7 @@ void *unified_init(struct ltfs_volume *vol)
 
 	ret = init_mrsw(&priv->lock);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "13006E", "lock", ret);
+		ltfsmsg(LTFS_ERR, 13006E, "lock", ret);
 		ltfs_thread_cond_destroy(&priv->queue_cond);
 		ltfs_thread_mutex_destroy(&priv->queue_lock);
 		ltfs_thread_cond_destroy(&priv->cache_cond);
@@ -352,7 +352,7 @@ void *unified_init(struct ltfs_volume *vol)
 	ret = ltfs_thread_create(&priv->writer_thread, _unified_writer_thread, priv);
 	if (ret) {
 		/* Cannot initialize scheduler: failed to create thread */
-		ltfsmsg(LTFS_ERR, "13008E", "queue_cond", ret);
+		ltfsmsg(LTFS_ERR, 13008E, "queue_cond", ret);
 		ltfs_thread_cond_destroy(&priv->queue_cond);
 		ltfs_thread_mutex_destroy(&priv->queue_lock);
 		ltfs_thread_cond_destroy(&priv->cache_cond);
@@ -364,7 +364,7 @@ void *unified_init(struct ltfs_volume *vol)
 	}
 
 	/* Unified I/O scheduler initialized */
-	ltfsmsg(LTFS_DEBUG, "13015D");
+	ltfsmsg(LTFS_DEBUG, 13015D);
 	return priv;
 }
 
@@ -412,7 +412,7 @@ int unified_destroy(void *iosched_handle)
 	free(priv);
 
 	/* Unified I/O scheduler deinitialized */
-	ltfsmsg(LTFS_DEBUG, "13016D");
+	ltfsmsg(LTFS_DEBUG, 13016D);
 	return 0;
 }
 
@@ -543,7 +543,7 @@ ssize_t unified_read(struct dentry *d, char *buf, size_t size, off_t offset, voi
 			/* Queue up a tape read */
 			rreq = malloc(sizeof(struct read_request));
 			if (! rreq) {
-				ltfsmsg(LTFS_ERR, "10001E", "unified_read: read request");
+				ltfsmsg(LTFS_ERR, 10001E, "unified_read: read request");
 				ltfs_mutex_unlock(&d->iosched_lock);
 				ret = -LTFS_NO_MEMORY;
 				goto out;
@@ -697,7 +697,7 @@ write_start:
 	ret = _unified_get_dentry_priv(d, &dpr, priv);
 	if (ret < 0) {
 		/* Cannot write: failed to allocate scheduler private data (%d) */
-		ltfsmsg(LTFS_ERR, "13010E", ret);
+		ltfsmsg(LTFS_ERR, 13010E, (int)ret);
 		goto out;
 	}
 
@@ -1147,7 +1147,7 @@ ltfs_thread_return _unified_writer_thread(void *iosched_handle)
 void _unified_process_queue(enum request_state queue, struct unified_data *priv)
 {
 	if (! priv) {
-		ltfsmsg(LTFS_ERR, "10005E", "priv", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10005E, "priv", __FUNCTION__);
 		return;
 	}
 
@@ -1179,7 +1179,7 @@ void _unified_process_index_queue(struct unified_data *priv)
 				char *cache_obj = cache_manager_get_object_data(req->write_cache);
 				struct extent_info *extent = calloc(1, sizeof(struct extent_info));
 				if (! extent) {
-					ltfsmsg(LTFS_ERR, "10001E", "_unified_process_index_queue: extent");
+					ltfsmsg(LTFS_ERR, 10001E, "_unified_process_index_queue: extent");
 					_unified_handle_write_error(-ENOMEM, req, dentry_priv, priv);
 					break;
 				}
@@ -1188,7 +1188,7 @@ void _unified_process_index_queue(struct unified_data *priv)
 					&extent->start.block, priv->vol);
 				if (ret < 0) {
 					/* Index partition writer: failed to write data to the tape (%d) */
-					ltfsmsg(LTFS_WARN, "13013W", ret);
+					ltfsmsg(LTFS_WARN, 13013W, (int)ret);
 					if (IS_MEDIUM_ERROR(-ret)) {
 						ret = tape_set_cart_volume_lock_status(priv->vol, VOLUME_WRITE_PERM_IP);
 					}
@@ -1250,7 +1250,7 @@ void _unified_process_data_queue(enum request_state queue, struct unified_data *
 		if (! dentry) {
 			/* Invalid backpointer to the dentry in the dentry_priv structure */
 			/* Note: this can only happen if there is a bug elsewhere. */
-			ltfsmsg(LTFS_ERR, "13011E");
+			ltfsmsg(LTFS_ERR, 13011E);
 			continue;
 		}
 
@@ -1282,7 +1282,7 @@ void _unified_process_data_queue(enum request_state queue, struct unified_data *
 						partition_id, false, priv->vol);
 					if (ret < 0) {
 						/* Data partition writer: failed to write data to the tape (%d) */
-						ltfsmsg(LTFS_WARN, "13014W", ret);
+						ltfsmsg(LTFS_WARN, 13014W, (int)ret);
 						(void)_unified_write_index_after_perm(ret, priv);
 						_unified_handle_write_error(ret, req, dentry_priv, priv);
 						break;
@@ -1313,7 +1313,7 @@ void _unified_process_data_queue(enum request_state queue, struct unified_data *
 					partition_id, false, priv->vol);
 				if (ret < 0) {
 					/* Data partition writer: failed to write data to the tape (%d) */
-					ltfsmsg(LTFS_WARN, "13014W", ret);
+					ltfsmsg(LTFS_WARN, 13014W, (int)ret);
 					(void)_unified_write_index_after_perm(ret, priv);
 					break;
 				} else {
@@ -1373,7 +1373,7 @@ int _unified_get_dentry_priv(struct dentry *d, struct dentry_priv **dentry_priv,
 
 	dpr = calloc(1, sizeof(struct dentry_priv));
 	if (! dpr) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 
@@ -1385,14 +1385,14 @@ int _unified_get_dentry_priv(struct dentry *d, struct dentry_priv **dentry_priv,
 	ret = ltfs_mutex_init(&dpr->io_lock);
 	if (ret) {
 		/* Failed to initialize mutex in scheduler private data (%d) */
-		ltfsmsg(LTFS_ERR, "13009E", ret);
+		ltfsmsg(LTFS_ERR, 13009E, ret);
 		free(dpr);
 		return -LTFS_MUTEX_INIT;
 	}
 	ret = ltfs_mutex_init(&dpr->write_error_lock);
 	if (ret) {
 		/* Failed to initialize mutex in scheduler private data (%d) */
-		ltfsmsg(LTFS_ERR, "13009E", ret);
+		ltfsmsg(LTFS_ERR, 13009E, ret);
 		ltfs_mutex_destroy(&dpr->io_lock);
 		free(dpr);
 		return -LTFS_MUTEX_INIT;
@@ -1523,7 +1523,7 @@ void _unified_clear_alt_extentlist(bool save, struct dentry_priv *dpr, struct un
 				TAILQ_REMOVE(&dpr->alt_extentlist, ext, list);
 				ret = ltfs_fsraw_add_extent(dpr->dentry, ext, false, priv->vol);
 				if (ret < 0)
-					ltfsmsg(LTFS_WARN, "13021W", ret);
+					ltfsmsg(LTFS_WARN, 13021W, ret);
 				free(ext);
 			}
 		} else {
@@ -1641,7 +1641,7 @@ int _unified_update_queue_membership(bool add, bool all, enum request_state queu
 
 		default:
 			/* Invalid request_state received when updating the queue membership (%d) */
-			ltfsmsg(LTFS_ERR, "13012E", queue);
+			ltfsmsg(LTFS_ERR, 13012E, queue);
 			ret = -LTFS_BAD_ARG;
 	};
 	ltfs_thread_mutex_unlock(&priv->queue_lock);
@@ -1748,7 +1748,7 @@ ssize_t _unified_insert_new_request(const char *buf, off_t offset, size_t count,
 	if (! (*cache)) {
 		ret = _unified_cache_alloc(cache, d, priv);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "13017E", (int)ret);
+			ltfsmsg(LTFS_ERR, 13017E, (int)ret);
 			return ret;
 		}
 		if (ret == 1) {
@@ -1766,7 +1766,7 @@ ssize_t _unified_insert_new_request(const char *buf, off_t offset, size_t count,
 	/* Store new write request */
 	new_req = calloc(1, sizeof(struct write_request));
 	if (! new_req) {
-		ltfsmsg(LTFS_ERR, "13018E");
+		ltfsmsg(LTFS_ERR, 13018E);
 		_unified_cache_free(*cache, 0, priv);
 		ltfs_mutex_unlock(&d->iosched_lock);
 		releaseread_mrsw(&priv->lock);
@@ -1960,7 +1960,7 @@ int _unified_flush_unlocked(struct dentry *d, struct unified_data *priv)
 			req_cache = cache_manager_get_object_data(req->write_cache);
 			ret = ltfs_fsraw_write(d, req_cache, req->count, req->offset, dp_id, false, priv->vol);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "13019E", (int)ret);
+				ltfsmsg(LTFS_ERR, 13019E, (int)ret);
 				(void)_unified_write_index_after_perm(ret, priv);
 				_unified_handle_write_error(ret, req, dpr, priv);
 				break;
@@ -2000,7 +2000,7 @@ int _unified_flush_all(struct unified_data *priv)
 		TAILQ_FOREACH_SAFE(dpr, &priv->dp_queue, dp_queue, aux) {
 			ret = _unified_flush_unlocked(dpr->dentry, priv);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "13020E", dpr->dentry->platform_safe_name, ret);
+				ltfsmsg(LTFS_ERR, 13020E, dpr->dentry->platform_safe_name, ret);
 				releasewrite_mrsw(&priv->lock);
 				return ret;
 			}
@@ -2011,7 +2011,7 @@ int _unified_flush_all(struct unified_data *priv)
 		TAILQ_FOREACH_SAFE(dpr, &priv->working_set, working_set, aux) {
 			ret = _unified_flush_unlocked(dpr->dentry, priv);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "13020E", dpr->dentry->platform_safe_name, ret);
+				ltfsmsg(LTFS_ERR, 13020E, dpr->dentry->platform_safe_name, ret);
 				releasewrite_mrsw(&priv->lock);
 				return ret;
 			}
@@ -2074,7 +2074,7 @@ void _unified_free_dentry_priv(struct dentry *d, struct unified_data *priv)
 		return;
 
 	if (! TAILQ_EMPTY(&dpr->requests))
-		ltfsmsg(LTFS_WARN, "13022W");
+		ltfsmsg(LTFS_WARN, 13022W);
 
 	/* Wait for background thread to finish flushing requests */
 	ltfs_mutex_lock(&dpr->io_lock);
@@ -2257,33 +2257,33 @@ int _unified_write_index_after_perm(int write_ret, struct unified_data *priv)
 		return ret;
 	}
 
-	ltfsmsg(LTFS_INFO, "13024I", write_ret);
+	ltfsmsg(LTFS_INFO, 13024I, write_ret);
 
 	blocksize = ltfs_get_blocksize(priv->vol);
 	ret = tape_get_physical_block_position(priv->vol->device, &err_pos);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "13026E", "get error pos", ret);
+		ltfsmsg(LTFS_ERR, 13026E, "get error pos", ret);
 		return ret;
 	}
 
-	ltfsmsg(LTFS_INFO, "13025I", err_pos.block, blocksize);
+	ltfsmsg(LTFS_INFO, 13025I, (int)err_pos.block, (int)blocksize);
 
 	ret = ltfs_fsraw_cleanup_extent(priv->vol->index->root, err_pos, blocksize, priv->vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "13026E", "extent cleanup", ret);
+		ltfsmsg(LTFS_ERR, 13026E, "extent cleanup", ret);
 		return ret;
 	}
 
 	ret = ltfs_write_index(ltfs_ip_id(priv->vol), SYNC_WRITE_PERM, priv->vol) ;
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "13026E", "append index", ret);
+		ltfsmsg(LTFS_ERR, 13026E, "append index", ret);
 		ret = tape_set_cart_volume_lock_status(priv->vol, VOLUME_WRITE_PERM_BOTH);
 		return ret;
 	}
 
 	ret = tape_set_cart_volume_lock_status(priv->vol, VOLUME_WRITE_PERM_DP);
 	if (ret < 0)
-		ltfsmsg(LTFS_ERR, "13026E", "update MAM", ret);
+		ltfsmsg(LTFS_ERR, 13026E, "update MAM", ret);
 
 	return ret;
 }
@@ -2313,7 +2313,7 @@ int unified_set_profiler(char *work_dir, bool enable, void *iosched_handle)
 		rc = asprintf(&path, "%s/%s%s%s", work_dir, IOSCHED_PROFILER_BASE,
 					  priv->vol->label->vol_uuid, PROFILER_EXTENSION);
 		if (rc < 0) {
-			ltfsmsg(LTFS_ERR, "10001E", __FILE__);
+			ltfsmsg(LTFS_ERR, 10001E, __FILE__);
 			return -LTFS_NO_MEMORY;
 		}
 

--- a/src/kmi/Makefile.am
+++ b/src/kmi/Makefile.am
@@ -42,7 +42,7 @@ libkmi_simple_la_SOURCES = simple.c key_format_ltfs.c
 libkmi_simple_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@
 libkmi_simple_la_DEPENDENCIES = ../../messages/kmi_simple_dat.o
 libkmi_simple_la_LIBADD = ../../messages/kmi_simple_dat.o
-libkmi_simple_la_CPPFLAGS = @AM_CPPFLAGS@ -I ..
+libkmi_simple_la_CPPFLAGS = @AM_CPPFLAGS@ -I .. -DKMI_SIMPLE
 
 libkmi_flatfile_la_SOURCES = flatfile.c key_format_ltfs.c
 libkmi_flatfile_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@

--- a/src/kmi/flatfile.c
+++ b/src/kmi/flatfile.c
@@ -92,14 +92,14 @@ static int convert_option(const unsigned char * const path, unsigned char **dk_l
 	int dk_list_offset = 0;
 	*dk_list = calloc(dk_list_length, sizeof(unsigned char));
 	if (! *dk_list) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 
 	FILE *fp = fopen((const char *) path, "r");
 	if (! fp) {
 		ret = -errno;
-		ltfsmsg(LTFS_ERR, "15513E", path, ret);
+		ltfsmsg(LTFS_ERR, 15553E, path, ret);
 		return ret;
 	}
 
@@ -118,7 +118,7 @@ static int convert_option(const unsigned char * const path, unsigned char **dk_l
 
 			void *new_dk_list = realloc(*dk_list, dk_list_length);
 			if (! new_dk_list) {
-				ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+				ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 				fclose(fp);
 				return -LTFS_NO_MEMORY;
 			}
@@ -139,7 +139,7 @@ static int convert_option(const unsigned char * const path, unsigned char **dk_l
 			continue;
 		} else {
 			ret = -1;
-			ltfsmsg(LTFS_ERR, "15514E");
+			ltfsmsg(LTFS_ERR, 15554E);
 			break;
 		}
 	}
@@ -158,7 +158,13 @@ static int convert_option(const unsigned char * const path, unsigned char **dk_l
  */
 void *flatfile_init(struct ltfs_volume *vol)
 {
-	return key_format_ltfs_init(vol, "15510D");
+	void* km;
+
+	km = key_format_ltfs_init(vol);
+	if (km)
+		ltfsmsg(LTFS_DEBUG, 15550D);
+
+	return km;
 }
 
 /**
@@ -168,7 +174,12 @@ void *flatfile_init(struct ltfs_volume *vol)
  */
 int flatfile_destroy(void * const kmi_handle)
 {
-	return key_format_ltfs_destroy(kmi_handle, "15511D");
+	int ret;
+
+	ret = key_format_ltfs_destroy(kmi_handle);
+	ltfsmsg(LTFS_DEBUG, 15551D);
+
+	return ret;
 }
 
 /**
@@ -185,7 +196,7 @@ int flatfile_get_key(unsigned char **keyalias, unsigned char **key, void * const
 	if (priv.dk_list && dk_list == NULL) {
 		int ret = convert_option(priv.dk_list, &dk_list);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "15512E");
+			ltfsmsg(LTFS_ERR, 15552E);
 			if (dk_list) {
 				memset(dk_list, 0, strlen((char *) dk_list));
 				free(dk_list);
@@ -212,7 +223,7 @@ int flatfile_get_key(unsigned char **keyalias, unsigned char **key, void * const
  */
 int flatfile_help_message(void)
 {
-	ltfsresult("15608I");
+	ltfsresult(15568I);
 
 	return 0;
 }
@@ -244,7 +255,7 @@ int flatfile_parse_opts(void *opt_args)
 	/* fuse_opt_parse can handle a NULL device parameter just fine */
 	ret = fuse_opt_parse(args, &priv, kmi_flatfile_options, null_parser);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "15604E", ret);
+		ltfsmsg(LTFS_ERR, 15564E, ret);
 		return ret;
 	}
 

--- a/src/kmi/key_format_ltfs.c
+++ b/src/kmi/key_format_ltfs.c
@@ -85,13 +85,21 @@ static int is_key(const unsigned char * const key)
 
 	for (i = 0; i < (DK_LENGTH * 8 + 5) / 6; ++i) {
 		if (! isalnum(*(key + i)) && *(key + i) != '+' && *(key + i) != '/') {
-			ltfsmsg(LTFS_ERR, "15600E", __FUNCTION__, "DK");
+#ifdef KMI_SIMPLE
+			ltfsmsg(LTFS_ERR, 15502E, __FUNCTION__, "DK");
+#else
+			ltfsmsg(LTFS_ERR, 15562E, __FUNCTION__, "DK");
+#endif
 			return -LTFS_BAD_ARG;
 		}
 	}
 	for (; i % 4; ++i) { /* BEAM: loop doesn't iterate - Use loop for future enhancement */
 		if (*(key + i) != '=') {
-			ltfsmsg(LTFS_ERR, "15600E", __FUNCTION__, "DK padding");
+#ifdef KMI_SIMPLE
+			ltfsmsg(LTFS_ERR, 15502E, __FUNCTION__, "DK padding");
+#else
+			ltfsmsg(LTFS_ERR, 15562E, __FUNCTION__, "DK padding");
+#endif
 			return -LTFS_BAD_ARG;
 		}
 	}
@@ -110,13 +118,21 @@ static int is_keyalias(const unsigned char * const keyalias)
 
 	for (i = 0; i < DKI_ASCII_LENGTH; ++i) {
 		if (! isprint(*(keyalias + i))) {
-			ltfsmsg(LTFS_ERR, "15600E", __FUNCTION__, "DKi ascii");
+#ifdef KMI_SIMPLE
+			ltfsmsg(LTFS_ERR, 15502E, __FUNCTION__, "DKi ascii");
+#else
+			ltfsmsg(LTFS_ERR, 15562E, __FUNCTION__, "DKi ascii");
+#endif
 			return -LTFS_BAD_ARG;
 		}
 	}
 	for (; i < DKI_ASCII_LENGTH + (DKI_LENGTH - DKI_ASCII_LENGTH) * 2; ++i) {
 		if (! isxdigit(*(keyalias + i))) {
-			ltfsmsg(LTFS_ERR, "15600E", __FUNCTION__, "DKi binary");
+#ifdef KMI_SIMPLE
+			ltfsmsg(LTFS_ERR, 15502E, __FUNCTION__, "DKi binary");
+#else
+			ltfsmsg(LTFS_ERR, 15562E, __FUNCTION__, "DKi binary");
+#endif
 			return -LTFS_BAD_ARG;
 		}
 	}
@@ -146,18 +162,30 @@ static int get_num_of_keys(const unsigned char * const dk_list)
 
 			int ret = is_key(dk_list + i);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "15600E", __FUNCTION__, "kmi_dk_list");
+#ifdef KMI_SIMPLE
+				ltfsmsg(LTFS_ERR, 15502E, __FUNCTION__, "kmi_dk_list");
+#else
+				ltfsmsg(LTFS_ERR, 15562E, __FUNCTION__, "kmi_dk_list");
+#endif
 				return -LTFS_BAD_ARG;
 			}
 			i += key_length;
 			if (*(dk_list + i) != ':') {
-				ltfsmsg(LTFS_ERR, "15600E", __FUNCTION__, "Separator of DK and DKi is incorrect.");
+#ifdef KMI_SIMPLE
+				ltfsmsg(LTFS_ERR, 15502E, __FUNCTION__, "Separator of DK and DKi is incorrect.");
+#else
+				ltfsmsg(LTFS_ERR, 15562E, __FUNCTION__, "Separator of DK and DKi is incorrect.");
+#endif
 				return -LTFS_BAD_ARG;
 			}
 			i += SEPARATOR_LENGTH;
 			ret = is_keyalias(dk_list + i);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "15600E", __FUNCTION__, "kmi_dk_list"); /* is_keyalias is called for kmi_dk_list */
+#ifdef KMI_SIMPLE
+				ltfsmsg(LTFS_ERR, 15502E, __FUNCTION__, "kmi_dk_list");
+#else
+				ltfsmsg(LTFS_ERR, 15562E, __FUNCTION__, "kmi_dk_list");
+#endif
 				return -LTFS_BAD_ARG;
 			}
 			i += keyalias_length;
@@ -166,7 +194,11 @@ static int get_num_of_keys(const unsigned char * const dk_list)
 				 *(dk_list + i) == '/');
 
 		if (i != length) {
-			ltfsmsg(LTFS_ERR, "15600E", __FUNCTION__, "Invalid length of kmi_dk_list.");
+#ifdef KMI_SIMPLE
+				ltfsmsg(LTFS_ERR, 15502E, __FUNCTION__, "Invalid length of kmi_dk_list.");
+#else
+				ltfsmsg(LTFS_ERR, 15562E, __FUNCTION__, "Invalid length of kmi_dk_list.");
+#endif
 			return -LTFS_BAD_ARG;
 		}
 	}
@@ -212,7 +244,7 @@ static void convert_keyalias(const unsigned char * const ascii_and_hex, unsigned
  * @id message id for initializing key manager interface plug-in
  * @return a pointer to the private data on success or NULL on error.
  */
-void *key_format_ltfs_init(struct ltfs_volume *vol, const char *id)
+void *key_format_ltfs_init(struct ltfs_volume *vol)
 {
 	CHECK_ARG_NULL(vol, NULL);
 
@@ -222,25 +254,29 @@ void *key_format_ltfs_init(struct ltfs_volume *vol, const char *id)
 	 * and KFL_DESTROYED because the process keep running after a user eject a cartridge.
 	 */
 	if (state != KFL_UNINITIALIZED) {
-		ltfsmsg(LTFS_ERR, "15605E", state, KFL_UNINITIALIZED, __FUNCTION__);
+#ifdef KMI_SIMPLE
+		ltfsmsg(LTFS_ERR, 15505E, state, KFL_UNINITIALIZED, __FUNCTION__);
+#else
+		ltfsmsg(LTFS_ERR, 15565E, state, KFL_UNINITIALIZED, __FUNCTION__);
+#endif
 		return NULL;
 	}
 #endif
 
 	struct key_format_ltfs_data *priv = calloc(1, sizeof(struct key_format_ltfs_data));
 	if (! priv) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return NULL;
 	}
 	priv->vol = vol;
 	priv->data = calloc(1, sizeof(struct key_format_ltfs));
 	if (! priv->data) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return NULL;
 	}
 
 	state = KFL_INITIALIZED;
-	ltfsmsg(LTFS_DEBUG, id);
+
 	return priv;
 }
 
@@ -250,7 +286,7 @@ void *key_format_ltfs_init(struct ltfs_volume *vol, const char *id)
  * @id message id for destroying key manager interface plug-in
  * @return 0 on success or a negative value on error.
  */
-int key_format_ltfs_destroy(void * const kmi_handle, const char *id)
+int key_format_ltfs_destroy(void * const kmi_handle)
 {
 	struct key_format_ltfs_data *priv = (struct key_format_ltfs_data *) kmi_handle;
 	CHECK_ARG_NULL(kmi_handle, -LTFS_NULL_ARG);
@@ -258,7 +294,7 @@ int key_format_ltfs_destroy(void * const kmi_handle, const char *id)
 	free(priv->data);
 	free(priv);
 	state = KFL_DESTROYED;
-	ltfsmsg(LTFS_DEBUG, id);
+
 	return 0;
 }
 
@@ -277,7 +313,11 @@ static int set_dk_list(const unsigned char * const dk_list, void **data)
 	CHECK_ARG_NULL(*data, -LTFS_NULL_ARG);
 
 	if (state != KFL_INITIALIZED && state != KFL_CLEARED) {
-		ltfsmsg(LTFS_ERR, "15605E", state, KFL_INITIALIZED, __FUNCTION__);
+#ifdef KMI_SIMPLE
+		ltfsmsg(LTFS_ERR, 15505E, state, KFL_UNINITIALIZED, __FUNCTION__);
+#else
+		ltfsmsg(LTFS_ERR, 15565E, state, KFL_UNINITIALIZED, __FUNCTION__);
+#endif
 		return -LTFS_INVALID_SEQUENCE;
 	}
 
@@ -290,7 +330,7 @@ static int set_dk_list(const unsigned char * const dk_list, void **data)
 	if (num_of_keys) {
 		(*priv)->dk_list = calloc(num_of_keys, sizeof(struct key));
 		if (! (*priv)->dk_list) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 		(*priv)->num_of_keys = num_of_keys;
@@ -331,7 +371,7 @@ static int get_key(unsigned char **keyalias, unsigned char **key, void *data, un
 				return 0; /* This is not an error path but a normal pass. Make a non-encrypted cartridge. */
 			*keyalias = calloc(DKI_LENGTH, sizeof(char));
 			if (! *keyalias) {
-				ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+				ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 				return -LTFS_NO_MEMORY;
 			}
 			convert_keyalias(dki_for_format, *keyalias);
@@ -342,7 +382,7 @@ static int get_key(unsigned char **keyalias, unsigned char **key, void *data, un
 			if (! memcmp(*keyalias, (priv->dk_list + i)->dki, DKI_LENGTH)) {
 				*key = calloc(DK_LENGTH, sizeof(char));
 				if (! *key) {
-					ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+					ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 					return -LTFS_NO_MEMORY;
 				}
 				memcpy(*key, (priv->dk_list + i)->dk, DK_LENGTH);
@@ -350,7 +390,12 @@ static int get_key(unsigned char **keyalias, unsigned char **key, void *data, un
 			}
 		}
 		if (! *key) {
-			ltfsmsg(LTFS_ERR, "15603E");
+#ifdef KMI_SIMPLE
+			ltfsmsg(LTFS_ERR, 15503E);
+#else
+			ltfsmsg(LTFS_ERR, 15563E);
+#endif
+
 			return -LTFS_KEY_NOT_FOUND;
 		}
 	}
@@ -398,12 +443,20 @@ int key_format_ltfs_get_key(unsigned char **keyalias, unsigned char **key, void 
 	CHECK_ARG_NULL(kmi_handle, -LTFS_NULL_ARG);
 	int ret = set_dk_list(dk_list, &priv->data);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "15606E");
+#ifdef KMI_SIMPLE
+			ltfsmsg(LTFS_ERR, 15506E);
+#else
+			ltfsmsg(LTFS_ERR, 15566E);
+#endif
 		return ret;
 	}
 	ret = get_key(keyalias, key, priv->data, dki_for_format);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "15607E");
+#ifdef KMI_SIMPLE
+		ltfsmsg(LTFS_ERR, 15507E);
+#else
+		ltfsmsg(LTFS_ERR, 15567E);
+#endif
 		(void) clear(&priv->data);
 		return ret;
 	}

--- a/src/kmi/key_format_ltfs.h
+++ b/src/kmi/key_format_ltfs.h
@@ -65,8 +65,8 @@ struct key_format_ltfs {
 	struct key *dk_list;              /**< DK and DKi pairs' list */
 };
 
-void *key_format_ltfs_init(struct ltfs_volume *vol, const char *id);
-int key_format_ltfs_destroy(void * const kmi_handle, const char *id);
+void *key_format_ltfs_init(struct ltfs_volume *vol);
+int key_format_ltfs_destroy(void * const kmi_handle);
 int key_format_ltfs_get_key(unsigned char **keyalias, unsigned char **key, void * const kmi_handle,
 	unsigned char * const dk_list, unsigned char * const dki_for_format);
 

--- a/src/kmi/simple.c
+++ b/src/kmi/simple.c
@@ -84,7 +84,13 @@ static struct fuse_opt kmi_simple_options[] = {
  */
 void *simple_init(struct ltfs_volume *vol)
 {
-	return key_format_ltfs_init(vol, "15500D");
+	void* km;
+
+	km = key_format_ltfs_init(vol);
+	if (km)
+		ltfsmsg(LTFS_DEBUG, 15500D);
+
+	return km;
 }
 
 /**
@@ -94,7 +100,12 @@ void *simple_init(struct ltfs_volume *vol)
  */
 int simple_destroy(void * const kmi_handle)
 {
-	return key_format_ltfs_destroy(kmi_handle, "15501D");
+	int ret;
+
+	ret = key_format_ltfs_destroy(kmi_handle);
+	ltfsmsg(LTFS_DEBUG, 15501D);
+
+	return ret;
 }
 
 /**
@@ -114,7 +125,7 @@ int simple_get_key(unsigned char **keyalias, unsigned char **key, void * const k
  */
 int simple_help_message(void)
 {
-	ltfsresult("15608I");
+	ltfsresult(15508I);
 
 	return 0;
 }
@@ -152,18 +163,18 @@ int simple_parse_opts(void *opt_args)
 	/* fuse_opt_parse can handle a NULL device parameter just fine */
 	ret = fuse_opt_parse(args, &priv, kmi_simple_options, null_parser);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "15604E", ret);
+		ltfsmsg(LTFS_ERR, 15504E, ret);
 		return ret;
 	}
 
 	if (((priv.dk != NULL) ^ (priv.dki != NULL)) || (priv.dk_for_format != NULL && priv.dki_for_format == NULL)) {
-		ltfsmsg(LTFS_ERR, "15604E", 0);
+		ltfsmsg(LTFS_ERR, 15504E, 0);
 		return -1;
 	}
 
 	if (priv.dk != NULL && priv.dki != NULL && priv.dk_for_format != NULL && priv.dki_for_format != NULL) {
 		if ((strcmp((char *) priv.dk, (char *) priv.dk_for_format) == 0) ^ (strcmp((char *) priv.dki, (char *) priv.dki_for_format) == 0)) {
-			ltfsmsg(LTFS_ERR, "15604E", 1);
+			ltfsmsg(LTFS_ERR, 15504E, 1);
 			return -1;
 		}
 	}
@@ -186,7 +197,7 @@ int simple_parse_opts(void *opt_args)
 		else
 			priv.dk_list = calloc(dk_list_len, sizeof(unsigned char));
 		if (priv.dk_list == NULL) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 		*(priv.dk_list + original_dk_list_len) = '\0';

--- a/src/libltfs/arch/arch_info.c
+++ b/src/libltfs/arch/arch_info.c
@@ -69,7 +69,7 @@ void show_runtime_system_info(void)
 
 	fd = open("/proc/version", O_RDONLY);
 	if( fd == -1) {
-		ltfsmsg(LTFS_WARN, "17086W");
+		ltfsmsg(LTFS_WARN, 17086W);
 	} else {
 		memset(kernel_version, 0, sizeof(kernel_version));
 		read(fd, kernel_version, sizeof(kernel_version));
@@ -94,7 +94,7 @@ void show_runtime_system_info(void)
 			strcat(kernel_version, " unknown");
 #endif
 		}
-		ltfsmsg(LTFS_INFO, "17087I", kernel_version);
+		ltfsmsg(LTFS_INFO, 17087I, kernel_version);
 		close(fd);
 	}
 
@@ -106,7 +106,7 @@ void show_runtime_system_info(void)
 				path = calloc(1, strlen(dent->d_name) + strlen("/etc/") + 1);
 				if (!path) {
 					/* Memory allocation failed */
-					ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+					ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 					closedir(dir);
 					return;
 				}
@@ -115,13 +115,13 @@ void show_runtime_system_info(void)
 				if(stat(path, &stat_rel) != -1 && S_ISREG(stat_rel.st_mode)) {
 					fd = open(path, O_RDONLY);
 					if( fd == -1) {
-						ltfsmsg(LTFS_WARN, "17088W");
+						ltfsmsg(LTFS_WARN, 17088W);
 					} else {
 						memset(destribution, 0, sizeof(destribution));
 						read(fd, destribution, sizeof(destribution));
 						if((tmp = strchr(destribution, '\n')) != NULL)
 							*tmp = '\0';
-						ltfsmsg(LTFS_INFO, "17089I", destribution);
+						ltfsmsg(LTFS_INFO, 17089I, destribution);
 						close(fd);
 					}
 				}
@@ -143,21 +143,21 @@ void show_runtime_system_info(void)
 	mib[1] = KERN_VERSION;
 
 	if (sysctl(mib, 2, NULL, &len, NULL, 0) == -1) {
-		ltfsmsg(LTFS_WARN, "17090W", "Length check");
+		ltfsmsg(LTFS_WARN, 17090W, "Length check");
 		return;
 	}
 
 	kernel_version = malloc(len);
 	if (!kernel_version) {
 		/* Memory allocation failed */
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return;
 	}
 
 	if (sysctl(mib, 2, kernel_version, &len, NULL, 0) == -1)
-		ltfsmsg(LTFS_WARN, "17090W", "Getting kernel version");
+		ltfsmsg(LTFS_WARN, 17090W, "Getting kernel version");
 	else if (len > 0)
-		ltfsmsg(LTFS_INFO, "17087I", kernel_version);
+		ltfsmsg(LTFS_INFO, 17087I, kernel_version);
 
 	free(kernel_version);
 
@@ -166,12 +166,12 @@ void show_runtime_system_info(void)
 #elif defined(mingw_PLATFORM)
 {
 	/* Windows kernel detection is not supported yet*/
-	ltfsmsg(LTFS_INFO, "17087I", "Windows");
+	ltfsmsg(LTFS_INFO, 17087I, "Windows");
 	return;
 }
 #else
 {
-	ltfsmsg(LTFS_INFO, "17087I", "Unknown kernel");
+	ltfsmsg(LTFS_INFO, 17087I, "Unknown kernel");
 	return;
 }
 #endif

--- a/src/libltfs/arch/errormap.c
+++ b/src/libltfs/arch/errormap.c
@@ -401,7 +401,7 @@ int errormap_init()
 
 	HASH_ADD_INT(fuse_errormap, ltfs_error, fuse_error_list);
 	if (! fuse_errormap) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 	for (err=fuse_error_list+1; err->ltfs_error!=-1; ++err)

--- a/src/libltfs/arch/time_internal.c
+++ b/src/libltfs/arch/time_internal.c
@@ -86,10 +86,10 @@ ltfs_time_t ltfs_timegm(struct tm *t)
 
 	if (sizeof(time_t) == 4) {
 		if (rel > LONG_MAX)
-			ltfsmsg(LTFS_WARN, "17172W", t->tm_year + 1900, t->tm_mon + 1, t->tm_mday
+			ltfsmsg(LTFS_WARN, 17172W, t->tm_year + 1900, t->tm_mon + 1, t->tm_mday
 					, t->tm_hour, t->tm_min, t->tm_sec);
 		if (rel < LONG_MIN)
-			ltfsmsg(LTFS_WARN, "17173W", t->tm_year + 1900, t->tm_mon + 1, t->tm_mday
+			ltfsmsg(LTFS_WARN, 17173W, t->tm_year + 1900, t->tm_mon + 1, t->tm_mday
 					, t->tm_hour, t->tm_min, t->tm_sec);
 	}
 
@@ -142,7 +142,7 @@ int get_osx_current_timespec(struct ltfs_timespec* now) {
 		ret = -1;
 	}
 	if (ret < 0)
-		ltfsmsg(LTFS_ERR, "11110E", ret);
+		ltfsmsg(LTFS_ERR, 11110E, ret);
 	return ret;
 }
 #elif defined(mingw_PLATFORM)

--- a/src/libltfs/base64.c
+++ b/src/libltfs/base64.c
@@ -79,7 +79,7 @@ size_t base64_decode(const unsigned char *enc, size_t nbytes_in, unsigned char *
 
 	/* check for empty input */
 	if (nbytes_in == 0) {
-		ltfsmsg(LTFS_ERR, "11111E");
+		ltfsmsg(LTFS_ERR, 11111E);
 		return 0;
 	}
 
@@ -100,14 +100,14 @@ size_t base64_decode(const unsigned char *enc, size_t nbytes_in, unsigned char *
 		} else if (enc[i] == '\r' || enc[i] == '\n' || enc[i] == ' ' || enc[i] == '\t') {
 			--nbytes_real;
 		} else if (base64_dec[enc[i]] == UCHAR_MAX) {
-			ltfsmsg(LTFS_ERR, "11112E");
+			ltfsmsg(LTFS_ERR, 11112E);
 			return 0;
 		}
 	}
 
 	/* check for bad input length */
 	if (nbytes_real % 4) {
-		ltfsmsg(LTFS_ERR, "11113E");
+		ltfsmsg(LTFS_ERR, 11113E);
 		return 0;
 	}
 
@@ -115,7 +115,7 @@ size_t base64_decode(const unsigned char *enc, size_t nbytes_in, unsigned char *
 	nout = 3 * (nbytes_real / 4) - nequal;
 	*dec = (unsigned char *)malloc(nout);
 	if (!(*dec)) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return 0;
 	}
 

--- a/src/libltfs/config_file.c
+++ b/src/libltfs/config_file.c
@@ -112,7 +112,7 @@ int config_file_load(const char *path, struct config_file **config)
 
 	*config = calloc(1, sizeof(struct config_file));
 	if (! (*config)) {
-		ltfsmsg(LTFS_ERR, "10001E", "config_file_load: config structure");
+		ltfsmsg(LTFS_ERR, 10001E, "config_file_load: config structure");
 		return -LTFS_NO_MEMORY;
 	}
 	TAILQ_INIT(&(*config)->plugins);
@@ -188,7 +188,7 @@ const char *config_file_get_lib(const char *type, const char *name, struct confi
 			return entry->library;
 	}
 
-	ltfsmsg(LTFS_ERR, "11267E", type, name);
+	ltfsmsg(LTFS_ERR, 11267E, type, name);
 
 	return NULL;
 }
@@ -205,7 +205,7 @@ char **config_file_get_plugins(const char *type, struct config_file *config)
 
 	list = calloc(count + 1, sizeof(char *));
 	if (! list) {
-		ltfsmsg(LTFS_ERR, "10001E", "config_file_get_plugins: pointer list");
+		ltfsmsg(LTFS_ERR, 10001E, "config_file_get_plugins: pointer list");
 		return NULL;
 	}
 
@@ -213,7 +213,7 @@ char **config_file_get_plugins(const char *type, struct config_file *config)
 		if (! strcmp(entry->type, type)) {
 			list[pos] = strdup(entry->name);
 			if (! list[pos]) {
-				ltfsmsg(LTFS_ERR, "10001E", "config_file_get_plugins: list entry");
+				ltfsmsg(LTFS_ERR, 10001E, "config_file_get_plugins: list entry");
 				for (count=0; count<pos; ++count)
 					free(list[pos]);
 				free(list);
@@ -238,7 +238,7 @@ char **config_file_get_options(const char *type, struct config_file *config)
 
 	list = calloc(count + 1, sizeof(char *));
 	if (! list) {
-		ltfsmsg(LTFS_ERR, "10001E", "config_file_get_options: pointer list");
+		ltfsmsg(LTFS_ERR, 10001E, "config_file_get_options: pointer list");
 		return NULL;
 	}
 
@@ -246,7 +246,7 @@ char **config_file_get_options(const char *type, struct config_file *config)
 		if (! strcmp(entry->type, type)) {
 			list[pos] = strdup(entry->option);
 			if (! list[pos]) {
-				ltfsmsg(LTFS_ERR, "10001E", "config_file_get_options: list entry");
+				ltfsmsg(LTFS_ERR, 10001E, "config_file_get_options: list entry");
 				goto out_free;
 			}
 			++pos;
@@ -281,7 +281,7 @@ int _config_file_parse(const char *path, bool ignore_error, struct config_file *
 	if (! conf_file) {
 		if (!ignore_error) {
 			ret = -errno;
-			ltfsmsg(LTFS_ERR, "11268E", path, ret);
+			ltfsmsg(LTFS_ERR, 11268E, path, ret);
 			return ret;
 		} else
 			return 0;
@@ -290,7 +290,7 @@ int _config_file_parse(const char *path, bool ignore_error, struct config_file *
 	/* Parse the config file */
 	while (fgets(line, 65536, conf_file)) {
 		if (strlen(line) == 65535) {
-			ltfsmsg(LTFS_ERR, "11269E");
+			ltfsmsg(LTFS_ERR, 11269E);
 			ret = -LTFS_CONFIG_INVALID;
 			goto out;
 		}
@@ -307,7 +307,7 @@ int _config_file_parse(const char *path, bool ignore_error, struct config_file *
 
 		saveline = strdup(line);
 		if (! saveline) {
-			ltfsmsg(LTFS_ERR, "10001E", "_config_file_parse: saveline");
+			ltfsmsg(LTFS_ERR, 10001E, "_config_file_parse: saveline");
 			ret = -LTFS_NO_MEMORY;
 			goto out;
 		}
@@ -361,7 +361,7 @@ int _config_file_parse(const char *path, bool ignore_error, struct config_file *
 					goto out;
 
 			} else
-				ltfsmsg(LTFS_WARN, "11276W", tok);
+				ltfsmsg(LTFS_WARN, 11276W, tok);
 		}
 
 		free(saveline);
@@ -397,7 +397,7 @@ int _config_file_validate(struct config_file *config)
 				found = true;
 		}
 		if (! found && strcmp(de->name, "none")) {
-			ltfsmsg(LTFS_ERR, "11280E", de->type, de->name);
+			ltfsmsg(LTFS_ERR, 11280E, de->type, de->name);
 			return -LTFS_CONFIG_INVALID;
 		}
 	}
@@ -405,7 +405,7 @@ int _config_file_validate(struct config_file *config)
 	/* Emit a warning if plugin library does not exist. */
 	TAILQ_FOREACH(pe, &config->plugins, list) {
 		if (stat(pe->library, &st) < 0)
-			ltfsmsg(LTFS_WARN, "11277W", pe->type, pe->name, pe->library);
+			ltfsmsg(LTFS_WARN, 11277W, pe->type, pe->name, pe->library);
 	}
 
 	return 0;
@@ -436,18 +436,18 @@ int _config_file_parse_name(const char *directive, const char *name_desc, char *
 	tok = strtok_r(NULL, " \t\r\n", &saveptr);
 #endif
 	if (! tok) {
-		ltfsmsg(LTFS_ERR, "11273E", directive, name_desc);
+		ltfsmsg(LTFS_ERR, 11273E, directive, name_desc);
 		return -LTFS_CONFIG_INVALID;
 	}
 	*out = strdup(tok);
 	if (! (*out)) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 
 	tok = strtok_r(NULL, " \t\r\n", &saveptr);
 	if (tok) {
-		ltfsmsg(LTFS_ERR, "11273E", directive, name_desc);
+		ltfsmsg(LTFS_ERR, 11273E, directive, name_desc);
 		return -LTFS_CONFIG_INVALID;
 	}
 
@@ -472,27 +472,27 @@ int _config_file_parse_default(char *saveptr, struct config_file *config)
 	/* Read the plugin type */
 	tok = strtok_r(NULL, " \t\r\n", &saveptr);
 	if (! tok) {
-		ltfsmsg(LTFS_ERR, "11265E");
+		ltfsmsg(LTFS_ERR, 11265E);
 		return -LTFS_CONFIG_INVALID;
 	}
 
 	type = strdup(tok);
 	if (! type) {
-		ltfsmsg(LTFS_ERR, "10001E", "_config_file_parse_default: plugin type");
+		ltfsmsg(LTFS_ERR, 10001E, "_config_file_parse_default: plugin type");
 		return -LTFS_NO_MEMORY;
 	}
 
 	/* Read the plugin name */
 	tok = strtok_r(NULL, " \t\r\n", &saveptr);
 	if (! tok) {
-		ltfsmsg(LTFS_ERR, "11265E");
+		ltfsmsg(LTFS_ERR, 11265E);
 		free(type);
 		return -LTFS_CONFIG_INVALID;
 	}
 
 	name = strdup(tok);
 	if (! name) {
-		ltfsmsg(LTFS_ERR, "10001E", "_config_file_parse_default: plugin name");
+		ltfsmsg(LTFS_ERR, 10001E, "_config_file_parse_default: plugin name");
 		free(type);
 		return -LTFS_NO_MEMORY;
 	}
@@ -500,7 +500,7 @@ int _config_file_parse_default(char *saveptr, struct config_file *config)
 	/* Make sure there's no end of line garbage */
 	tok = strtok_r(NULL, " \t\r\n", &saveptr);
 	if (tok) {
-		ltfsmsg(LTFS_ERR, "11265E");
+		ltfsmsg(LTFS_ERR, 11265E);
 		free(name);
 		free(type);
 		return -LTFS_CONFIG_INVALID;
@@ -519,7 +519,7 @@ int _config_file_parse_default(char *saveptr, struct config_file *config)
 	if (!found) {
 		entry = calloc(1, sizeof(struct plugin_entry));
 		if (! entry) {
-			ltfsmsg(LTFS_ERR, "10001E", "_config_file_parse_default: plugin entry");
+			ltfsmsg(LTFS_ERR, 10001E, "_config_file_parse_default: plugin entry");
 			free(name);
 			free(type);
 			return -LTFS_NO_MEMORY;
@@ -548,20 +548,20 @@ int _config_file_remove_default(char *saveptr, struct config_file *config)
 	/* Read the plugin type */
 	tok = strtok_r(NULL, " \t\r\n", &saveptr);
 	if (! tok) {
-		ltfsmsg(LTFS_ERR, "11270E");
+		ltfsmsg(LTFS_ERR, 11270E);
 		return -LTFS_CONFIG_INVALID;
 	}
 
 	type = strdup(tok);
 	if (! type) {
-		ltfsmsg(LTFS_ERR, "10001E", "_config_file_remove_default: plugin type");
+		ltfsmsg(LTFS_ERR, 10001E, "_config_file_remove_default: plugin type");
 		return -LTFS_NO_MEMORY;
 	}
 
 	/* Make sure there's no end of line garbage */
 	tok = strtok_r(NULL, " \t\r\n", &saveptr);
 	if (tok) {
-		ltfsmsg(LTFS_ERR, "11270E");
+		ltfsmsg(LTFS_ERR, 11270E);
 		free(type);
 		return -LTFS_CONFIG_INVALID;
 	}
@@ -578,7 +578,7 @@ int _config_file_remove_default(char *saveptr, struct config_file *config)
 	}
 
 	if (!found) {
-		ltfsmsg(LTFS_ERR, "11271E", type);
+		ltfsmsg(LTFS_ERR, 11271E, type);
 		free(type);
 		return -LTFS_CONFIG_INVALID;
 	}
@@ -603,14 +603,14 @@ int _config_file_parse_plugin(char *saveptr, struct config_file *config)
 	/* Get the plugin type */
 	tok = strtok_r(NULL, " \t\r\n", &saveptr);
 	if (! tok) {
-		ltfsmsg(LTFS_ERR, "11275E");
+		ltfsmsg(LTFS_ERR, 11275E);
 		ret = -LTFS_CONFIG_INVALID;
 		goto out_free;
 	}
 
 	type = strdup(tok);
 	if (! type) {
-		ltfsmsg(LTFS_ERR, "10001E", "_config_file_parse_plugin: plugin type");
+		ltfsmsg(LTFS_ERR, 10001E, "_config_file_parse_plugin: plugin type");
 		ret = -LTFS_NO_MEMORY;
 		goto out_free;
 	}
@@ -618,14 +618,14 @@ int _config_file_parse_plugin(char *saveptr, struct config_file *config)
 	/* Get the driver name */
 	tok = strtok_r(NULL, " \t\r\n", &saveptr);
 	if (! tok) {
-		ltfsmsg(LTFS_ERR, "11275E");
+		ltfsmsg(LTFS_ERR, 11275E);
 		ret = -LTFS_CONFIG_INVALID;
 		goto out_free;
 	}
 
 	name = strdup(tok);
 	if (! name) {
-		ltfsmsg(LTFS_ERR, "10001E", "_config_file_parse_plugin: plugin name");
+		ltfsmsg(LTFS_ERR, 10001E, "_config_file_parse_plugin: plugin name");
 		ret = -LTFS_NO_MEMORY;
 		goto out_free;
 	}
@@ -633,14 +633,14 @@ int _config_file_parse_plugin(char *saveptr, struct config_file *config)
 	/* Get the driver path */
 	tok = strtok_r(NULL, "\r\n", &saveptr);
 	if (! tok) {
-		ltfsmsg(LTFS_ERR, "11275E");
+		ltfsmsg(LTFS_ERR, 11275E);
 		ret = -LTFS_CONFIG_INVALID;
 		goto out_free;
 	}
 
 	library = strdup(tok);
 	if (! library) {
-		ltfsmsg(LTFS_ERR, "10001E", "_config_file_parse_plugin: plugin path");
+		ltfsmsg(LTFS_ERR, 10001E, "_config_file_parse_plugin: plugin path");
 		ret = -LTFS_NO_MEMORY;
 		goto out_free;
 	}
@@ -657,7 +657,7 @@ int _config_file_parse_plugin(char *saveptr, struct config_file *config)
 	if (!found) {
 		entry = calloc(1, sizeof(struct plugin_entry));
 		if (! entry) {
-			ltfsmsg(LTFS_ERR, "10001E", "_config_file_parse_plugin: plugin entry");
+			ltfsmsg(LTFS_ERR, 10001E, "_config_file_parse_plugin: plugin entry");
 			ret = -LTFS_NO_MEMORY;
 			goto out_free;
 		}
@@ -695,27 +695,27 @@ int _config_file_remove_plugin(char *saveptr, struct config_file *config)
 	/* Read the plugin type */
 	tok = strtok_r(NULL, " \t\r\n", &saveptr);
 	if (! tok) {
-		ltfsmsg(LTFS_ERR, "11309E");
+		ltfsmsg(LTFS_ERR, 11309E);
 		return -LTFS_CONFIG_INVALID;
 	}
 
 	type = strdup(tok);
 	if (! type) {
-		ltfsmsg(LTFS_ERR, "10001E", "_config_file_remove_plugin: plugin type");
+		ltfsmsg(LTFS_ERR, 10001E, "_config_file_remove_plugin: plugin type");
 		return -LTFS_NO_MEMORY;
 	}
 
 	/* Read the plugin name */
 	tok = strtok_r(NULL, " \t\r\n", &saveptr);
 	if (! tok) {
-		ltfsmsg(LTFS_ERR, "11309E");
+		ltfsmsg(LTFS_ERR, 11309E);
 		free(type);
 		return -LTFS_CONFIG_INVALID;
 	}
 
 	name = strdup(tok);
 	if (! name) {
-		ltfsmsg(LTFS_ERR, "10001E", "_config_file_remove_plugin: plugin name");
+		ltfsmsg(LTFS_ERR, 10001E, "_config_file_remove_plugin: plugin name");
 		free(type);
 		return -LTFS_NO_MEMORY;
 	}
@@ -723,7 +723,7 @@ int _config_file_remove_plugin(char *saveptr, struct config_file *config)
 	/* Make sure there's no end of line garbage */
 	tok = strtok_r(NULL, " \t\r\n", &saveptr);
 	if (tok) {
-		ltfsmsg(LTFS_ERR, "11309E");
+		ltfsmsg(LTFS_ERR, 11309E);
 		free(type);
 		free(name);
 		return -LTFS_CONFIG_INVALID;
@@ -769,14 +769,14 @@ int _config_file_parse_option(const char *line, char *saveptr, struct option_ent
 	if (! tok) {
 		/* Cannot parse configuration file: \'option\' directive must be followed
 		 * by a option type and LTFS mount option */
-		ltfsmsg(LTFS_ERR, "11272E");
+		ltfsmsg(LTFS_ERR, 11272E);
 		return -LTFS_CONFIG_INVALID;
 	}
 	start = tok;
 
 	type = strdup(tok);
 	if (! type) {
-		ltfsmsg(LTFS_ERR, "10001E", "_config_file_parse_mount_option: option");
+		ltfsmsg(LTFS_ERR, 10001E, "_config_file_parse_mount_option: option");
 		return -LTFS_NO_MEMORY;
 	}
 
@@ -794,7 +794,7 @@ int _config_file_parse_option(const char *line, char *saveptr, struct option_ent
 	if (! tok) {
 		/* Cannot parse configuration file: \'option\' directive must be followed
 		 * by a LTFS mount option */
-		ltfsmsg(LTFS_ERR, "11272E");
+		ltfsmsg(LTFS_ERR, 11272E);
 		free(type);
 		return -LTFS_CONFIG_INVALID;
 	}
@@ -804,14 +804,14 @@ int _config_file_parse_option(const char *line, char *saveptr, struct option_ent
 	else
 		ret = asprintf(&option, "-o%s", &line[tok-start]);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10001E", "_config_file_parse_mount_option: option");
+		ltfsmsg(LTFS_ERR, 10001E, "_config_file_parse_mount_option: option");
 		free(type);
 		return -LTFS_NO_MEMORY;
 	}
 
 	*out = calloc(1, sizeof(struct option_entry));
 	if (! (*out)) {
-		ltfsmsg(LTFS_ERR, "10001E", "_config_file_parse_plugin: plugin structure");
+		ltfsmsg(LTFS_ERR, 10001E, "_config_file_parse_plugin: plugin structure");
 		free(type);
 		free(option);
 		return -LTFS_NO_MEMORY;

--- a/src/libltfs/dcache.c
+++ b/src/libltfs/dcache.c
@@ -76,7 +76,7 @@ int dcache_init(struct libltfs_plugin *plugin, const struct dcache_options *opti
 
 	priv = calloc(1, sizeof(struct dcache_priv));
 	if (! priv) {
-		ltfsmsg(LTFS_ERR, "10001E", "dcache_init: private data");
+		ltfsmsg(LTFS_ERR, 10001E, "dcache_init: private data");
 		return -LTFS_NO_MEMORY;
 	}
 
@@ -87,7 +87,7 @@ int dcache_init(struct libltfs_plugin *plugin, const struct dcache_options *opti
 	for (i=0; i<sizeof(struct dcache_ops)/sizeof(void *); ++i) {
 		if (((void **)(priv->ops))[i] == NULL) {
 			/* Dentry cache backend does not implement all required methods */
-			ltfsmsg(LTFS_ERR, "13004E");
+			ltfsmsg(LTFS_ERR, 13004E);
 			free(priv);
 			return -LTFS_PLUGIN_INCOMPLETE;
 		}
@@ -150,21 +150,21 @@ int dcache_parse_options(const char **options, struct dcache_options **out)
 
 	opt = calloc(1, sizeof(struct dcache_options));
 	if (! opt) {
-		ltfsmsg(LTFS_ERR, "10001E", "dcache_parse_options: opt");
+		ltfsmsg(LTFS_ERR, 10001E, "dcache_parse_options: opt");
 		return -ENOMEM;
 	}
 
 	for (i=0; options[i]; ++i) {
 		line = strdup(options[i]);
 		if (! line) {
-			ltfsmsg(LTFS_ERR, "10001E", "dcache_parse_options: line");
+			ltfsmsg(LTFS_ERR, 10001E, "dcache_parse_options: line");
 			ret = -ENOMEM;
 			goto out_free;
 		}
 		option = strtok(line, " \t");
 		if (! option) {
 			/* Failed to parse LTFS dcache configuration rules: invalid option '%s' */
-			ltfsmsg(LTFS_ERR, "17170E", options[i]);
+			ltfsmsg(LTFS_ERR, 17170E, options[i]);
 			ret = -EINVAL;
 			goto out_free;
 		}
@@ -184,7 +184,7 @@ int dcache_parse_options(const char **options, struct dcache_options **out)
 		value = strtok(NULL, " \t");
 		if (! value) {
 			/* Failed to parse LTFS dcache configuration rules: invalid option '%s' */
-			ltfsmsg(LTFS_ERR, "17170E", options[i]);
+			ltfsmsg(LTFS_ERR, 17170E, options[i]);
 			ret = -EINVAL;
 			goto out_free;
 		}
@@ -193,7 +193,7 @@ int dcache_parse_options(const char **options, struct dcache_options **out)
 			opt->minsize = atoi(value);
 			if (opt->minsize <= 0) {
 				/* Failed to parse LTFS dcache configuration rules: invalid value '%d' for option '%s' */
-				ltfsmsg(LTFS_ERR, "17171E", opt->minsize, option);
+				ltfsmsg(LTFS_ERR, 17171E, opt->minsize, option);
 				ret = -EINVAL;
 				goto out_free;
 			}
@@ -201,13 +201,13 @@ int dcache_parse_options(const char **options, struct dcache_options **out)
 			opt->maxsize = atoi(value);
 			if (opt->maxsize <= 0) {
 				/* Failed to parse LTFS dcache configuration rules: invalid value '%d' for option '%s' */
-				ltfsmsg(LTFS_ERR, "17171E", opt->maxsize, option);
+				ltfsmsg(LTFS_ERR, 17171E, opt->maxsize, option);
 				ret = -EINVAL;
 				goto out_free;
 			}
 		} else {
 			/* Failed to parse LTFS dcache configuration rules: invalid option '%s' */
-			ltfsmsg(LTFS_ERR, "17170E", options[i]);
+			ltfsmsg(LTFS_ERR, 17170E, options[i]);
 			ret = -EINVAL;
 			goto out_free;
 		}

--- a/src/libltfs/fs.c
+++ b/src/libltfs/fs.c
@@ -102,7 +102,7 @@ struct name_list* fs_add_key_to_hash_table(struct name_list *list, struct dentry
 
 	new_list = (struct name_list *) malloc(sizeof(struct name_list));
 	if (!new_list) {
-		ltfsmsg(LTFS_ERR, "10001E", "fs_add_key_to_hash_table: new list");
+		ltfsmsg(LTFS_ERR, 10001E, "fs_add_key_to_hash_table: new list");
 		*rc = -LTFS_NO_MEMORY;
 		return list;
 	}
@@ -115,7 +115,7 @@ struct name_list* fs_add_key_to_hash_table(struct name_list *list, struct dentry
 		new_list->uid = add_entry->uid;
 		HASH_ADD_KEYPTR(hh, list, new_list->name, strlen(new_list->name), new_list);
 		if (errno == ENOMEM) {
-			ltfsmsg(LTFS_ERR, "10001E", "fs_add_key_to_hash_table: add key");
+			ltfsmsg(LTFS_ERR, 10001E, "fs_add_key_to_hash_table: add key");
 			*rc = -LTFS_NO_MEMORY;
 		}
 	}
@@ -178,7 +178,7 @@ int fs_init_inode(void)
 
 	ret = ltfs_mutex_init(&inode_mutex);
 	if (ret)
-		ltfsmsg(LTFS_ERR, "10002E", ret);
+		ltfsmsg(LTFS_ERR, 10002E, ret);
 
 	return ret;
 }
@@ -252,7 +252,7 @@ struct dentry * fs_allocate_dentry(struct dentry *parent, const char *name, cons
 
 	d = (struct dentry *) malloc(sizeof(struct dentry));
 	if (! d) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return NULL;
 	}
 
@@ -265,7 +265,7 @@ struct dentry * fs_allocate_dentry(struct dentry *parent, const char *name, cons
 		d->name.name = strdup(name);
 		update_platform_safe_name(d, FALSE, idx);
 		if (! d->name.name || ! d->platform_safe_name) {
-			ltfsmsg(LTFS_ERR, "10001E", "fs_allocate_dentry: name");
+			ltfsmsg(LTFS_ERR, 10001E, "fs_allocate_dentry: name");
 			if (d->name.name)
 				free(d->name.name);
 			if (d->platform_safe_name)
@@ -277,7 +277,7 @@ struct dentry * fs_allocate_dentry(struct dentry *parent, const char *name, cons
 		d->name.name = strdup(platform_safe_name);
 		d->platform_safe_name = strdup(platform_safe_name);
 		if (! d->name.name || ! d->platform_safe_name) {
-			ltfsmsg(LTFS_ERR, "10001E", "fs_allocate_dentry: name");
+			ltfsmsg(LTFS_ERR, 10001E, "fs_allocate_dentry: name");
 			if (d->name.name)
 				free(d->name.name);
 			if (d->platform_safe_name)
@@ -291,7 +291,7 @@ struct dentry * fs_allocate_dentry(struct dentry *parent, const char *name, cons
 		d->name.name = strdup(name);
 		d->platform_safe_name = strdup(platform_safe_name);
 		if (! d->name.name || ! d->platform_safe_name) {
-			ltfsmsg(LTFS_ERR, "10001E", "fs_allocate_dentry: name");
+			ltfsmsg(LTFS_ERR, 10001E, "fs_allocate_dentry: name");
 			if (d->name.name)
 				free(d->name.name);
 			if (d->platform_safe_name)
@@ -326,7 +326,7 @@ struct dentry * fs_allocate_dentry(struct dentry *parent, const char *name, cons
 	}
 	ret = init_mrsw(&d->contents_lock);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10002E", ret);
+		ltfsmsg(LTFS_ERR, 10002E, ret);
 		if (d->name.name)
 			free(d->name.name);
 		if (d->platform_safe_name)
@@ -336,7 +336,7 @@ struct dentry * fs_allocate_dentry(struct dentry *parent, const char *name, cons
 	}
 	ret = init_mrsw(&d->meta_lock);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10002E", ret);
+		ltfsmsg(LTFS_ERR, 10002E, ret);
 		destroy_mrsw(&d->contents_lock);
 		if (d->name.name)
 			free(d->name.name);
@@ -351,7 +351,7 @@ struct dentry * fs_allocate_dentry(struct dentry *parent, const char *name, cons
 
 	ret = ltfs_mutex_init(&d->iosched_lock);
 	if (ret) {
-		ltfsmsg(LTFS_ERR, "10002E", ret);
+		ltfsmsg(LTFS_ERR, 10002E, ret);
 		destroy_mrsw(&d->contents_lock);
 		destroy_mrsw(&d->meta_lock);
 		if (d->name.name)
@@ -371,7 +371,7 @@ struct dentry * fs_allocate_dentry(struct dentry *parent, const char *name, cons
 		if (d->platform_safe_name != NULL) {
 			parent->child_list = fs_add_key_to_hash_table(parent->child_list, d, &ret);
 			if (ret != 0) {
-				ltfsmsg(LTFS_ERR, "11319E", "fs_allocate_dentry", ret);
+				ltfsmsg(LTFS_ERR, 11319E, "fs_allocate_dentry", ret);
 				releasewrite_mrsw(&parent->meta_lock);
 				releasewrite_mrsw(&parent->contents_lock);
 				if (d->name.name)
@@ -410,7 +410,7 @@ uint64_t fs_allocate_uid(struct ltfs_index *idx)
 	else {
 		uid = ++idx->uid_number;
 		if (uid == 0)
-			ltfsmsg(LTFS_WARN, "11307W", idx->vol_uuid);
+			ltfsmsg(LTFS_WARN, 11307W, idx->vol_uuid);
 	}
 	ltfs_mutex_unlock(&idx->dirty_lock);
 
@@ -435,7 +435,7 @@ int fs_dentry_lookup(struct dentry *dentry, char **name)
 
 	dentry_names = (char **) calloc(names+1, sizeof(char *));
 	if (! dentry_names)  {
-		ltfsmsg(LTFS_ERR, "10001E", "fs_dentry_lookup: dentry_names");
+		ltfsmsg(LTFS_ERR, 10001E, "fs_dentry_lookup: dentry_names");
 		return -LTFS_NO_MEMORY;
 	}
 
@@ -455,7 +455,7 @@ int fs_dentry_lookup(struct dentry *dentry, char **name)
 		}
 		dentry_names[i] = strdup(lookup_name);
 		if (! dentry_names[i]) {
-			ltfsmsg(LTFS_ERR, "10001E", "fs_dentry_lookup: dentry_names member");
+			ltfsmsg(LTFS_ERR, 10001E, "fs_dentry_lookup: dentry_names member");
 			goto out;
 		}
 		namelen += strlen(lookup_name);
@@ -471,7 +471,7 @@ int fs_dentry_lookup(struct dentry *dentry, char **name)
 
 	tmp_name = calloc(namelen + names, sizeof(char));
 	if (! tmp_name) {
-		ltfsmsg(LTFS_ERR, "10001E", "fs_dentry_lookup: tmp_name");
+		ltfsmsg(LTFS_ERR, 10001E, "fs_dentry_lookup: tmp_name");
 		ret = -LTFS_NO_MEMORY;
 		goto out;
 	}
@@ -517,7 +517,7 @@ int fs_directory_lookup(struct dentry *basedir, const char *name, struct dentry 
 	namelist = fs_find_key_from_hash_table(basedir->child_list, name, &rc);
 	if (rc != 0) {
 		/* Can only happen in a case-insensitive environment (Windows) */
-        ltfsmsg(LTFS_ERR, "11320E", "fs_directory_lookup", rc);
+        ltfsmsg(LTFS_ERR, 11320E, "fs_directory_lookup", rc);
 		return rc;
 	}
 
@@ -545,7 +545,7 @@ int fs_path_lookup(const char *path, int flags, struct dentry **dentry, struct l
 
 	tmp_path = strdup(path);
 	if (! tmp_path) {
-		ltfsmsg(LTFS_ERR, "10001E", "fs_path_lookup: tmp_path");
+		ltfsmsg(LTFS_ERR, 10001E, "fs_path_lookup: tmp_path");
 		return -LTFS_NO_MEMORY;
 	}
 
@@ -679,7 +679,7 @@ void _fs_dispose_dentry_contents(struct dentry *dentry, bool unlock, bool gc)
 				if (child->d->numhandles != 1) {
 					/* Unable to delete dentry '%s': it still has outstanding references */
 					name = child->d->platform_safe_name ? child->d->platform_safe_name : "(null)";
-					ltfsmsg(LTFS_WARN, "11998W", name);
+					ltfsmsg(LTFS_WARN, 11998W, name);
 				} else {
 					child->d->numhandles--;
 					_fs_dispose_dentry_contents(child->d, false, gc);
@@ -688,7 +688,7 @@ void _fs_dispose_dentry_contents(struct dentry *dentry, bool unlock, bool gc)
 				if (child->d->numhandles != 0) {
 					/* Unable to delete dentry '%s': it still has outstanding references */
 					name = child->d->platform_safe_name ? child->d->platform_safe_name : "(null)";
-					ltfsmsg(LTFS_WARN, "11998W", name);
+					ltfsmsg(LTFS_WARN, 11998W, name);
 				} else {
 					_fs_dispose_dentry_contents(child->d, false, gc);
 				}
@@ -726,7 +726,7 @@ void _fs_dispose_dentry_contents(struct dentry *dentry, bool unlock, bool gc)
 	if (dentry->parent) {
 		namelist = fs_find_key_from_hash_table(dentry->parent->child_list, dentry->platform_safe_name, &rc);
 		if (rc != 0) {
-            ltfsmsg(LTFS_ERR, "11320E", "_fs_dispose_dentry_contents", rc);
+            ltfsmsg(LTFS_ERR, 11320E, "_fs_dispose_dentry_contents", rc);
 		}
 		if (namelist) {
 			HASH_DEL(dentry->parent->child_list, namelist);
@@ -759,7 +759,7 @@ void _fs_dispose_dentry_contents(struct dentry *dentry, bool unlock, bool gc)
 void fs_release_dentry(struct dentry *d)
 {
 	if (! d) {
-		ltfsmsg(LTFS_WARN, "10006W", "dentry", __FUNCTION__);
+		ltfsmsg(LTFS_WARN, 10006W, "dentry", __FUNCTION__);
 		return;
 	}
 
@@ -812,7 +812,7 @@ static struct name_list* fs_update_platform_safe_names_and_hash_table(struct den
 		if (!handle_dup_name) {
 			same_name = fs_find_key_from_hash_table(basedir->child_list, list_ptr->name, &rc);
 			if (rc != 0) {
-				ltfsmsg(LTFS_ERR, "11320E", "fs_update_platform_safe_names_and_hash_table", rc);
+				ltfsmsg(LTFS_ERR, 11320E, "fs_update_platform_safe_names_and_hash_table", rc);
 			}
 			if (same_name) {
 				/* same name file exists. skip the operation. */
@@ -830,7 +830,7 @@ static struct name_list* fs_update_platform_safe_names_and_hash_table(struct den
 		/* Add hash table whose key is upper case of platform safe name */
 		basedir->child_list = fs_add_key_to_hash_table(basedir->child_list, list_ptr->d, &rc);
 		if (rc != 0) {
-			ltfsmsg(LTFS_ERR, "11319E", "fs_update_platform_safe_names_and_hash_table", rc);
+			ltfsmsg(LTFS_ERR, 11319E, "fs_update_platform_safe_names_and_hash_table", rc);
 		} else {
 			/* delete the entry from the temporary list */
 			idx->valid_blocks += list_ptr->d->used_blocks;

--- a/src/libltfs/index_criteria.c
+++ b/src/libltfs/index_criteria.c
@@ -99,7 +99,7 @@ bool index_criteria_contains_invalid_options(const char *str)
 	if (! str)
 		return !error;
 	else if (strlen(str) < 5) {
-		ltfsmsg(LTFS_ERR, "11146E", str);
+		ltfsmsg(LTFS_ERR, 11146E, str);
 		return error;
 	}
 
@@ -110,7 +110,7 @@ bool index_criteria_contains_invalid_options(const char *str)
 			break;
 		}
 	if (! valid_option) {
-		ltfsmsg(LTFS_ERR, "11146E", str);
+		ltfsmsg(LTFS_ERR, 11146E, str);
 		return error;
 	}
 
@@ -125,7 +125,7 @@ bool index_criteria_contains_invalid_options(const char *str)
 				break;
 			}
 		if (! valid_option) {
-			ltfsmsg(LTFS_ERR, "11146E", ptr+1);
+			ltfsmsg(LTFS_ERR, 11146E, ptr+1);
 			return error;
 		}
 	}
@@ -179,7 +179,7 @@ bool index_criteria_find_option(const char *str, const char *substr,
 	}
 
 	if (index_criteria_find_option(str_end, substr, &next_start, &next_end, &next_error) == true) {
-		ltfsmsg(LTFS_ERR, "11147E", substr);
+		ltfsmsg(LTFS_ERR, 11147E, substr);
 		*error = true;
 		return false;
 	}
@@ -206,7 +206,7 @@ int index_criteria_parse_size(const char *criteria, size_t len, struct index_cri
 
 	for (ptr=&rule[0]; *ptr; ptr++) {
 		if (isalpha(*ptr) && *(ptr+1) && isalpha(*(ptr+1))) {
-			ltfsmsg(LTFS_ERR, "11148E");
+			ltfsmsg(LTFS_ERR, 11148E);
 			return -LTFS_POLICY_INVALID;
 		}
 	}
@@ -220,17 +220,17 @@ int index_criteria_parse_size(const char *criteria, size_t len, struct index_cri
 		else if (last == 'g' || last == 'G')
 			multiplier = 1024 * 1024 * 1024;
 		else {
-			ltfsmsg(LTFS_ERR, "11149E", last);
+			ltfsmsg(LTFS_ERR, 11149E, last);
 			return -LTFS_POLICY_INVALID;
 		}
 		rule[strlen(rule)-1] = '\0';
 	}
 
 	if (strlen(rule) == 0) {
-		ltfsmsg(LTFS_ERR, "11150E");
+		ltfsmsg(LTFS_ERR, 11150E);
 		return -LTFS_POLICY_INVALID;
 	} else if (!isdigit(rule[0])) {
-		ltfsmsg(LTFS_ERR, "11151E");
+		ltfsmsg(LTFS_ERR, 11151E);
 		return -LTFS_POLICY_INVALID;
 	}
 	ic->max_filesize_criteria = strtoull(rule, NULL, 10) * multiplier;
@@ -257,13 +257,13 @@ int index_criteria_parse_name(const char *criteria, size_t len, struct index_cri
 
 	/* Count the rules and check for empty ones */
 	if (rule[5] == ':') {
-		ltfsmsg(LTFS_ERR, "11305E", rule);
+		ltfsmsg(LTFS_ERR, 11305E, rule);
 		return -LTFS_POLICY_EMPTY_RULE;
 	}
 	for (delim=rule+6; *delim; delim++) {
 		if (*delim == ':') {
 			if (*(delim-1) == ':' || *(delim+1) == '\0') {
-				ltfsmsg(LTFS_ERR, "11305E", rule);
+				ltfsmsg(LTFS_ERR, 11305E, rule);
 				return -LTFS_POLICY_EMPTY_RULE;
 			}
 			++num_names;
@@ -272,7 +272,7 @@ int index_criteria_parse_name(const char *criteria, size_t len, struct index_cri
 
 	ic->glob_patterns = calloc(num_names+1, sizeof(struct ltfs_name));
 	if (! ic->glob_patterns) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 	rule_ptr = ic->glob_patterns;
@@ -309,11 +309,11 @@ int index_criteria_parse_name(const char *criteria, size_t len, struct index_cri
 		while (rule_ptr && rule_ptr->name && ret == 0) {
 			ret = pathname_validate_file(rule_ptr->name);
 			if (ret == -LTFS_INVALID_PATH)
-				ltfsmsg(LTFS_ERR, "11302E", rule_ptr->name);
+				ltfsmsg(LTFS_ERR, 11302E, rule_ptr->name);
 			else if (ret == -LTFS_NAMETOOLONG)
-				ltfsmsg(LTFS_ERR, "11303E", rule_ptr->name);
+				ltfsmsg(LTFS_ERR, 11303E, rule_ptr->name);
 			else if (ret < 0)
-				ltfsmsg(LTFS_ERR, "11304E", ret);
+				ltfsmsg(LTFS_ERR, 11304E, ret);
 			++rule_ptr;
 		}
 	}
@@ -347,7 +347,7 @@ int index_criteria_parse(const char *filterrules, struct ltfs_volume *vol)
 
 	/* Sanity checks */
 	if (index_criteria_contains_invalid_options(filterrules)) {
-		ltfsmsg(LTFS_ERR, "11152E");
+		ltfsmsg(LTFS_ERR, 11152E);
 		return -LTFS_POLICY_INVALID;
 	}
 
@@ -355,12 +355,12 @@ int index_criteria_parse(const char *filterrules, struct ltfs_volume *vol)
 	if (index_criteria_find_option(filterrules, "name=", &start, &end, &error)) {
 		ret = index_criteria_parse_name(start, end-start+1, ic);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "11153E", ret);
+			ltfsmsg(LTFS_ERR, 11153E, ret);
 			return ret;
 		}
 		has_name = true;
 	} else if (error) {
-		ltfsmsg(LTFS_ERR, "11154E");
+		ltfsmsg(LTFS_ERR, 11154E);
 		return -LTFS_POLICY_INVALID;
 	}
 
@@ -369,14 +369,14 @@ int index_criteria_parse(const char *filterrules, struct ltfs_volume *vol)
 	if (index_criteria_find_option(filterrules, "size=", &start, &end, &error)) {
 		ret = index_criteria_parse_size(start, end-start+1, ic);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "11155E", ret);
+			ltfsmsg(LTFS_ERR, 11155E, ret);
 			return ret;
 		}
 	} else if (error) {
-		ltfsmsg(LTFS_ERR, "11156E");
+		ltfsmsg(LTFS_ERR, 11156E);
 		return -LTFS_POLICY_INVALID;
 	} else if (has_name) {
-		ltfsmsg(LTFS_ERR, "11157E");
+		ltfsmsg(LTFS_ERR, 11157E);
 		return -LTFS_POLICY_INVALID;
 	}
 
@@ -422,7 +422,7 @@ int index_criteria_dup_rules(struct index_criteria *dest_ic, struct index_criter
 
 		dest_ic->glob_patterns = calloc(counter+1, sizeof(struct ltfs_name));
 		if (! dest_ic->glob_patterns) {
-			ltfsmsg(LTFS_ERR, "10001E", "index_criteria_dup_rules: glob pattern array");
+			ltfsmsg(LTFS_ERR, 10001E, "index_criteria_dup_rules: glob pattern array");
 			return -LTFS_NO_MEMORY;
 		}
 
@@ -433,7 +433,7 @@ int index_criteria_dup_rules(struct index_criteria *dest_ic, struct index_criter
 			dst_gp->percent_encode = src_gp->percent_encode;
 			dst_gp->name = strdup(src_gp->name);
 			if (! dst_gp->name) {
-				ltfsmsg(LTFS_ERR, "10001E", "index_criteria_dup_rules: glob pattern");
+				ltfsmsg(LTFS_ERR, 10001E, "index_criteria_dup_rules: glob pattern");
 				while (--i >= 0) {
 					--dst_gp;
 					free(dst_gp->name);
@@ -456,7 +456,7 @@ int index_criteria_dup_rules(struct index_criteria *dest_ic, struct index_criter
 void index_criteria_free(struct index_criteria *ic)
 {
 	if (! ic) {
-		ltfsmsg(LTFS_WARN, "10006W", "ic", __FUNCTION__);
+		ltfsmsg(LTFS_WARN, 10006W, "ic", __FUNCTION__);
 		return;
 	} else if (! ic->have_criteria)
 		return;
@@ -554,7 +554,7 @@ bool index_criteria_match(struct dentry *d, struct ltfs_volume *vol)
 	if (! ic->glob_cache) {
 		ret = _prepare_glob_cache(ic);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "11158E", ret);
+			ltfsmsg(LTFS_ERR, 11158E, ret);
 			return ret;
 		}
 	}
@@ -563,7 +563,7 @@ bool index_criteria_match(struct dentry *d, struct ltfs_volume *vol)
 	/* Prepare the dentry's name for caseless matching. */
 	ret = pathname_prepare_caseless(d->name.name, &dname, false);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11159E", ret);
+		ltfsmsg(LTFS_ERR, 11159E, ret);
 		return ret;
 	}
 	dname_len = u_strlen(dname);
@@ -575,7 +575,7 @@ bool index_criteria_match(struct dentry *d, struct ltfs_volume *vol)
 			free(dname);
 			return true;
 		} else if (match < 0) {
-			ltfsmsg(LTFS_ERR, "11161E", match);
+			ltfsmsg(LTFS_ERR, 11161E, match);
 		}
 	}
 
@@ -606,13 +606,13 @@ int _prepare_glob_cache(struct index_criteria *ic)
 
 	ic->glob_cache = calloc(num_patterns + 1, sizeof(UChar *));
 	if (! ic->glob_cache) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 	for (i=0; ic->glob_patterns[i].name; ++i) {
 		ret = pathname_prepare_caseless(ic->glob_patterns[i].name, &ic->glob_cache[i], false);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "11160E", ret);
+			ltfsmsg(LTFS_ERR, 11160E, ret);
 			return ret;
 		}
 	}
@@ -647,12 +647,12 @@ int _matches_name_criteria_caseless(const UChar *criteria, int32_t cr_len,
 	/* Open text boundary iterators. */
 	ub_criteria = ubrk_open(UBRK_CHARACTER, uloc_getDefault(), criteria, cr_len, &err);
 	if (U_FAILURE(err)) {
-		ltfsmsg(LTFS_ERR, "11162E", err);
+		ltfsmsg(LTFS_ERR, 11162E, err);
 		return -LTFS_ICU_ERROR;
 	}
 	ub_filename = ubrk_open(UBRK_CHARACTER, uloc_getDefault(), filename, fi_len, &err);
 	if (U_FAILURE(err)) {
-		ltfsmsg(LTFS_ERR, "11163E", err);
+		ltfsmsg(LTFS_ERR, 11163E, err);
 		ubrk_close(ub_criteria);
 		return -LTFS_ICU_ERROR;
 	}
@@ -692,7 +692,7 @@ int _matches_name_criteria_caseless(const UChar *criteria, int32_t cr_len,
 					/* Push this position onto the stack and consume the character. */
 					element = (filename_ustack_t *) calloc(1, sizeof(filename_ustack_t));
 					if (! element) {
-						ltfsmsg(LTFS_ERR, "10001E", "_matches_name_criteria_caseless: filename stack");
+						ltfsmsg(LTFS_ERR, 10001E, "_matches_name_criteria_caseless: filename stack");
 						match = 0;
 						goto out;
 					}
@@ -805,7 +805,7 @@ void _destroy_ustack(filename_ustack_t **stack)
 int _push_ustack(filename_ustack_t **stack, filename_ustack_t *element)
 {
 	if (! stack) {
-		ltfsmsg(LTFS_ERR, "11164E");
+		ltfsmsg(LTFS_ERR, 11164E);
 		return -1;
 	}
 	if (! *stack)
@@ -820,7 +820,7 @@ filename_ustack_t *_pop_ustack(filename_ustack_t **stack)
 {
 	filename_ustack_t *prev = NULL, *top;
 	if (! stack) {
-		ltfsmsg(LTFS_ERR, "11165E");
+		ltfsmsg(LTFS_ERR, 11165E);
 		return NULL;
 	}
 	for (top=*stack; top->next; top=top->next)

--- a/src/libltfs/iosched.c
+++ b/src/libltfs/iosched.c
@@ -78,7 +78,7 @@ int iosched_init(struct libltfs_plugin *plugin, struct ltfs_volume *vol)
 
 	priv = calloc(1, sizeof(struct iosched_priv));
 	if (! priv) {
-		ltfsmsg(LTFS_ERR, "10001E", "iosched_init: private data");
+		ltfsmsg(LTFS_ERR, 10001E, "iosched_init: private data");
 		return -LTFS_NO_MEMORY;
 	}
 
@@ -88,7 +88,7 @@ int iosched_init(struct libltfs_plugin *plugin, struct ltfs_volume *vol)
 	/* Verify that backend implements all required operations */
 	for (i=0; i<sizeof(struct iosched_ops)/sizeof(void *); ++i) {
 		if (((void **)(priv->ops))[i] == NULL) {
-			ltfsmsg(LTFS_ERR, "13003E");
+			ltfsmsg(LTFS_ERR, 13003E);
 			free(priv);
 			return -LTFS_PLUGIN_INCOMPLETE;
 		}

--- a/src/libltfs/kmi.c
+++ b/src/libltfs/kmi.c
@@ -74,7 +74,7 @@ int kmi_init(struct libltfs_plugin * const plugin, struct ltfs_volume * const vo
 
 	priv = calloc(1, sizeof(struct kmi_priv));
 	if (! priv) {
-		ltfsmsg(LTFS_ERR, "10001E", "kmi_init: private data");
+		ltfsmsg(LTFS_ERR, 10001E, "kmi_init: private data");
 		return -LTFS_NO_MEMORY;
 	}
 
@@ -84,7 +84,7 @@ int kmi_init(struct libltfs_plugin * const plugin, struct ltfs_volume * const vo
 	/* Verify that backend implements all required operations */
 	for (i=0; i<sizeof(struct kmi_ops)/sizeof(void *); ++i) {
 		if (((void **)(priv->ops))[i] == NULL) {
-			ltfsmsg(LTFS_ERR, "17174E");
+			ltfsmsg(LTFS_ERR, 17174E);
 			free(priv);
 			return -LTFS_PLUGIN_INCOMPLETE;
 		}
@@ -162,7 +162,7 @@ int kmi_print_help_message(const struct kmi_ops * const ops)
 	int ret = 0;
 
 	if (! ops) {
-		ltfsmsg(LTFS_WARN, "10006W", "ops", __FUNCTION__);
+		ltfsmsg(LTFS_WARN, 10006W, "ops", __FUNCTION__);
 		return -LTFS_NULL_ARG;
 	}
 
@@ -185,7 +185,7 @@ int kmi_parse_opts(void * const kmi_handle, void *opt_args)
 	ret = priv->ops->parse_opts(opt_args);
 	if (ret < 0)
 		/* Cannot parse backend options: backend call failed (%d) */
-		ltfsmsg(LTFS_ERR, "12040E", ret);
+		ltfsmsg(LTFS_ERR, 12040E, ret);
 
 	return ret;
 }

--- a/src/libltfs/label.c
+++ b/src/libltfs/label.c
@@ -64,7 +64,7 @@ int label_alloc(struct ltfs_label **label)
 
 	newlabel = calloc(1, sizeof(struct ltfs_label));
 	if (!newlabel) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 	newlabel->version = LTFS_LABEL_VERSION;
@@ -101,53 +101,53 @@ int label_compare(struct ltfs_label *label1, struct ltfs_label *label2)
 	CHECK_ARG_NULL(label2, -LTFS_NULL_ARG);
 
 	if (strncmp(label1->barcode, label2->barcode, 6)) {
-		ltfsmsg(LTFS_ERR, "11182E");
+		ltfsmsg(LTFS_ERR, 11182E);
 		return -LTFS_LABEL_MISMATCH;
 
 	} else if (strncmp(label1->vol_uuid, label2->vol_uuid, 36)) {
-		ltfsmsg(LTFS_ERR, "11183E");
+		ltfsmsg(LTFS_ERR, 11183E);
 		return -LTFS_LABEL_MISMATCH;
 
 	} else if (label1->format_time.tv_sec != label2->format_time.tv_sec ||
 		label1->format_time.tv_nsec != label2->format_time.tv_nsec) {
-		ltfsmsg(LTFS_ERR, "11184E");
+		ltfsmsg(LTFS_ERR, 11184E);
 		return -LTFS_LABEL_MISMATCH;
 
 	} else if (label1->blocksize != label2->blocksize) {
-		ltfsmsg(LTFS_ERR, "11185E");
+		ltfsmsg(LTFS_ERR, 11185E);
 		return -LTFS_LABEL_MISMATCH;
 
 	} else if (label1->enable_compression != label2->enable_compression) {
-		ltfsmsg(LTFS_ERR, "11186E");
+		ltfsmsg(LTFS_ERR, 11186E);
 		return -LTFS_LABEL_MISMATCH;
 
 	} else if (! ltfs_is_valid_partid(label1->partid_dp) ||
 			   ! ltfs_is_valid_partid(label1->partid_ip)) {
-		ltfsmsg(LTFS_ERR, "11187E");
+		ltfsmsg(LTFS_ERR, 11187E);
 		return -LTFS_LABEL_MISMATCH;
 
 	} else if (label1->partid_dp == label1->partid_ip) {
-		ltfsmsg(LTFS_ERR, "11188E");
+		ltfsmsg(LTFS_ERR, 11188E);
 		return -LTFS_LABEL_MISMATCH;
 
 	} else if (label2->partid_dp != label1->partid_dp ||
 			   label2->partid_ip != label1->partid_ip) {
-		ltfsmsg(LTFS_ERR, "11189E");
+		ltfsmsg(LTFS_ERR, 11189E);
 		return -LTFS_LABEL_MISMATCH;
 
 	} else if ((label1->this_partition != label1->partid_dp &&
 			    label1->this_partition != label1->partid_ip) ||
 			   (label2->this_partition != label1->partid_dp &&
 			    label2->this_partition != label1->partid_ip)) {
-		ltfsmsg(LTFS_ERR, "11190E");
+		ltfsmsg(LTFS_ERR, 11190E);
 		return -LTFS_LABEL_MISMATCH;
 
 	} else if (label1->this_partition == label2->this_partition) {
-		ltfsmsg(LTFS_ERR, "11191E", label1->this_partition);
+		ltfsmsg(LTFS_ERR, 11191E, label1->this_partition);
 		return -LTFS_LABEL_MISMATCH;
 
 	} else if (label1->version != label2->version) {
-		ltfsmsg(LTFS_ERR, "11197E");
+		ltfsmsg(LTFS_ERR, 11197E);
 		return -LTFS_LABEL_MISMATCH;
 	}
 
@@ -156,7 +156,7 @@ int label_compare(struct ltfs_label *label1, struct ltfs_label *label2)
 		tmp = label1->barcode;
 		while (*tmp) {
 			if ((*tmp < '0' || *tmp > '9') && (*tmp < 'A' || *tmp > 'Z')) {
-				ltfsmsg(LTFS_ERR, "11192E");
+				ltfsmsg(LTFS_ERR, 11192E);
 				return -LTFS_LABEL_MISMATCH;
 			}
 			++tmp;

--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -148,7 +148,7 @@ int ltfs_fs_init(void)
 
 	ret = fs_init_inode();
 	if (ret < 0)
-		ltfsmsg(LTFS_ERR, "17232E", ret);
+		ltfsmsg(LTFS_ERR, 17232E, ret);
 
 	return ret;
 }
@@ -301,28 +301,28 @@ int ltfs_volume_alloc(const char *execname, struct ltfs_volume **volume)
 	newvol = calloc(1, sizeof(struct ltfs_volume));
 	if (!newvol) {
 		/* Memory allocation failed */
-		ltfsmsg(LTFS_ERR, "10001E", "ltfs_volume_alloc");
+		ltfsmsg(LTFS_ERR, 10001E, "ltfs_volume_alloc");
 		return -LTFS_NO_MEMORY;
 	}
 
 	ret = tape_device_alloc(&newvol->device);
 	if (ret < 0) {
 		/* Couldn't allocate device data structure */
-		ltfsmsg(LTFS_ERR, "11000E");
+		ltfsmsg(LTFS_ERR, 11000E);
 		goto out_volfree;
 	}
 
 	ret = label_alloc(&newvol->label);
 	if (ret < 0) {
 		/* Failed to allocate label data */
-		ltfsmsg(LTFS_ERR, "11001E");
+		ltfsmsg(LTFS_ERR, 11001E);
 		goto out_devfree;
 	}
 
 	ret = ltfs_index_alloc(&newvol->index, newvol);
 	if (ret < 0) {
 		/* Failed to allocate index data */
-		ltfsmsg(LTFS_ERR, "11002E");
+		ltfsmsg(LTFS_ERR, 11002E);
 		goto out_labelfree;
 	}
 
@@ -333,18 +333,18 @@ int ltfs_volume_alloc(const char *execname, struct ltfs_volume **volume)
 
 	ret = init_mrsw(&newvol->lock);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10002E", ret);
+		ltfsmsg(LTFS_ERR, 10002E, ret);
 		goto out_indexfree;
 	}
 	ret = ltfs_thread_mutex_init(&newvol->reval_lock);
 	if (ret) {
-		ltfsmsg(LTFS_ERR, "10002E", ret);
+		ltfsmsg(LTFS_ERR, 10002E, ret);
 		ret = -LTFS_MUTEX_INIT;
 		goto out_lockfree;
 	}
 	ret = ltfs_thread_cond_init(&newvol->reval_cond);
 	if (ret) {
-		ltfsmsg(LTFS_ERR, "10003E", ret);
+		ltfsmsg(LTFS_ERR, 10003E, ret);
 		ret = -LTFS_MUTEX_INIT;
 		goto out_lockfree2;
 	}
@@ -354,7 +354,7 @@ int ltfs_volume_alloc(const char *execname, struct ltfs_volume **volume)
 			"IBM LTFS", PACKAGE_VERSION, PLATFORM, execname);
 		if (ret < 0) {
 			/* Memory allocation failed */
-			ltfsmsg(LTFS_ERR, "10001E", "ltfs_volume_alloc, creator string");
+			ltfsmsg(LTFS_ERR, 10001E, "ltfs_volume_alloc, creator string");
 			ret = -LTFS_NO_MEMORY;
 			goto out_condfree;
 		}
@@ -444,10 +444,10 @@ int ltfs_device_open(const char *devname, struct tape_ops *ops, struct ltfs_volu
 
 	ret = tape_get_max_blocksize(vol->device, &block_size);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17195E", "open", ret);
+		ltfsmsg(LTFS_ERR, 17195E, "open", ret);
 		return ret;
 	}
-	ltfsmsg(LTFS_INFO, "17160I", block_size);
+	ltfsmsg(LTFS_INFO, 17160I, block_size);
 
 	return 0;
 }
@@ -500,16 +500,16 @@ int ltfs_setup_device(struct ltfs_volume *vol)
 		return ret;
 
 	if (vol->append_only_mode) {
-		ltfsmsg(LTFS_INFO, "17157I", "to append-only mode");
+		ltfsmsg(LTFS_INFO, 17157I, "to append-only mode");
 		ret = tape_enable_append_only_mode(vol->device, true);
 	} else {
 		/* Check write mode and reset to write-anywhere mode if required. */
-		ltfsmsg(LTFS_INFO, "17157I", "to write-anywhere mode");
+		ltfsmsg(LTFS_INFO, 17157I, "to write-anywhere mode");
 		ret = tape_get_append_only_mode_setting(vol->device, &enabled);
 		if (ret < 0)
 			return ret;
 		if (enabled) {
-			ltfsmsg(LTFS_INFO, "17157I", "from append-only mode to write-anywhere mode");
+			ltfsmsg(LTFS_INFO, 17157I, "from append-only mode to write-anywhere mode");
 			ret = tape_enable_append_only_mode(vol->device, false);
 		}
 	}
@@ -541,7 +541,7 @@ start:
 		else
 			return ret;
 	} else if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "12010E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 12010E, __FUNCTION__);
 		releaseread_mrsw(&vol->lock);
 		return ret;
 	}
@@ -662,7 +662,7 @@ int ltfs_capacity_data_unlocked(struct device_capacity *cap, struct ltfs_volume 
 	if (vol->device) {
 		ret = tape_device_lock(vol->device);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "12010E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 12010E, __FUNCTION__);
 			return ret;
 		}
 
@@ -683,7 +683,7 @@ int ltfs_capacity_data_unlocked(struct device_capacity *cap, struct ltfs_volume 
 			vol->reval = -LTFS_REVAL_FAILED;
 		tape_device_unlock(vol->device);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "11003E", ret);
+			ltfsmsg(LTFS_ERR, 11003E, ret);
 			return ret;
 		}
 
@@ -735,7 +735,7 @@ int ltfs_get_cartridge_health(cartridge_health_info *h, struct ltfs_volume *vol)
 	if (vol->device) {
 		ret = tape_device_lock(vol->device);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "12010E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 12010E, __FUNCTION__);
 			return ret;
 		}
 
@@ -808,7 +808,7 @@ int ltfs_get_tape_alert_unlocked(uint64_t *tape_alert, struct ltfs_volume *vol)
 	if (vol->device) {
 		ret = tape_device_lock(vol->device);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "12010E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 12010E, __FUNCTION__);
 			return ret;
 		}
 
@@ -850,7 +850,7 @@ int ltfs_clear_tape_alert(uint64_t tape_alert, struct ltfs_volume *vol)
 	if (vol->device) {
 		ret = tape_device_lock(vol->device);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "12010E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 12010E, __FUNCTION__);
 			return ret;
 		}
 
@@ -881,7 +881,7 @@ int ltfs_get_params_unlocked(struct device_param *params, struct ltfs_volume *vo
 	if (vol->device) {
 		ret = tape_device_lock(vol->device);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "12010E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 12010E, __FUNCTION__);
 			return ret;
 		}
 
@@ -954,7 +954,7 @@ int ltfs_get_vendorunique_xattr(const char *name, char **buf, struct ltfs_volume
 	if (vol->device) {
 		ret = tape_device_lock(vol->device);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "12010E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 12010E, __FUNCTION__);
 			return ret;
 		}
 
@@ -990,7 +990,7 @@ int ltfs_set_vendorunique_xattr(const char *name, const char *value, size_t size
 	if (vol->device) {
 		ret = tape_device_lock(vol->device);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "12010E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 12010E, __FUNCTION__);
 			return ret;
 		}
 
@@ -1244,7 +1244,7 @@ int ltfs_get_index_commit_message(char **msg, struct ltfs_volume *vol)
 	if (vol->index->commit_message) {
 		ret = strdup(vol->index->commit_message);
 		if (! ret) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			releaseread_mrsw(&vol->lock);
 			return -LTFS_NO_MEMORY;
 		}
@@ -1269,7 +1269,7 @@ int ltfs_get_index_creator(char **msg, struct ltfs_volume *vol)
 	if (vol->index->creator) {
 		ret = strdup(vol->index->creator);
 		if (! ret) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			releaseread_mrsw(&vol->lock);
 			return -LTFS_NO_MEMORY;
 		}
@@ -1294,7 +1294,7 @@ int ltfs_get_volume_name(char **msg, struct ltfs_volume *vol)
 	if (vol->index->volume_name.name) {
 		ret = strdup(vol->index->volume_name.name);
 		if (! ret) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			releaseread_mrsw(&vol->lock);
 			return -LTFS_NO_MEMORY;
 		}
@@ -1377,13 +1377,13 @@ int ltfs_start_mount(bool trial, struct ltfs_volume *vol)
 
 	/* load tape */
 	INTERRUPTED_RETURN();
-	ltfsmsg(LTFS_DEBUG, "11012D"); /* loading the tape... */
+	ltfsmsg(LTFS_DEBUG, 11012D); /* loading the tape... */
 	ret = tape_load_tape(vol->device, vol->kmi_handle, false);
 	if (ret < 0) {
 		if (ret == -LTFS_UNSUPPORTED_MEDIUM)
-			ltfsmsg(LTFS_ERR, "11298E");
+			ltfsmsg(LTFS_ERR, 11298E);
 		else
-			ltfsmsg(LTFS_ERR, "11006E");
+			ltfsmsg(LTFS_ERR, 11006E);
 		return ret;
 	}
 
@@ -1393,50 +1393,50 @@ int ltfs_start_mount(bool trial, struct ltfs_volume *vol)
 	ret = tape_seek(vol->device, &seekpos);
 	if (ret < 0) {
 		if (ret == -LTFS_UNSUPPORTED_MEDIUM || ret == -EDEV_MEDIUM_FORMAT_ERROR)
-			ltfsmsg(LTFS_ERR, "11298E");
+			ltfsmsg(LTFS_ERR, 11298E);
 		else
-			ltfsmsg(LTFS_ERR, "11006E");
+			ltfsmsg(LTFS_ERR, 11006E);
 		return ret;
 	}
 
-	ltfsmsg(LTFS_DEBUG, "11007D"); /* tape is loaded */
+	ltfsmsg(LTFS_DEBUG, 11007D); /* tape is loaded */
 
 	/* Check partition */
 	ret = tape_get_capacity(vol->device, &cap);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17167E", ret);
+		ltfsmsg(LTFS_ERR, 17167E, ret);
 		return ret;
 	} else if (cap.max_p0 == 0 || cap.max_p1 == 0) {
 		if (! trial)
-			ltfsmsg(LTFS_ERR, "17168E");
+			ltfsmsg(LTFS_ERR, 17168E);
 		return -LTFS_NOT_PARTITIONED;
 	}
 
 	/* read labels from both partitions and compare them */
 	INTERRUPTED_RETURN();
-	ltfsmsg(LTFS_DEBUG, "11008D"); /* read partition labels ... */
+	ltfsmsg(LTFS_DEBUG, 11008D); /* read partition labels ... */
 	ret = ltfs_read_labels(trial, vol);
 	if (ret < 0) {
 		/* Failed to read partition labels */
-		ltfsmsg(LTFS_ERR, "11009E");
+		ltfsmsg(LTFS_ERR, 11009E);
 		return ret;
 	}
 
 	ret = tape_set_compression(vol->device, vol->label->enable_compression);
 	if (ret < 0) {
 		/* Failed to set compression */
-		ltfsmsg(LTFS_ERR, "11010E");
+		ltfsmsg(LTFS_ERR, 11010E);
 		return ret;
 	}
 
 	ret = tape_get_max_blocksize(vol->device, &tape_maxblk);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17195E", "mount", ret);
+		ltfsmsg(LTFS_ERR, 17195E, "mount", ret);
 		return ret;
 	}
 	if (tape_maxblk < vol->label->blocksize) {
 		/* Blocksize too large for device */
-		ltfsmsg(LTFS_ERR, "11011E", vol->label->blocksize, tape_maxblk);
+		ltfsmsg(LTFS_ERR, 11011E, vol->label->blocksize, tape_maxblk);
 		return -LTFS_LARGE_BLOCKSIZE;
 	}
 
@@ -1466,7 +1466,7 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 	/* TODO: is_worm_recovery_mount should be set by user via option */
 	int vollock = VOLUME_UNLOCKED;
 
-	ltfsmsg(LTFS_INFO, "11005I");
+	ltfsmsg(LTFS_INFO, 11005I);
 
 	CHECK_ARG_NULL(vol, -LTFS_NULL_ARG);
 
@@ -1486,8 +1486,8 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 	vol->first_locate.tv_sec = 0;
 	vol->first_locate.tv_nsec = 0;
 
-	ltfsmsg(LTFS_DEBUG, "11013D"); /* partition labels are valid */
-	ltfsmsg(LTFS_DEBUG, "11014D"); /* read MAM parameters... */
+	ltfsmsg(LTFS_DEBUG, 11013D); /* partition labels are valid */
+	ltfsmsg(LTFS_DEBUG, 11014D); /* read MAM parameters... */
 
 	tape_get_cart_volume_lock_status(vol->device, &vollock);
 	tape_get_worm_status(vol->device, &vol->device->is_worm);
@@ -1511,7 +1511,7 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 		&vol->ip_coh);
 	if (ret != 0 || strcmp(vol->ip_coh.uuid, vol->label->vol_uuid)) {
 		/* MAM parameter for index partition invalid */
-		ltfsmsg(LTFS_WARN, "11016W");
+		ltfsmsg(LTFS_WARN, 11016W);
 		memset(&vol->ip_coh, 0, sizeof(struct tc_coherency));
 	}
 
@@ -1519,14 +1519,14 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 		&vol->dp_coh);
 	if (ret != 0 || strcmp(vol->dp_coh.uuid, vol->label->vol_uuid)) { /* attribute was invalid */
 		/* MAM parameter for data partition invalid */
-		ltfsmsg(LTFS_WARN, "11017W");
+		ltfsmsg(LTFS_WARN, 11017W);
 		memset(&vol->dp_coh, 0, sizeof(struct tc_coherency));
 	}
 
 	ret = tape_get_volume_change_reference(vol->device, &volume_change_ref);
 	if (ret < 0 || volume_change_ref == 0 || volume_change_ref == UINT64_MAX) {
 		/* MAM parameters are invalid. */
-		ltfsmsg(LTFS_WARN, "11015W");
+		ltfsmsg(LTFS_WARN, 11015W);
 		memset(&vol->ip_coh, 0, sizeof(struct tc_coherency));
 		memset(&vol->dp_coh, 0, sizeof(struct tc_coherency));
 	}
@@ -1536,8 +1536,8 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 	if (vol->ip_coh.version == 0 || vol->dp_coh.version == 0)
 		force_full = true;
 
-	ltfsmsg(LTFS_DEBUG, "11018D"); /* Done reading MAM parameters */
-	ltfsmsg(LTFS_DEBUG, "11019D"); /* Checking volume consistency... */
+	ltfsmsg(LTFS_DEBUG, 11018D); /* Done reading MAM parameters */
+	ltfsmsg(LTFS_DEBUG, 11019D); /* Checking volume consistency... */
 
 	/* check for consistency */
 	INTERRUPTED_GOTO(ret, out_unlock);
@@ -1551,24 +1551,24 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 			if (ret == -EDEV_EOD_DETECTED) {
 				INTERRUPTED_GOTO(ret, out_unlock);
 				/* MAM parameters could be corrupted, try a full consistency check */
-				ltfsmsg(LTFS_INFO, "11026I");
+				ltfsmsg(LTFS_INFO, 11026I);
 				ret = ltfs_check_medium(true, deep_recovery, recover_extra, recover_symlink, vol);
 				if (ret < 0) {
-					ltfsmsg(LTFS_ERR, "11027E");
+					ltfsmsg(LTFS_ERR, 11027E);
 					goto out_unlock;
 				}
 			} else if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "11020E"); /* seek to DP Index failed */
+				ltfsmsg(LTFS_ERR, 11020E); /* seek to DP Index failed */
 				goto out_unlock;
 			} else {
 				INTERRUPTED_GOTO(ret, out_unlock);
 				ret = ltfs_read_index(0, false, vol);
 				if (ret < 0) {
-					ltfsmsg(LTFS_ERR, "11021E"); /* read DP Index failed */
+					ltfsmsg(LTFS_ERR, 11021E); /* read DP Index failed */
 					goto out_unlock;
 				}
 				INTERRUPTED_GOTO(ret, out_unlock);
-				ltfsmsg(LTFS_INFO, "11022I");
+				ltfsmsg(LTFS_INFO, 11022I);
 				ret = ltfs_write_index(vol->label->partid_ip, SYNC_RECOVERY, vol);
 				if (ret < 0)
 					goto out_unlock;
@@ -1580,23 +1580,23 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 			if (ret == -EDEV_EOD_DETECTED) {
 				INTERRUPTED_GOTO(ret, out_unlock);
 				/* MAM parameters could be corrupted, try a full consistency check */
-				ltfsmsg(LTFS_INFO, "11026I");
+				ltfsmsg(LTFS_INFO, 11026I);
 				ret = ltfs_check_medium(true, deep_recovery, recover_extra, recover_symlink, vol);
 				if (ret < 0) {
-					ltfsmsg(LTFS_ERR, "11027E");
+					ltfsmsg(LTFS_ERR, 11027E);
 					goto out_unlock;
 				}
 			} else if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "11023E"); /* seek to IP Index failed */
+				ltfsmsg(LTFS_ERR, 11023E); /* seek to IP Index failed */
 				goto out_unlock;
 			} else {
 				INTERRUPTED_GOTO(ret, out_unlock);
 				ret = ltfs_read_index(0, false, vol);
 				if (ret < 0) {
-					ltfsmsg(LTFS_ERR, "11024E"); /* read IP Index failed */
+					ltfsmsg(LTFS_ERR, 11024E); /* read IP Index failed */
 					goto out_unlock;
 				}
-				ltfsmsg(LTFS_DEBUG, "11025D"); /* volume is consistent */
+				ltfsmsg(LTFS_DEBUG, 11025D); /* volume is consistent */
 			}
 		}
 	} else if (is_worm_recovery_mount) {
@@ -1605,7 +1605,7 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 		bool read_ip = false;
 
 		/* Write permed cartridge is detected. Seek the newest index */
-		ltfsmsg(LTFS_INFO, "11333I", vol->ip_coh.count, vol->dp_coh.count);
+		ltfsmsg(LTFS_INFO, 11333I, (unsigned long long)vol->ip_coh.count, (unsigned long long)vol->dp_coh.count);
 
 		if (vol->ip_coh.count < vol->dp_coh.count) {
 			seekpos.partition = ltfs_part_id2num(vol->label->partid_dp, vol);
@@ -1621,43 +1621,43 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 		if (ret == -EDEV_EOD_DETECTED) {
 			INTERRUPTED_GOTO(ret, out_unlock);
 			/* MAM parameters could be corrupted, try a full consistency check */
-			ltfsmsg(LTFS_INFO, "11026I");
+			ltfsmsg(LTFS_INFO, 11026I);
 			ret = ltfs_check_medium(true, deep_recovery, recover_extra, recover_symlink, vol);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "11027E");
+				ltfsmsg(LTFS_ERR, 11027E);
 				goto out_unlock;
 			}
 		} else if (ret < 0) {
 			if (read_ip)
-				ltfsmsg(LTFS_ERR, "11023E"); /* seek to IP Index failed */
+				ltfsmsg(LTFS_ERR, 11023E); /* seek to IP Index failed */
 			else
-				ltfsmsg(LTFS_ERR, "11020E"); /* seek to DP Index failed */
+				ltfsmsg(LTFS_ERR, 11020E); /* seek to DP Index failed */
 			goto out_unlock;
 		} else {
 			INTERRUPTED_GOTO(ret, out_unlock);
 			ret = ltfs_read_index(0, false, vol);
 			if (ret < 0) {
 				if (read_ip)
-					ltfsmsg(LTFS_ERR, "11024E"); /* read IP Index failed */
+					ltfsmsg(LTFS_ERR, 11024E); /* read IP Index failed */
 				else
-					ltfsmsg(LTFS_ERR, "11021E"); /* read DP Index failed */
+					ltfsmsg(LTFS_ERR, 11021E); /* read DP Index failed */
 				goto out_unlock;
 			}
 			else
-				ltfsmsg(LTFS_DEBUG, "11025D"); /* volume is consistent */
+				ltfsmsg(LTFS_DEBUG, 11025D); /* volume is consistent */
 		}
 	} else {
 		/* do a full consistency check on the medium itself */
 		INTERRUPTED_GOTO(ret, out_unlock);
-		ltfsmsg(LTFS_INFO, "11026I"); /* performing full medium consistency check */
+		ltfsmsg(LTFS_INFO, 11026I); /* performing full medium consistency check */
 		ret = ltfs_check_medium(true, deep_recovery, recover_extra, recover_symlink, vol);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "11027E"); /* consistency check failed */
+			ltfsmsg(LTFS_ERR, 11027E); /* consistency check failed */
 			goto out_unlock;
 		}
 	}
 
-	ltfsmsg(LTFS_DEBUG, "11028D"); /* finished consistency check */
+	ltfsmsg(LTFS_DEBUG, 11028D); /* finished consistency check */
 
 	/* Make roll back mount if necessary */
 	INTERRUPTED_GOTO(ret, out_unlock);
@@ -1677,7 +1677,7 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 				ret = ltfs_traverse_index_backward(vol, ltfs_dp_id(vol), gen, NULL, NULL, NULL);
 		}
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "17079E", gen);
+			ltfsmsg(LTFS_ERR, 17079E, gen);
 			goto out_unlock;
 		} else {
 			vol->rollback_mount = true;
@@ -1692,13 +1692,13 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 	ret = tape_set_ip_append_position(vol->device, ltfs_part_id2num(ltfs_ip_id(vol), vol), vol->index->selfptr.block - 1);
 
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11029E"); /* failed to save append position for IP */
+		ltfsmsg(LTFS_ERR, 11029E); /* failed to save append position for IP */
 		goto out_unlock;
 	}
 
 	/* Issue a warning if the UID space is exhausted: new create/mkdir requests will be rejected */
 	if (vol->index->uid_number == 0)
-		ltfsmsg(LTFS_WARN, "11307W", vol->label->vol_uuid);
+		ltfsmsg(LTFS_WARN, 11307W, vol->label->vol_uuid);
 
 	/* Clear the commit message so it doesn't carry over from the previous session */
 	/* TODO: is this the right place to clear the commit message? */
@@ -1754,7 +1754,7 @@ int ltfs_load_all_attributes(struct ltfs_volume *vol)
 		/* load tape attribute from Cartridge Memory*/
 		vol->t_attr = (struct tape_attr *) calloc(1, sizeof(struct tape_attr));
 		if (! vol->t_attr) {
-			ltfsmsg(LTFS_ERR, "10001E", "ltfs_load_all_attribute: vol->t_attr");
+			ltfsmsg(LTFS_ERR, 10001E, "ltfs_load_all_attribute: vol->t_attr");
 			ret = -LTFS_NO_MEMORY;
 		} else
 			tape_load_all_attribute_from_cm(vol->device, vol->t_attr);
@@ -1790,9 +1790,9 @@ void ltfs_set_index_dirty(bool locking, bool atime, struct ltfs_index *idx)
 
 		if (!was_dirty && idx->dirty) {
 			if (idx->root->vol->label->barcode[0] != ' ')
-				ltfsmsg(LTFS_INFO, "11337I", true, idx->root->vol->label->barcode, idx->root->vol);
+				ltfsmsg(LTFS_INFO, 11337I, true, idx->root->vol->label->barcode, idx->root->vol);
 			else
-				ltfsmsg(LTFS_INFO, "11337I", true, LTFS_NO_BARCODE, idx->root->vol);
+				ltfsmsg(LTFS_INFO, 11337I, true, LTFS_NO_BARCODE, idx->root->vol);
 		}
 	}
 }
@@ -1819,9 +1819,9 @@ void ltfs_unset_index_dirty(bool update_version, struct ltfs_index *idx)
 
 		if (was_dirty && !idx->dirty) {
 			if (idx->root->vol->label->barcode[0] != ' ')
-				ltfsmsg(LTFS_INFO, "11337I", false, idx->root->vol->label->barcode, idx->root->vol);
+				ltfsmsg(LTFS_INFO, 11337I, false, idx->root->vol->label->barcode, idx->root->vol);
 			else
-				ltfsmsg(LTFS_INFO, "11337I", false, LTFS_NO_BARCODE, idx->root->vol);
+				ltfsmsg(LTFS_INFO, 11337I, false, LTFS_NO_BARCODE, idx->root->vol);
 		}
 	}
 }
@@ -1839,7 +1839,7 @@ int ltfs_unmount(char *reason, struct ltfs_volume *vol)
 	cartridge_health_info h;
 	int vollock = VOLUME_UNLOCKED;
 
-	ltfsmsg(LTFS_DEBUG, "11032D"); /* Unmount the volume... */
+	ltfsmsg(LTFS_DEBUG, 11032D); /* Unmount the volume... */
 
 start:
 	ret = ltfs_get_volume_lock(true, vol);
@@ -1856,7 +1856,7 @@ start:
 					releasewrite_mrsw(&vol->lock);
 					goto start;
 				} else {
-					ltfsmsg(LTFS_ERR, "11033E");
+					ltfsmsg(LTFS_ERR, 11033E);
 					/* Reset revalidation flag to allow future mount attempts */
 					ltfs_thread_mutex_lock(&vol->reval_lock);
 					vol->reval = 0;
@@ -1867,7 +1867,7 @@ start:
 			} else if (ret < 0) {
 				if (IS_UNEXPECTED_MOVE(ret))
 					vol->reval = -LTFS_REVAL_FAILED;
-				ltfsmsg(LTFS_ERR, "11033E"); /* could not unmount, failed to write Index */
+				ltfsmsg(LTFS_ERR, 11033E); /* could not unmount, failed to write Index */
 				releasewrite_mrsw(&vol->lock);
 				return ret;
 			}
@@ -1888,7 +1888,7 @@ start:
 
 	releasewrite_mrsw(&vol->lock);
 
-	ltfsmsg(LTFS_INFO, "11034I"); /* unmount successful */
+	ltfsmsg(LTFS_INFO, 11034I); /* unmount successful */
 	return 0;
 }
 
@@ -1939,16 +1939,16 @@ int ltfs_load_tape(struct ltfs_volume *vol)
 {
 	int ret;
 
-	ltfsmsg(LTFS_INFO, "11330I"); /* Loading cartridge... */
+	ltfsmsg(LTFS_INFO, 11330I); /* Loading cartridge... */
 
 	INTERRUPTED_RETURN();
 	ret = tape_load_tape(vol->device, vol->kmi_handle, true);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11331E", __FUNCTION__); /* Failed to load the cartridge */
+		ltfsmsg(LTFS_ERR, 11331E, __FUNCTION__); /* Failed to load the cartridge */
 		return ret;
 	}
 
-	ltfsmsg(LTFS_INFO, "11332I"); /* Eject successful */
+	ltfsmsg(LTFS_INFO, 11332I); /* Eject successful */
 	return ret;
 }
 
@@ -1961,16 +1961,16 @@ int ltfs_eject_tape(bool keep_on_drive, struct ltfs_volume *vol)
 {
 	int ret;
 
-	ltfsmsg(LTFS_INFO, "11289I"); /* Ejecting cartridge... */
+	ltfsmsg(LTFS_INFO, 11289I); /* Ejecting cartridge... */
 
 	INTERRUPTED_RETURN();
 	ret = tape_unload_tape(keep_on_drive, vol->device);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11290E", __FUNCTION__); /* Failed to eject the cartridge */
+		ltfsmsg(LTFS_ERR, 11290E, __FUNCTION__); /* Failed to eject the cartridge */
 		return ret;
 	}
 
-	ltfsmsg(LTFS_INFO, "11291I"); /* Eject successful */
+	ltfsmsg(LTFS_INFO, 11291I); /* Eject successful */
 	return ret;
 }
 
@@ -2037,7 +2037,7 @@ int ltfs_get_partition_readonly(char partition, struct ltfs_volume *vol)
 {
 	CHECK_ARG_NULL(vol, -LTFS_NULL_ARG);
 	if (partition != ltfs_dp_id(vol) && partition != ltfs_ip_id(vol)) {
-		ltfsmsg(LTFS_ERR, "11306E");
+		ltfsmsg(LTFS_ERR, 11306E);
 		return -LTFS_BAD_PARTNUM;
 	}
 
@@ -2097,7 +2097,7 @@ void ltfs_set_eod_check(bool use, struct ltfs_volume *vol)
 void ltfs_set_traverse_mode(int mode, struct ltfs_volume *vol)
 {
 	if (mode != TRAVERSE_FORWARD && mode != TRAVERSE_BACKWARD) {
-		ltfsmsg(LTFS_WARN, "11310W", mode);
+		ltfsmsg(LTFS_WARN, 11310W, mode);
 		return;
 	}
 	if (vol)
@@ -2242,7 +2242,7 @@ int ltfs_write_index(char partition, char *reason, struct ltfs_volume *vol)
 	/* locate to append position */
 	ret = tape_seek_append_position(vol->device, ltfs_part_id2num(partition, vol), partition == vol->label->partid_ip);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11080E", partition, ret);
+		ltfsmsg(LTFS_ERR, 11080E, partition, ret);
 		if (generation_inc) {
 			vol->index->mod_time = modtime_old;
 			--vol->index->generation;
@@ -2258,7 +2258,7 @@ int ltfs_write_index(char partition, char *reason, struct ltfs_volume *vol)
 	/* update self pointer */
 	ret = tape_get_position(vol->device, &physical_selfptr);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11081E", ret);
+		ltfsmsg(LTFS_ERR, 11081E, ret);
 		if (generation_inc) {
 			vol->index->mod_time = modtime_old;
 			--vol->index->generation;
@@ -2276,7 +2276,7 @@ int ltfs_write_index(char partition, char *reason, struct ltfs_volume *vol)
 	if ((partition == ltfs_ip_id(vol)) && !vol->ip_index_file_end) {
 		ret = tape_write_filemark(vol->device, 0, true, true, false);	// Flush data before writing FM
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "11326E", ret);
+			ltfsmsg(LTFS_ERR, 11326E, ret);
 			if (generation_inc) {
 				vol->index->mod_time = modtime_old;
 				--vol->index->generation;
@@ -2288,16 +2288,16 @@ int ltfs_write_index(char partition, char *reason, struct ltfs_volume *vol)
 	}
 
 	if (vol->label->barcode[0] != ' ') {
-		ltfsmsg(LTFS_INFO, "17235I", vol->label->barcode, partition, reason,
-				vol->index->file_count, tape_get_serialnumber(vol->device));
+		ltfsmsg(LTFS_INFO, 17235I, vol->label->barcode, partition, reason,
+				(unsigned long long)vol->index->file_count, tape_get_serialnumber(vol->device));
 	} else {
-		ltfsmsg(LTFS_INFO, "17235I", LTFS_NO_BARCODE, partition, reason,
-				vol->index->file_count, tape_get_serialnumber(vol->device));
+		ltfsmsg(LTFS_INFO, 17235I, LTFS_NO_BARCODE, partition, reason,
+				(unsigned long long)vol->index->file_count, tape_get_serialnumber(vol->device));
 	}
 
 	ret = tape_write_filemark(vol->device, 1, true, true, true);	// immediate WFM
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11082E", ret);
+		ltfsmsg(LTFS_ERR, 11082E, ret);
 		if (generation_inc) {
 			vol->index->mod_time = modtime_old;
 			--vol->index->generation;
@@ -2310,7 +2310,7 @@ int ltfs_write_index(char partition, char *reason, struct ltfs_volume *vol)
 	/* Actually write index to tape and disk if vol->index_cache_path is existed */
 	ret = xml_schema_to_tape(reason, vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11083E", ret);
+		ltfsmsg(LTFS_ERR, 11083E, ret);
 		if (generation_inc) {
 			vol->index->mod_time = modtime_old;
 			--vol->index->generation;
@@ -2324,7 +2324,7 @@ int ltfs_write_index(char partition, char *reason, struct ltfs_volume *vol)
 	immed = (strcmp(reason, SYNC_FORMAT) == 0);
 	ret = tape_write_filemark(vol->device, 1, true, true, immed);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11084E", ret);
+		ltfsmsg(LTFS_ERR, 11084E, ret);
 		if (generation_inc) {
 			vol->index->mod_time = modtime_old;
 			--vol->index->generation;
@@ -2345,10 +2345,10 @@ int ltfs_write_index(char partition, char *reason, struct ltfs_volume *vol)
 	ltfs_update_cart_coherency(vol);
 
 	if (vol->label->barcode[0] != ' ') {
-		ltfsmsg(LTFS_INFO, "17236I", vol->label->barcode, partition,
+		ltfsmsg(LTFS_INFO, 17236I, vol->label->barcode, partition,
 				tape_get_serialnumber(vol->device));
 	} else {
-		ltfsmsg(LTFS_INFO, "17236I", LTFS_NO_BARCODE, partition,
+		ltfsmsg(LTFS_INFO, 17236I, LTFS_NO_BARCODE, partition,
 				tape_get_serialnumber(vol->device));
 	}
 
@@ -2396,7 +2396,7 @@ int ltfs_save_index_to_disk(const char *work_dir, char * reason, bool need_gen, 
 	CHECK_ARG_NULL(vol->label, -LTFS_NULL_ARG);
 
 	/* Write the schema to a file on disk */
-	ltfsmsg(LTFS_DEBUG, "17182D", vol->label->vol_uuid, vol->label->barcode);
+	ltfsmsg(LTFS_DEBUG, 17182D, vol->label->vol_uuid, vol->label->barcode);
 	if (need_gen) {
 		if (strcmp(vol->label->barcode, "      "))
 			ret = asprintf(&path, "%s/%s-%d.schema", work_dir, vol->label->barcode, vol->index->generation);
@@ -2410,22 +2410,22 @@ int ltfs_save_index_to_disk(const char *work_dir, char * reason, bool need_gen, 
 	}
 
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10001E", "ltfs_save_index_to_disk: path");
+		ltfsmsg(LTFS_ERR, 10001E, "ltfs_save_index_to_disk: path");
 		return -ENOMEM;
 	}
 
 	if (vol->label->barcode[0] != ' ') {
-		ltfsmsg(LTFS_INFO, "17235I", vol->label->barcode, 'Z', "Volume Cache",
-				vol->index->file_count, path);
+		ltfsmsg(LTFS_INFO, 17235I, vol->label->barcode, 'Z', "Volume Cache",
+				(unsigned long long)vol->index->file_count, path);
 	} else {
-		ltfsmsg(LTFS_INFO, "17235I", LTFS_NO_BARCODE, 'Z', "Volume Cache",
-				vol->index->file_count, path);
+		ltfsmsg(LTFS_INFO, 17235I, LTFS_NO_BARCODE, 'Z', "Volume Cache",
+				(unsigned long long)vol->index->file_count, path);
 	}
 
 	ret = xml_schema_to_file(path, vol->index->creator, reason, vol->index);
 	if (ret < 0) {
 		/* Error writing XML schema to file '%s' on disk */
-		ltfsmsg(LTFS_ERR, "17183E", path);
+		ltfsmsg(LTFS_ERR, 17183E, path);
 		free(path);
 		return ret;
 	}
@@ -2433,13 +2433,13 @@ int ltfs_save_index_to_disk(const char *work_dir, char * reason, bool need_gen, 
 	/* Change index file's mode */
 	if (chmod(path, S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP | S_IROTH | S_IWOTH)) {
 		ret = -errno;
-		ltfsmsg(LTFS_ERR, "17184E", errno);
+		ltfsmsg(LTFS_ERR, 17184E, errno);
 	}
 
 	if (vol->label->barcode[0] != ' ')
-		ltfsmsg(LTFS_INFO, "17236I", vol->label->barcode, 'Z', path);
+		ltfsmsg(LTFS_INFO, 17236I, vol->label->barcode, 'Z', path);
 	else
-		ltfsmsg(LTFS_INFO, "17236I", LTFS_NO_BARCODE, 'Z', path);
+		ltfsmsg(LTFS_INFO, 17236I, LTFS_NO_BARCODE, 'Z', path);
 
 	free(path);
 	return ret;
@@ -2454,7 +2454,7 @@ int ltfs_save_index_to_disk(const char *work_dir, char * reason, bool need_gen, 
 char ltfs_dp_id(struct ltfs_volume *vol)
 {
 	if (! vol || ! vol->label) {
-		ltfsmsg(LTFS_WARN, "11090W");
+		ltfsmsg(LTFS_WARN, 11090W);
 		return 0;
 	}
 	return vol->label->partid_dp;
@@ -2469,7 +2469,7 @@ char ltfs_dp_id(struct ltfs_volume *vol)
 char ltfs_ip_id(struct ltfs_volume *vol)
 {
 	if (! vol || ! vol->label) {
-		ltfsmsg(LTFS_WARN, "11091W");
+		ltfsmsg(LTFS_WARN, 11091W);
 		return 0;
 	}
 	return vol->label->partid_ip;
@@ -2559,7 +2559,7 @@ int ltfs_set_volume_name(const char *volname, struct ltfs_volume *vol)
 			return ret;
 		name_dup = strdup(volname);
 		if (! name_dup) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 	}
@@ -2639,7 +2639,7 @@ int ltfs_write_label(tape_partition_t partition, struct ltfs_volume *vol)
 	seekpos.block = 0;
 	ret = tape_seek(vol->device, &seekpos);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11101E", ret, partition);
+		ltfsmsg(LTFS_ERR, 11101E, ret, partition);
 		return ret;
 	}
 
@@ -2647,27 +2647,27 @@ int ltfs_write_label(tape_partition_t partition, struct ltfs_volume *vol)
 	label_make_ansi_label(vol, ansi_label, sizeof(ansi_label) - LTFS_CRC_SIZE);
 	nw = tape_write(vol->device, ansi_label, sizeof(ansi_label) - LTFS_CRC_SIZE, true, false);
 	if (nw < 0) {
-		ltfsmsg(LTFS_ERR, "11102E", (int)nw, partition);
+		ltfsmsg(LTFS_ERR, 11102E, (int)nw, partition);
 		return nw;
 	}
 
 	ret = tape_write_filemark(vol->device, 1, true, false, true);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11104E", ret, partition);
+		ltfsmsg(LTFS_ERR, 11104E, ret, partition);
 		return ret;
 	}
 
 	/* write XML label */
 	xml_buf = xml_make_label(vol->creator, partition, vol->label);
 	if (! xml_buf) {
-		ltfsmsg(LTFS_ERR, "11105E");
+		ltfsmsg(LTFS_ERR, 11105E);
 		return -LTFS_NO_MEMORY; /* TODO: this is the most likely error, but not the only possible one */
 	}
 
 	buf = calloc(1, xmlBufferLength(xml_buf) + LTFS_CRC_SIZE);
 	if (!buf) {
 		/* Memory allocation failed */
-		ltfsmsg(LTFS_ERR, "10001E", "label buffer");
+		ltfsmsg(LTFS_ERR, 10001E, "label buffer");
 		xmlBufferFree(xml_buf);
 		return -LTFS_NO_MEMORY;
 	}
@@ -2676,7 +2676,7 @@ int ltfs_write_label(tape_partition_t partition, struct ltfs_volume *vol)
 
 	nw = tape_write(vol->device, buf, xmlBufferLength(xml_buf), true, false);
 	if (nw < 0) {
-		ltfsmsg(LTFS_ERR, "11106E", (int)nw, partition);
+		ltfsmsg(LTFS_ERR, 11106E, (int)nw, partition);
 		free(buf);
 		xmlBufferFree(xml_buf);
 		return -nw;
@@ -2686,7 +2686,7 @@ int ltfs_write_label(tape_partition_t partition, struct ltfs_volume *vol)
 
 	ret = tape_write_filemark(vol->device, 1, true, false, true);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11108E", ret, partition);
+		ltfsmsg(LTFS_ERR, 11108E, ret, partition);
 		return ret;
 	}
 
@@ -2714,18 +2714,18 @@ int ltfs_format_tape(struct ltfs_volume *vol, int density_code)
 	if (! ret || ret == -LTFS_NO_SPACE || ret == -LTFS_LESS_SPACE)
 		ret = ltfs_get_partition_readonly(ltfs_dp_id(vol), vol);
 	if (ret < 0 && ret != -LTFS_NO_SPACE && ret != -LTFS_LESS_SPACE) {
-		ltfsmsg(LTFS_ERR, "11095E");
+		ltfsmsg(LTFS_ERR, 11095E);
 		return ret;
 	}
 
 	ret = tape_get_max_blocksize(vol->device, &tape_maxblk);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17195E", "format", ret);
+		ltfsmsg(LTFS_ERR, 17195E, "format", ret);
 		return ret;
 	}
 
 	if (tape_maxblk < vol->label->blocksize) {
-		ltfsmsg(LTFS_ERR, "11096E", vol->label->blocksize, tape_maxblk);
+		ltfsmsg(LTFS_ERR, 11096E, vol->label->blocksize, tape_maxblk);
 		return -LTFS_LARGE_BLOCKSIZE;
 	}
 
@@ -2739,7 +2739,7 @@ int ltfs_format_tape(struct ltfs_volume *vol, int density_code)
 
 	vol->label->creator = strdup(vol->creator);
 	if (!vol->label->creator) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 
@@ -2755,26 +2755,26 @@ int ltfs_format_tape(struct ltfs_volume *vol, int density_code)
 
 	/* Reset capacity proportion */
 	if (vol->reset_capacity) {
-		ltfsmsg(LTFS_INFO, "17165I");
+		ltfsmsg(LTFS_INFO, 17165I);
 		ret = tape_reset_capacity(vol->device);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "11311E", ret);
+			ltfsmsg(LTFS_ERR, 11311E, ret);
 			return ret;
 		}
 	}
 
 	/* Format the tape */
 	INTERRUPTED_RETURN();
-	ltfsmsg(LTFS_INFO, "11097I");
+	ltfsmsg(LTFS_INFO, 11097I);
 	ret = tape_format(vol->device, ltfs_part_id2num(vol->label->partid_ip, vol), density_code);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11098E", ret);
+		ltfsmsg(LTFS_ERR, 11098E, ret);
 		return ret;
 	}
 
 	ret = tape_set_compression(vol->device, vol->label->enable_compression);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11099E", ret);
+		ltfsmsg(LTFS_ERR, 11099E, ret);
 		return ret;
 	}
 
@@ -2783,39 +2783,39 @@ int ltfs_format_tape(struct ltfs_volume *vol, int density_code)
 		unsigned char *key = NULL;
 		ret = kmi_get_key(&keyalias, &key, vol->kmi_handle);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "11314E", ret);
+			ltfsmsg(LTFS_ERR, 11314E, ret);
 			return ret;
 		}
 		ret = tape_set_key(vol->device, keyalias, key);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "11315E", ret);
+			ltfsmsg(LTFS_ERR, 11315E, ret);
 			return ret;
 		}
 	}
 
 	/* Write data partition */
 	INTERRUPTED_RETURN();
-	ltfsmsg(LTFS_INFO, "11100I", vol->label->partid_dp);
+	ltfsmsg(LTFS_INFO, 11100I, vol->label->partid_dp);
 	ret = ltfs_write_label(ltfs_part_id2num(vol->label->partid_dp, vol), vol);
 	if (ret < 0)
 		return ret;
-	ltfsmsg(LTFS_INFO, "11278I", vol->label->partid_dp); /* "Writing Index to ..." */
+	ltfsmsg(LTFS_INFO, 11278I, vol->label->partid_dp); /* "Writing Index to ..." */
 	ret = ltfs_write_index(vol->label->partid_dp, SYNC_FORMAT, vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11279E", vol->label->partid_dp, ret);
+		ltfsmsg(LTFS_ERR, 11279E, vol->label->partid_dp, ret);
 		return ret;
 	}
 
 	/* Write index partition */
 	INTERRUPTED_RETURN();
-	ltfsmsg(LTFS_INFO, "11100I", vol->label->partid_ip);
+	ltfsmsg(LTFS_INFO, 11100I, vol->label->partid_ip);
 	ret = ltfs_write_label(ltfs_part_id2num(vol->label->partid_ip, vol), vol);
 	if (ret < 0)
 		return ret;
-	ltfsmsg(LTFS_INFO, "11278I", vol->label->partid_ip); /* "Writing Index to ..." */
+	ltfsmsg(LTFS_INFO, 11278I, vol->label->partid_ip); /* "Writing Index to ..." */
 	ret = ltfs_write_index(vol->label->partid_ip, SYNC_FORMAT, vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11279E", vol->label->partid_ip, ret);
+		ltfsmsg(LTFS_ERR, 11279E, vol->label->partid_ip, ret);
 		return ret;
 	}
 
@@ -2840,9 +2840,9 @@ int ltfs_unformat_tape(struct ltfs_volume *vol, bool long_wipe)
 	ret = tape_load_tape(vol->device, vol->kmi_handle, false);
 	if (ret < 0) {
 		if (ret == -LTFS_UNSUPPORTED_MEDIUM)
-			ltfsmsg(LTFS_ERR, "11299E");
+			ltfsmsg(LTFS_ERR, 11299E);
 		else
-			ltfsmsg(LTFS_ERR, "11093E", ret);
+			ltfsmsg(LTFS_ERR, 11093E, ret);
 		return ret;
 	}
 
@@ -2850,25 +2850,25 @@ int ltfs_unformat_tape(struct ltfs_volume *vol, bool long_wipe)
 	if (! ret || ret == -LTFS_NO_SPACE || ret == -LTFS_LESS_SPACE)
 		ret = ltfs_get_partition_readonly(ltfs_dp_id(vol), vol);
 	if (ret < 0 && ret != -LTFS_NO_SPACE && ret != -LTFS_LESS_SPACE) {
-		ltfsmsg(LTFS_ERR, "11095E");
+		ltfsmsg(LTFS_ERR, 11095E);
 		return ret;
 	}
 
 	/* Unformat the tape */
 	INTERRUPTED_RETURN();
-	ltfsmsg(LTFS_INFO, "17071I");
+	ltfsmsg(LTFS_INFO, 17071I);
 	ret = tape_unformat(vol->device);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17072E", ret);
+		ltfsmsg(LTFS_ERR, 17072E, ret);
 		return ret;
 	}
 
 	INTERRUPTED_RETURN();
 	if (long_wipe) {
-		ltfsmsg(LTFS_INFO, "17201I");
+		ltfsmsg(LTFS_INFO, 17201I);
 		ret = tape_erase(vol->device, true);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "17202E", ret);
+			ltfsmsg(LTFS_ERR, 17202E, ret);
 			return ret;
 		}
 	}
@@ -2943,13 +2943,17 @@ int _ltfs_revalidate_mam(struct ltfs_volume *vol)
 	if (ret < 0)
 		return ret;
 
-	ltfsmsg(LTFS_DEBUG, "17166D", "coh0", coh0.volume_change_ref, coh0.count, coh0.set_id,
+	ltfsmsg(LTFS_DEBUG, 17166D, "coh0",
+			(unsigned long long)coh0.volume_change_ref, (unsigned long long)coh0.count, (unsigned long long)coh0.set_id,
 			coh0.version, coh0.uuid, vol->label->part_num2id[0]);
-	ltfsmsg(LTFS_DEBUG, "17166D", "coh1", coh1.volume_change_ref, coh1.count, coh1.set_id,
+	ltfsmsg(LTFS_DEBUG, 17166D, "coh1",
+			(unsigned long long)coh1.volume_change_ref, (unsigned long long)coh1.count, (unsigned long long)coh1.set_id,
 			coh1.version, coh1.uuid, vol->label->part_num2id[0]);
-	ltfsmsg(LTFS_DEBUG, "17166D", "IP", vol->ip_coh.volume_change_ref, vol->ip_coh.count, vol->ip_coh.set_id,
+	ltfsmsg(LTFS_DEBUG, 17166D, "IP",
+			(unsigned long long)vol->ip_coh.volume_change_ref, (unsigned long long)vol->ip_coh.count, (unsigned long long)vol->ip_coh.set_id,
 			vol->ip_coh.version, vol->ip_coh.uuid, vol->label->partid_ip);
-	ltfsmsg(LTFS_DEBUG, "17166D", "DP", vol->dp_coh.volume_change_ref, vol->dp_coh.count, vol->dp_coh.set_id,
+	ltfsmsg(LTFS_DEBUG, 17166D, "DP",
+			(unsigned long long)vol->dp_coh.volume_change_ref, (unsigned long long)vol->dp_coh.count, (unsigned long long)vol->dp_coh.set_id,
 			vol->dp_coh.version, vol->dp_coh.uuid, vol->label->partid_dp);
 
 	if (vol->label->part_num2id[0] == vol->label->partid_dp) {
@@ -3003,9 +3007,9 @@ int ltfs_revalidate(bool have_write_lock, struct ltfs_volume *vol)
 	CHECK_ARG_NULL(vol, -LTFS_NULL_ARG);
 
 	if (vol->label->barcode[0] != ' ')
-		ltfsmsg(LTFS_INFO, "11312I", vol->label->barcode);
+		ltfsmsg(LTFS_INFO, 11312I, vol->label->barcode);
 	else
-		ltfsmsg(LTFS_INFO, "11312I", LTFS_NO_BARCODE);
+		ltfsmsg(LTFS_INFO, 11312I, LTFS_NO_BARCODE);
 
 	/* Block other libltfs operations until revalidation finishes */
 	ltfs_thread_mutex_lock(&vol->reval_lock);
@@ -3195,14 +3199,14 @@ out:
 
 	if (ret < 0) {
 		if (vol->label->barcode[0] != ' ')
-			ltfsmsg(LTFS_ERR, "11313E", ret, vol->label->barcode);
+			ltfsmsg(LTFS_ERR, 11313E, ret, vol->label->barcode);
 		else
-			ltfsmsg(LTFS_ERR, "11313E", ret, LTFS_NO_BARCODE);
+			ltfsmsg(LTFS_ERR, 11313E, ret, LTFS_NO_BARCODE);
 	} else {
 		if (vol->label->barcode[0] != ' ')
-			ltfsmsg(LTFS_INFO, "11340I", vol->label->barcode);
+			ltfsmsg(LTFS_INFO, 11340I, vol->label->barcode);
 		else
-			ltfsmsg(LTFS_INFO, "11340I", LTFS_NO_BARCODE);
+			ltfsmsg(LTFS_INFO, 11340I, LTFS_NO_BARCODE);
 	}
 
 	return ret;
@@ -3243,10 +3247,10 @@ start:
 		releaseread_mrsw(&vol->lock);
 
 	if (dirty) {
-		ltfsmsg(LTFS_INFO, "11338I", vol->label->barcode, vol->device->serial_number);
+		ltfsmsg(LTFS_INFO, 11338I, vol->label->barcode, vol->device->serial_number);
 
 		/* Force a new XML schema to be flushed to the tape */
-		ltfsmsg(LTFS_INFO, "17068I", vol->label->barcode, reason, vol->device->serial_number);
+		ltfsmsg(LTFS_INFO, 17068I, vol->label->barcode, reason, vol->device->serial_number);
 		/* If the DP ends in an index and the IP doesn't, then we're most likely positioned
 		 * at the end of the IP, and writing an index there is allowed without first putting
 		 * down a DP index. */
@@ -3269,7 +3273,7 @@ start:
 		 */
 		ret = tape_device_lock(vol->device);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "12010E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 12010E, __FUNCTION__);
 			if (index_locking)
 				releasewrite_mrsw(&vol->lock);
 			return ret;
@@ -3287,9 +3291,9 @@ start:
 		} else if (index_locking)
 			releasewrite_mrsw(&vol->lock);
 		if (ret)
-			ltfsmsg(LTFS_ERR, "17069E");
+			ltfsmsg(LTFS_ERR, 17069E);
 
-		ltfsmsg(LTFS_INFO, "17070I", vol->label->barcode, ret, vol->device->serial_number);
+		ltfsmsg(LTFS_INFO, 17070I, vol->label->barcode, ret, vol->device->serial_number);
 	}
 
 	return ret;
@@ -3312,7 +3316,7 @@ int ltfs_traverse_index_no_eod(struct ltfs_volume *vol, char partition, unsigned
 
 	ret = tape_locate_first_index(vol->device, ltfs_part_id2num(partition, vol));
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17082E", 'N', partition);
+		ltfsmsg(LTFS_ERR, 17082E, 'N', partition);
 		return ret;
 	}
 
@@ -3321,7 +3325,7 @@ int ltfs_traverse_index_no_eod(struct ltfs_volume *vol, char partition, unsigned
 		ltfs_index_alloc(&vol->index, vol);
 		ret = ltfs_read_index(0, false, vol);
 		if (ret < 0 && ret != -LTFS_UNSUPPORTED_INDEX_VERSION) {
-			ltfsmsg(LTFS_ERR, "17075E", 'N', vol->device->position.block, partition);
+			ltfsmsg(LTFS_ERR, 17075E, 'N', (int)vol->device->position.block, partition);
 			return ret;
 		} else if (ret == -LTFS_UNSUPPORTED_INDEX_VERSION) {
 			ret = tape_spacefm(vol->device, 1);
@@ -3334,11 +3338,11 @@ int ltfs_traverse_index_no_eod(struct ltfs_volume *vol, char partition, unsigned
 				vol->label->part_num2id[vol->device->position.partition];
 		}
 
-		ltfsmsg(LTFS_DEBUG, "17080D", 'N', vol->index->generation, partition);
+		ltfsmsg(LTFS_DEBUG, 17080D, 'N', vol->index->generation, partition);
 		if (func) {
 			func_ret = (*func)(vol, gen, list, priv);
 			if(func_ret < 0) {
-				ltfsmsg(LTFS_ERR, "17081E", 'N', func_ret, partition);
+				ltfsmsg(LTFS_ERR, 17081E, 'N', func_ret, partition);
 				return func_ret;
 			} else if (func_ret > 0) /* Break if call back function returns positive value */
 				return 0;
@@ -3350,17 +3354,17 @@ int ltfs_traverse_index_no_eod(struct ltfs_volume *vol, char partition, unsigned
 
 		ret = tape_locate_next_index(vol->device);
 		if (ret < 0) {
-			ltfsmsg(LTFS_INFO, "17208I", ret, vol->index->generation);
+			ltfsmsg(LTFS_INFO, 17208I, ret, vol->index->generation);
 			break;
 		}
 	}
 
 	if(gen != 0) {
 		if(vol->index->generation != gen) {
-			ltfsmsg(LTFS_DEBUG, "17078D", 'N', gen, partition);
+			ltfsmsg(LTFS_DEBUG, 17078D, 'N', gen, partition);
 			return -LTFS_NO_INDEX;
 		} else {
-			ltfsmsg(LTFS_INFO, "17077I", 'N', gen, partition);
+			ltfsmsg(LTFS_INFO, 17077I, 'N', gen, partition);
 			return 0;
 		}
 	}
@@ -3386,7 +3390,7 @@ int ltfs_traverse_index_forward(struct ltfs_volume *vol, char partition, unsigne
 
 	ret = tape_locate_last_index(vol->device, ltfs_part_id2num(partition, vol));
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17083E", 'F', partition);
+		ltfsmsg(LTFS_ERR, 17083E, 'F', partition);
 		return ret;
 	}
 
@@ -3395,7 +3399,7 @@ int ltfs_traverse_index_forward(struct ltfs_volume *vol, char partition, unsigne
 
 	ret = tape_locate_first_index(vol->device, ltfs_part_id2num(partition, vol));
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17082E", 'F', partition);
+		ltfsmsg(LTFS_ERR, 17082E, 'F', partition);
 		return ret;
 	}
 
@@ -3404,7 +3408,7 @@ int ltfs_traverse_index_forward(struct ltfs_volume *vol, char partition, unsigne
 		ltfs_index_alloc(&vol->index, vol);
 		ret = ltfs_read_index(0, false, vol);
 		if (ret < 0 && ret != -LTFS_UNSUPPORTED_INDEX_VERSION) {
-			ltfsmsg(LTFS_ERR, "17075E", 'F', vol->device->position.block, partition);
+			ltfsmsg(LTFS_ERR, 17075E, 'F', (int)vol->device->position.block, partition);
 			return ret;
 		} else if (ret == -LTFS_UNSUPPORTED_INDEX_VERSION) {
 			ret = tape_spacefm(vol->device, 1);
@@ -3416,11 +3420,11 @@ int ltfs_traverse_index_forward(struct ltfs_volume *vol, char partition, unsigne
 				vol->label->part_num2id[vol->device->position.partition];
 		}
 
-		ltfsmsg(LTFS_DEBUG, "17080D", 'F', vol->index->generation, partition);
+		ltfsmsg(LTFS_DEBUG, 17080D, 'F', vol->index->generation, partition);
 		if (func) {
 			func_ret = (*func)(vol, gen, list, priv);
 			if(func_ret < 0) {
-				ltfsmsg(LTFS_ERR, "17081E", 'F', func_ret, partition);
+				ltfsmsg(LTFS_ERR, 17081E, 'F', func_ret, partition);
 				return func_ret;
 			} else if (func_ret > 0) /* Break if call back function returns positive value */
 				return 0;
@@ -3433,7 +3437,7 @@ int ltfs_traverse_index_forward(struct ltfs_volume *vol, char partition, unsigne
 		if (last_index.block > vol->device->position.block) {
 			ret = tape_locate_next_index(vol->device);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "17076E", 'F', partition);
+				ltfsmsg(LTFS_ERR, 17076E, 'F', partition);
 				return ret;
 			}
 		}
@@ -3441,10 +3445,10 @@ int ltfs_traverse_index_forward(struct ltfs_volume *vol, char partition, unsigne
 
 	if(gen != 0) {
 		if(vol->index->generation != gen) {
-			ltfsmsg(LTFS_DEBUG, "17078D", 'F', gen, partition);
+			ltfsmsg(LTFS_DEBUG, 17078D, 'F', gen, partition);
 			return -LTFS_NO_INDEX;
 		} else {
-			ltfsmsg(LTFS_INFO, "17077I", 'F', gen, partition);
+			ltfsmsg(LTFS_INFO, 17077I, 'F', gen, partition);
 			return 0;
 		}
 	}
@@ -3468,7 +3472,7 @@ int ltfs_traverse_index_backward(struct ltfs_volume *vol, char partition, unsign
 
 	ret = tape_locate_last_index(vol->device, ltfs_part_id2num(partition, vol));
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17083E", 'B', partition);
+		ltfsmsg(LTFS_ERR, 17083E, 'B', partition);
 		return ret;
 	}
 
@@ -3480,7 +3484,7 @@ int ltfs_traverse_index_backward(struct ltfs_volume *vol, char partition, unsign
 		ltfs_index_alloc(&vol->index, vol);
 		ret = ltfs_read_index(0, false, vol);
 		if (ret < 0 && ret != -LTFS_UNSUPPORTED_INDEX_VERSION) {
-			ltfsmsg(LTFS_ERR, "17075E", 'B', vol->device->position.block, partition);
+			ltfsmsg(LTFS_ERR, 17075E, 'B', (int)vol->device->position.block, partition);
 			return ret;
 		} else if (ret == -LTFS_UNSUPPORTED_INDEX_VERSION) {
 			ret = tape_spacefm(vol->device, 1);
@@ -3492,12 +3496,12 @@ int ltfs_traverse_index_backward(struct ltfs_volume *vol, char partition, unsign
 				vol->label->part_num2id[vol->device->position.partition];
 		}
 
-		ltfsmsg(LTFS_DEBUG, "17080D", 'B', vol->index->generation, partition);
+		ltfsmsg(LTFS_DEBUG, 17080D, 'B', vol->index->generation, partition);
 
 		if (func) {
 			func_ret = (*func)(vol, gen, list, priv);
 			if(func_ret < 0) {
-				ltfsmsg(LTFS_ERR, "17081E", 'B', func_ret, partition);
+				ltfsmsg(LTFS_ERR, 17081E, 'B', func_ret, partition);
 				return func_ret;
 			} else if (func_ret > 0) /* Break if call back function returns positive value */
 				return 0;
@@ -3509,17 +3513,17 @@ int ltfs_traverse_index_backward(struct ltfs_volume *vol, char partition, unsign
 
 		ret = tape_locate_previous_index(vol->device);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "17076E", 'B', partition);
+			ltfsmsg(LTFS_ERR, 17076E, 'B', partition);
 			return ret;
 		}
 	}
 
 	if(gen != 0) {
 		if(vol->index->generation != gen) {
-			ltfsmsg(LTFS_DEBUG, "17078D", 'B', gen, partition);
+			ltfsmsg(LTFS_DEBUG, 17078D, 'B', gen, partition);
 			return -LTFS_NO_INDEX;
 		} else {
-			ltfsmsg(LTFS_INFO, "17077I", 'B', gen, partition);
+			ltfsmsg(LTFS_INFO, 17077I, 'B', gen, partition);
 			return 0;
 		}
 	}
@@ -3546,41 +3550,41 @@ int ltfs_check_eod_status(struct ltfs_volume *vol)
 	eod_status_dp = tape_check_eod_status(vol->device, ltfs_part_id2num(vol->label->partid_dp, vol));
 	if(eod_status_ip == EOD_UNKNOWN || eod_status_dp == EOD_UNKNOWN) {
 		/* Backend cannnot support EOD status check, print warning  */
-		ltfsmsg(LTFS_WARN, "17145W");
-		ltfsmsg(LTFS_INFO, "17147I");
+		ltfsmsg(LTFS_WARN, 17145W);
+		ltfsmsg(LTFS_INFO, 17147I);
 	} else if(eod_status_ip == EOD_MISSING || eod_status_dp == EOD_MISSING) {
 		ret = tape_get_worm_status(vol->device, &is_worm);
 
 		/* EOD is missing in both or one of partitions, print message and exit */
 		if(eod_status_ip == EOD_MISSING && eod_status_dp == EOD_MISSING) {
-			ltfsmsg(LTFS_ERR, "17142E");
+			ltfsmsg(LTFS_ERR, 17142E);
 			if (is_worm) {
-				ltfsmsg(LTFS_ERR, "17207E");
+				ltfsmsg(LTFS_ERR, 17207E);
 			}
 			else {
-				ltfsmsg(LTFS_ERR, "17148E");
+				ltfsmsg(LTFS_ERR, 17148E);
 			}
 			ret = -LTFS_BOTH_EOD_MISSING;
 		} else if (eod_status_ip == EOD_MISSING) {
-			ltfsmsg(LTFS_ERR, "17146E", "IP", ltfs_part_id2num(vol->label->partid_ip, vol));
+			ltfsmsg(LTFS_ERR, 17146E, "IP", ltfs_part_id2num(vol->label->partid_ip, vol));
 			if (is_worm) {
-				ltfsmsg(LTFS_ERR, "17207E");
+				ltfsmsg(LTFS_ERR, 17207E);
 			}
 			else {
-				ltfsmsg(LTFS_ERR, "17148E");
+				ltfsmsg(LTFS_ERR, 17148E);
 			}
 			ret = -LTFS_EOD_MISSING_MEDIUM;
 		} else if (eod_status_dp == EOD_MISSING) {
-			ltfsmsg(LTFS_ERR, "17146E", "DP", ltfs_part_id2num(vol->label->partid_dp, vol));
+			ltfsmsg(LTFS_ERR, 17146E, "DP", ltfs_part_id2num(vol->label->partid_dp, vol));
 			if (is_worm) {
-				ltfsmsg(LTFS_ERR, "17207E");
+				ltfsmsg(LTFS_ERR, 17207E);
 			}
 			else {
-				ltfsmsg(LTFS_ERR, "17148E");
+				ltfsmsg(LTFS_ERR, 17148E);
 			}
 			ret = -LTFS_EOD_MISSING_MEDIUM;
 		} else {
-			ltfsmsg(LTFS_ERR, "17126E", eod_status_ip, eod_status_dp);
+			ltfsmsg(LTFS_ERR, 17126E, eod_status_ip, eod_status_dp);
 			ret = -LTFS_UNEXPECTED_VALUE;
 		}
 	}
@@ -3606,11 +3610,11 @@ static int _ltfs_detect_final_rec_dp(struct ltfs_volume *vol, struct tc_position
 
 	/* Read the final index of IP */
 	INTERRUPTED_RETURN();
-	ltfsmsg(LTFS_INFO, "17114I");
+	ltfsmsg(LTFS_INFO, 17114I);
 	ret = ltfs_seek_index(vol->label->partid_ip, &end_pos, &index_end_pos,
 						  &fm_after, &blocks_after, false, vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17115E");
+		ltfsmsg(LTFS_ERR, 17115E);
 		return ret;
 	}
 
@@ -3632,7 +3636,7 @@ static int _ltfs_detect_final_rec_dp(struct ltfs_volume *vol, struct tc_position
 		seekpos.block = vol->ip_coh.set_id;
 		seekpos.partition = ltfs_part_id2num(vol->label->partid_dp, vol);
 	} else {
-		ltfsmsg(LTFS_ERR, "17123E",
+		ltfsmsg(LTFS_ERR, 17123E,
 				vol->index->generation,
 				ip_coh_gen,
 				dp_coh_gen);
@@ -3640,18 +3644,18 @@ static int _ltfs_detect_final_rec_dp(struct ltfs_volume *vol, struct tc_position
 	}
 
 	INTERRUPTED_RETURN();
-	ltfsmsg(LTFS_INFO, "17118I", "DP", seekpos.partition, seekpos.block);
+	ltfsmsg(LTFS_INFO, 17118I, "DP", (unsigned long long)seekpos.partition, (unsigned long long)seekpos.block);
 	ret = tape_seek(vol->device, &seekpos);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17119E", "DP",  ret);
+		ltfsmsg(LTFS_ERR, 17119E, "DP",  ret);
 		return ret;
 	}
 
 	INTERRUPTED_RETURN();
-	ltfsmsg(LTFS_INFO, "17120I", "DP", seekpos.partition, seekpos.block);
+	ltfsmsg(LTFS_INFO, 17120I, "DP", (unsigned long long)seekpos.partition, (unsigned long long)seekpos.block);
 	ret = ltfs_read_index(0, false, vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17121E", "DP",  ret);
+		ltfsmsg(LTFS_ERR, 17121E, "DP",  ret);
 		return ret;
 	}
 
@@ -3675,11 +3679,11 @@ int _ltfs_detect_final_rec_ip(struct ltfs_volume *vol, struct tc_position *pos)
 	/* Detect the final record number of IP from
        the final index of DP */
 	INTERRUPTED_RETURN();
-	ltfsmsg(LTFS_INFO, "17116I");
+	ltfsmsg(LTFS_INFO, 17116I);
 	ret = ltfs_seek_index(vol->label->partid_dp, &end_pos, &index_end_pos,
 						  &fm_after, &blocks_after, false, vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17117E");
+		ltfsmsg(LTFS_ERR, 17117E);
 		return ret;
 	}
 
@@ -3688,10 +3692,10 @@ int _ltfs_detect_final_rec_ip(struct ltfs_volume *vol, struct tc_position *pos)
 	INTERRUPTED_RETURN();
 	seekpos.block = ip_last;
 	seekpos.partition = ltfs_part_id2num(vol->label->partid_ip, vol);
-	ltfsmsg(LTFS_INFO, "17124I", "IP", seekpos.partition, seekpos.block);
+	ltfsmsg(LTFS_INFO, 17124I, "IP", (unsigned long long)seekpos.partition, (unsigned long long)seekpos.block);
 	ret = tape_seek(vol->device, &seekpos);
 	if (ret < 0){
-		ltfsmsg(LTFS_ERR, "17125E", "DP",  ret);
+		ltfsmsg(LTFS_ERR, 17125E, "DP",  ret);
 		return ret;
 	}
 
@@ -3711,7 +3715,7 @@ int ltfs_recover_eod(struct ltfs_volume *vol)
 	bool need_verify = false;
 	struct tc_position seekpos;
 
-	ltfsmsg(LTFS_INFO, "17139I");
+	ltfsmsg(LTFS_INFO, 17139I);
 
 	/* Check EOD status in both partitions */
 	INTERRUPTED_RETURN();
@@ -3719,29 +3723,29 @@ int ltfs_recover_eod(struct ltfs_volume *vol)
 	eod_status_dp = tape_check_eod_status(vol->device, ltfs_part_id2num(vol->label->partid_dp, vol));
 	if(eod_status_ip == EOD_UNKNOWN || eod_status_dp == EOD_UNKNOWN) {
 		/* Backend cannnot support EOD status check */
-		ltfsmsg(LTFS_ERR, "17140E");
+		ltfsmsg(LTFS_ERR, 17140E);
 		return -LTFS_UNSUPPORTED;
 	} else if(eod_status_ip == EOD_GOOD && eod_status_dp == EOD_GOOD) {
 		/* Both EODs are good, no need to perform EOD recovery */
-		ltfsmsg(LTFS_INFO, "17141I");
+		ltfsmsg(LTFS_INFO, 17141I);
 		return 0;
 	} else if(eod_status_ip == EOD_MISSING && eod_status_dp == EOD_MISSING) {
 		/* Both EODs are missing, Unrecoverable */
-		ltfsmsg(LTFS_ERR, "17142E");
+		ltfsmsg(LTFS_ERR, 17142E);
 		return -LTFS_UNSUPPORTED;
 	} else if(eod_status_ip == EOD_GOOD && eod_status_dp == EOD_MISSING) {
 		/* EOD of DP is missing */
-		ltfsmsg(LTFS_INFO, "17143I", "DP", ltfs_part_id2num(vol->label->partid_dp, vol));
+		ltfsmsg(LTFS_INFO, 17143I, "DP", ltfs_part_id2num(vol->label->partid_dp, vol));
 		no_eod_part_id = vol->label->partid_dp;
 		(void)ltfs_part_id2num(vol->label->partid_dp, vol);
 	} else if(eod_status_ip == EOD_MISSING && eod_status_dp == EOD_GOOD) {
 		/* EOD of IP is missing */
-		ltfsmsg(LTFS_INFO, "17143I", "IP", ltfs_part_id2num(vol->label->partid_ip, vol));
+		ltfsmsg(LTFS_INFO, 17143I, "IP", ltfs_part_id2num(vol->label->partid_ip, vol));
 		no_eod_part_id = vol->label->partid_ip;
 		(void)ltfs_part_id2num(vol->label->partid_ip, vol);
 	} else {
 		// Unexpected result
-		ltfsmsg(LTFS_ERR, "17126E", eod_status_ip, eod_status_dp);
+		ltfsmsg(LTFS_ERR, 17126E, eod_status_ip, eod_status_dp);
 		return -LTFS_UNEXPECTED_VALUE;
 	}
 
@@ -3750,29 +3754,29 @@ int ltfs_recover_eod(struct ltfs_volume *vol)
 	ret = tape_get_cart_coherency(vol->device, ltfs_part_id2num(vol->label->partid_ip, vol),
 								  &vol->ip_coh);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17144E", "IP");
+		ltfsmsg(LTFS_ERR, 17144E, "IP");
 		return ret;
 	}
 
 	ret = tape_get_cart_coherency(vol->device, ltfs_part_id2num(vol->label->partid_dp, vol),
 		&vol->dp_coh);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17144E", "DP");
+		ltfsmsg(LTFS_ERR, 17144E, "DP");
 		return ret;
 	}
 
 	if(vol->ip_coh.version == 0 && vol->dp_coh.version == 0){
 		/* MAM is written by PGA1 or earlier */
-		ltfsmsg(LTFS_INFO, "17110I");
+		ltfsmsg(LTFS_INFO, 17110I);
 		need_verify = true;
 	} else if (vol->ip_coh.version >= 1 && vol->dp_coh.version >= 1 &&
 			   vol->ip_coh.version == vol->dp_coh.version){
 		/* MAM is written by PGA2 or later (includes version2) */
-		ltfsmsg(LTFS_INFO, "17111I");
+		ltfsmsg(LTFS_INFO, 17111I);
 		need_verify = false;
 	} else {
 		/* Unexpected condition. Cannot support */
-		ltfsmsg(LTFS_ERR, "17107E", vol->ip_coh.version, vol->dp_coh.version);
+		ltfsmsg(LTFS_ERR, 17107E, vol->ip_coh.version, vol->dp_coh.version);
 		return -LTFS_UNEXPECTED_VALUE;
 	}
 
@@ -3782,19 +3786,19 @@ int ltfs_recover_eod(struct ltfs_volume *vol)
 		/* MAM points the partition which has EOD */
 		if(no_eod_part_id == vol->label->partid_dp) {
 			/* Go to the end of final index of corrupted data partition */
-			ltfsmsg(LTFS_INFO, "17112I");
+			ltfsmsg(LTFS_INFO, 17112I);
 			ret = _ltfs_detect_final_rec_dp(vol, &seekpos);
 		} else if(no_eod_part_id == vol->label->partid_ip) {
 			/* Go to the end of final record of corrupted index partition */
-			ltfsmsg(LTFS_INFO, "17112I");
+			ltfsmsg(LTFS_INFO, 17112I);
 			ret = _ltfs_detect_final_rec_ip(vol, &seekpos);
 		} else {
-			ltfsmsg(LTFS_ERR, "17108E", no_eod_part_id, no_eod_part_id);
+			ltfsmsg(LTFS_ERR, 17108E, no_eod_part_id, no_eod_part_id);
 			return -LTFS_UNEXPECTED_VALUE;
 		}
 
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "17109E");
+			ltfsmsg(LTFS_ERR, 17109E);
 			return ret;
 		}
 	} else {
@@ -3810,10 +3814,10 @@ int ltfs_recover_eod(struct ltfs_volume *vol)
 			seekpos.block = vol->dp_coh.set_id;
 			seekpos.partition = ltfs_part_id2num(vol->label->partid_dp, vol);;
 		} else {
-			ltfsmsg(LTFS_ERR, "17108E", no_eod_part_id, no_eod_part_id);
+			ltfsmsg(LTFS_ERR, 17108E, no_eod_part_id, no_eod_part_id);
 			return -LTFS_UNEXPECTED_VALUE;
 		}
-		ltfsmsg(LTFS_INFO, "17113I", seekpos.partition, seekpos.block);
+		ltfsmsg(LTFS_INFO, 17113I, (unsigned long long)seekpos.partition, (unsigned long long)seekpos.block);
 
 		/* Locate to target and read index */
 		ret = tape_seek(vol->device, &seekpos);
@@ -3835,11 +3839,11 @@ int ltfs_recover_eod(struct ltfs_volume *vol)
 	INTERRUPTED_RETURN();
 	ret = tape_recover_eod_status(vol->device, vol->kmi_handle);
 	if(ret < 0) {
-		ltfsmsg(LTFS_ERR, "17137E", ret);
+		ltfsmsg(LTFS_ERR, 17137E, ret);
 		return ret;
 	}
 
-	ltfsmsg(LTFS_INFO, "17138I", ret);
+	ltfsmsg(LTFS_INFO, 17138I, ret);
 
 	return 0;
 }
@@ -3890,16 +3894,16 @@ void ltfs_recover_eod_simple(struct ltfs_volume *vol)
 
 	eod_status_ip = tape_check_eod_status(vol->device, ltfs_part_id2num(vol->label->partid_ip, vol));
 	if (eod_status_ip == EOD_MISSING) {
-		ltfsmsg(LTFS_INFO, "17161I", "IP");
-		ltfsmsg(LTFS_INFO, "17162I");
+		ltfsmsg(LTFS_INFO, 17161I, "IP");
+		ltfsmsg(LTFS_INFO, 17162I);
 		corrupted = true;
 		tape_seek_eod(vol->device, ltfs_part_id2num(vol->label->partid_ip, vol));
 	}
 
 	eod_status_dp = tape_check_eod_status(vol->device, ltfs_part_id2num(vol->label->partid_dp, vol));
 	if (eod_status_dp == EOD_MISSING) {
-		ltfsmsg(LTFS_INFO, "17161I", "DP");
-		ltfsmsg(LTFS_INFO, "17162I");
+		ltfsmsg(LTFS_INFO, 17161I, "DP");
+		ltfsmsg(LTFS_INFO, 17162I);
 		corrupted = true;
 		tape_seek_eod(vol->device, ltfs_part_id2num(vol->label->partid_dp, vol));
 	}
@@ -3925,7 +3929,7 @@ int ltfs_print_device_list(struct tape_ops *ops)
 	if (count) {
 		buf = (struct tc_drive_info *)calloc(count * 2, sizeof(struct tc_drive_info));
 		if (! buf) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			ret = -LTFS_NO_MEMORY;
 			return ret;
 		}
@@ -3933,13 +3937,13 @@ int ltfs_print_device_list(struct tape_ops *ops)
 	}
 
 	/* Print device list */
-	ltfsresult("17073I");
+	ltfsresult(17073I);
 	c = MIN(info_count, (count * 2));
 	for (i = 0; i < c; i++)
 		if (buf[i].name[0] && buf[i].vendor[0] &&
 			buf[i].model[0] && buf[i].serial_number[0] &&
 			buf[i].product_name[0])
-			ltfsresult("17074I", buf[i].name, buf[i].vendor,
+			ltfsresult(17074I, buf[i].name, buf[i].vendor,
 				buf[i].model, buf[i].serial_number, buf[i].product_name);
 	ret = 0;
 

--- a/src/libltfs/ltfs.h
+++ b/src/libltfs/ltfs.h
@@ -168,7 +168,7 @@ struct device_data;
 #define INTERRUPTED_GOTO(rc, label)				\
 	do{											\
 		if (ltfs_is_interrupted()) {			\
-			ltfsmsg(LTFS_INFO, "17159I");		\
+			ltfsmsg(LTFS_INFO, 17159I);		\
 			rc = -LTFS_INTERRUPTED;				\
 			goto label;							\
 		}										\
@@ -177,7 +177,7 @@ struct device_data;
 #define INTERRUPTED_RETURN()					\
 	do{											\
 		if (ltfs_is_interrupted()) {			\
-			ltfsmsg(LTFS_INFO, "17159I");		\
+			ltfsmsg(LTFS_INFO, 17159I);		\
 			return -LTFS_INTERRUPTED;			\
 		}										\
 	}while (0)

--- a/src/libltfs/ltfs_fsops.c
+++ b/src/libltfs/ltfs_fsops.c
@@ -85,7 +85,7 @@ int ltfs_fsops_open(const char *path, bool open_write, bool use_iosched, struct 
 	if (ret == -LTFS_INVALID_PATH)
 		return -LTFS_INVALID_SRC_PATH;
 	else if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11039E", ret);
+		ltfsmsg(LTFS_ERR, 11039E, ret);
 		return ret;
 	}
 
@@ -131,7 +131,7 @@ int ltfs_fsops_open_combo(const char *path, bool open_write, bool use_iosched,
 	if (ret == -LTFS_INVALID_PATH)
 		return -LTFS_INVALID_SRC_PATH;
 	else if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11039E", ret);
+		ltfsmsg(LTFS_ERR, 11039E, ret);
 		return ret;
 	}
 
@@ -248,7 +248,7 @@ int ltfs_fsops_create(const char *path, bool isdir, bool readonly, bool overwrit
 		return ret;
 	ret = ltfs_test_unit_ready(vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11047E");
+		ltfsmsg(LTFS_ERR, 11047E);
 		return ret;
 	}
 
@@ -256,7 +256,7 @@ int ltfs_fsops_create(const char *path, bool isdir, bool readonly, bool overwrit
 	ret = pathname_format(path, &path_norm, true, true);
 	if (ret < 0) {
 		if (ret != -LTFS_INVALID_PATH)
-			ltfsmsg(LTFS_ERR, "11048E", ret);
+			ltfsmsg(LTFS_ERR, 11048E, ret);
 		return ret;
 	}
 
@@ -271,7 +271,7 @@ int ltfs_fsops_create(const char *path, bool isdir, bool readonly, bool overwrit
 	if (dcache_initialized(vol)) {
 		ret = asprintf(&dentry_path, "%s/%s", path_norm, filename);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "10001E", "ltfs_fsops_create: dentry_path");
+			ltfsmsg(LTFS_ERR, 10001E, "ltfs_fsops_create: dentry_path");
 			goto out_dispose;
 		}
 	}
@@ -280,17 +280,17 @@ int ltfs_fsops_create(const char *path, bool isdir, bool readonly, bool overwrit
 	ret = fs_path_lookup(path_norm, LOCK_DENTRY_CONTENTS_W, &parent, vol->index);
 	if (ret < 0) {
 		if (ret != -LTFS_NO_DENTRY && ret != -LTFS_NAMETOOLONG)
-			ltfsmsg(LTFS_ERR, "11049E", ret);
+			ltfsmsg(LTFS_ERR, 11049E, ret);
 		goto out_free;
 	}
 
 	if (parent->is_immutable) {
-		ltfsmsg(LTFS_ERR, "17237E", "create: parent is immutable");
+		ltfsmsg(LTFS_ERR, 17237E, "create: parent is immutable");
 		ret = -LTFS_WORM_ENABLED;
 		goto out_dispose;
 	}
     if (parent->is_appendonly && overwrite) {
-		ltfsmsg(LTFS_ERR, "17237E", "create: overwrite under appendonly dir");
+		ltfsmsg(LTFS_ERR, 17237E, "create: overwrite under appendonly dir");
 		ret = -LTFS_WORM_ENABLED;
 		goto out_dispose;
 	}
@@ -300,7 +300,7 @@ int ltfs_fsops_create(const char *path, bool isdir, bool readonly, bool overwrit
 
 	if (ret < 0) {
 		if (ret != -LTFS_NAMETOOLONG)
-			ltfsmsg(LTFS_ERR, "11049E", ret);
+			ltfsmsg(LTFS_ERR, 11049E, ret);
 		goto out_dispose;
 	} else if (d) {
 		releasewrite_mrsw(&parent->contents_lock);
@@ -316,7 +316,7 @@ int ltfs_fsops_create(const char *path, bool isdir, bool readonly, bool overwrit
 	/* Allocate and set up the dentry */
 	d = fs_allocate_dentry(NULL, NULL, filename, isdir, readonly, true, vol->index);
 	if (! d) {
-		ltfsmsg(LTFS_ERR, "11167E");
+		ltfsmsg(LTFS_ERR, 11167E);
 		ret = -LTFS_NO_MEMORY;
 		goto out_dispose;
 	}
@@ -350,7 +350,7 @@ int ltfs_fsops_create(const char *path, bool isdir, bool readonly, bool overwrit
 	d->child_list=NULL;
 	d->parent->child_list = fs_add_key_to_hash_table(d->parent->child_list, d, &ret);
 	if (ret != 0) {
-		ltfsmsg(LTFS_ERR, "11319E", "ltfs_fsops_create", ret);
+		ltfsmsg(LTFS_ERR, 11319E, "ltfs_fsops_create", ret);
 		releasewrite_mrsw(&d->meta_lock);
 		releasewrite_mrsw(&parent->meta_lock);
 		goto out_dispose;
@@ -385,7 +385,7 @@ out_dispose:
 		ltfs_file_id id;
 		ret = ltfs_fsops_setxattr(path, "user.ltfs.vendor.IBM.appendonly", "1", 1, 0, &id, vol);
 		if (ret != 0) {
-			ltfsmsg(LTFS_ERR, "17237E", "create: failed to set appendonly");
+			ltfsmsg(LTFS_ERR, 17237E, "create: failed to set appendonly");
 			dcache_unlink(dentry_path, d, vol);
 			fs_release_dentry(d);
 		}
@@ -420,7 +420,7 @@ int ltfs_fsops_unlink(const char *path, ltfs_file_id *id, struct ltfs_volume *vo
 		return ret;
 	ret = ltfs_test_unit_ready(vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11050E");
+		ltfsmsg(LTFS_ERR, 11050E);
 		return ret;
 	}
 
@@ -429,7 +429,7 @@ int ltfs_fsops_unlink(const char *path, ltfs_file_id *id, struct ltfs_volume *vo
 	if (ret == -LTFS_INVALID_PATH)
 		return -LTFS_INVALID_SRC_PATH;
 	else if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11051E", ret);
+		ltfsmsg(LTFS_ERR, 11051E, ret);
 		return ret;
 	}
 
@@ -449,7 +449,7 @@ int ltfs_fsops_unlink(const char *path, ltfs_file_id *id, struct ltfs_volume *vo
 	ret = fs_path_lookup(path_norm, LOCK_PARENT_CONTENTS_W, &d, vol->index);
 	if (ret < 0) {
 		if (ret != -LTFS_NO_DENTRY && ret != -LTFS_NAMETOOLONG)
-			ltfsmsg(LTFS_ERR, "11052E", ret);
+			ltfsmsg(LTFS_ERR, 11052E, ret);
 		releaseread_mrsw(&vol->lock);
 		free(path_norm);
 		return ret;
@@ -457,12 +457,12 @@ int ltfs_fsops_unlink(const char *path, ltfs_file_id *id, struct ltfs_volume *vo
 	parent = d->parent;
 
 	if (parent->is_immutable || parent->is_appendonly) {
-		ltfsmsg(LTFS_ERR, "17237E", "unlink: parent is WORM");
+		ltfsmsg(LTFS_ERR, 17237E, "unlink: parent is WORM");
 		ret = -LTFS_WORM_ENABLED;
 		goto out;
 	}
 	if (d->is_immutable || d->is_appendonly) {
-		ltfsmsg(LTFS_ERR, "17237E", "unlink: WORM ently");
+		ltfsmsg(LTFS_ERR, 17237E, "unlink: WORM ently");
 		ret = -LTFS_WORM_ENABLED;
 		goto out;
 	}
@@ -503,7 +503,7 @@ int ltfs_fsops_unlink(const char *path, ltfs_file_id *id, struct ltfs_volume *vo
 		free(namelist);
 	}
 	else {
-		ltfsmsg(LTFS_ERR, "11320E", "ltfs_fsops_unlink", ret);
+		ltfsmsg(LTFS_ERR, 11320E, "ltfs_fsops_unlink", ret);
 		releasewrite_mrsw(&d->meta_lock);
 		goto out;
 	}
@@ -564,7 +564,7 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 		return ret;
 	ret = ltfs_test_unit_ready(vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11053E");
+		ltfsmsg(LTFS_ERR, 11053E);
 		return ret;
 	}
 
@@ -573,13 +573,13 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 	if (ret == -LTFS_INVALID_PATH)
 		return -LTFS_INVALID_SRC_PATH;
 	else if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11054E", ret);
+		ltfsmsg(LTFS_ERR, 11054E, ret);
 		return ret;
 	}
 	ret = pathname_format(to, &to_norm, true, true);
 	if (ret < 0) {
 		if (ret != -LTFS_INVALID_PATH)
-			ltfsmsg(LTFS_ERR, "11055E", ret);
+			ltfsmsg(LTFS_ERR, 11055E, ret);
 		goto out_free;
 	}
 
@@ -587,7 +587,7 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 		from_norm_copy = strdup(from_norm);
 		to_norm_copy = strdup(to_norm);
 		if (! from_norm_copy || ! to_norm_copy) {
-			ltfsmsg(LTFS_ERR, "10001E", "ltfs_fsops_rename: file name copy");
+			ltfsmsg(LTFS_ERR, 10001E, "ltfs_fsops_rename: file name copy");
 			ret = -LTFS_NO_MEMORY;
 			goto out_free;
 		}
@@ -601,7 +601,7 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 	to_filename_copy = strdup(to_filename);
 	to_filename_copy2 = strdup(to_filename);
 	if (! to_filename_copy || ! to_filename_copy2) {
-		ltfsmsg(LTFS_ERR, "10001E", "ltfs_fsops_rename: file name copy");
+		ltfsmsg(LTFS_ERR, 10001E, "ltfs_fsops_rename: file name copy");
 		ret = -LTFS_NO_MEMORY;
 		goto out_free;
 	}
@@ -623,27 +623,27 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 	ret = fs_path_lookup(from_norm, 0, &fromdir, vol->index);
 	if (ret < 0) {
 		if (ret != -LTFS_NO_DENTRY && ret != -LTFS_NAMETOOLONG)
-			ltfsmsg(LTFS_ERR, "11056E", ret);
+			ltfsmsg(LTFS_ERR, 11056E, ret);
 		goto out_release;
 	}
 
 	ret = fs_path_lookup(to_norm, 0, &todir, vol->index);
 	if (ret < 0) {
 		if (ret != -LTFS_NO_DENTRY && ret != -LTFS_NAMETOOLONG)
-			ltfsmsg(LTFS_ERR, "11057E", ret);
+			ltfsmsg(LTFS_ERR, 11057E, ret);
 		/* fromdir meta_lock is needed because the exit code calls fs_release_dentry_unlocked */
 		acquirewrite_mrsw(&fromdir->meta_lock);
 		goto out_release;
 	}
 
 	if (fromdir->is_appendonly || fromdir->is_immutable ) {
-		ltfsmsg(LTFS_ERR, "17237E", "rename: parent is WORM");
+		ltfsmsg(LTFS_ERR, 17237E, "rename: parent is WORM");
 		ret = -LTFS_WORM_ENABLED;
 		acquirewrite_mrsw(&fromdir->meta_lock);
 		goto out_release;
 	}
 	if (todir->is_immutable || todir->is_appendonly) {
-		ltfsmsg(LTFS_ERR, "17237E", "rename: target dir is WORM");
+		ltfsmsg(LTFS_ERR, 17237E, "rename: target dir is WORM");
 		ret = -LTFS_WORM_ENABLED;
 		acquirewrite_mrsw(&fromdir->meta_lock);
 		goto out_release;
@@ -661,14 +661,14 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 		}
 		if (ret < 0) {
 			if (ret != -LTFS_NAMETOOLONG)
-				ltfsmsg(LTFS_ERR, "11057E", ret);
+				ltfsmsg(LTFS_ERR, 11057E, ret);
 			goto out_unlock;
 		}
 
 		ret = fs_directory_lookup(fromdir, from_filename, &fromdentry);
 		if (ret < 0 || ! fromdentry) {
 			if (ret < 0 && ret != -LTFS_NAMETOOLONG)
-				ltfsmsg(LTFS_ERR, "11056E", ret);
+				ltfsmsg(LTFS_ERR, 11056E, ret);
 			if (! fromdentry)
 				ret = -LTFS_NO_DENTRY;
 			if (todentry) {
@@ -688,7 +688,7 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 		acquirewrite_mrsw(&todir->meta_lock);
 		if (ret < 0) {
 			if (ret != -LTFS_NAMETOOLONG)
-				ltfsmsg(LTFS_ERR, "11056E", ret);
+				ltfsmsg(LTFS_ERR, 11056E, ret);
 			goto out_unlock;
 		} else if (! fromdentry) {
 			ret = -LTFS_NO_DENTRY;
@@ -698,7 +698,7 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 		ret = fs_directory_lookup(todir, to_filename, &todentry);
 		if (ret < 0) {
 			if (ret != -LTFS_NAMETOOLONG)
-				ltfsmsg(LTFS_ERR, "11057E", ret);
+				ltfsmsg(LTFS_ERR, 11057E, ret);
 			if (fromdentry) { /* BEAM: constant condition - fromdentry has always non-zero value here. */
 				if (fromdentry == todir)
 					--fromdentry->numhandles;
@@ -747,7 +747,7 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 	 * causes an unexpected move.
 	 */
 	if (fromdentry->isdir && fromdir != todir) {
-		ltfsmsg(LTFS_INFO, "11259I");
+		ltfsmsg(LTFS_INFO, 11259I);
 		ret = -LTFS_DIRMOVE;
 		if (todentry && fromdentry != todentry)
 			fs_release_dentry(todentry);
@@ -757,13 +757,13 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 #endif
 
 	if (fromdentry->is_immutable || fromdentry->is_appendonly) {
-		ltfsmsg(LTFS_ERR, "17237E", "rename: src entry is WORM");
+		ltfsmsg(LTFS_ERR, 17237E, "rename: src entry is WORM");
 		ret = -LTFS_WORM_ENABLED;
 		fs_release_dentry(fromdentry);
 		goto out_unlock;
 	}
 	else if (todentry && (todentry->is_immutable || todentry->is_appendonly)) {
-		ltfsmsg(LTFS_ERR, "17237E", "rename: target entry is WORM");
+		ltfsmsg(LTFS_ERR, 17237E, "rename: target entry is WORM");
 		ret = -LTFS_WORM_ENABLED;
 		fs_release_dentry(fromdentry);  // fromdentry != todentry befause fromdentry is not immutable/appendonly
 		fs_release_dentry(todentry);
@@ -800,7 +800,7 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 			free(namelist);
 		}
 		else {
-			ltfsmsg(LTFS_ERR, "11320E", "ltfs_fsops_rename", ret);
+			ltfsmsg(LTFS_ERR, 11320E, "ltfs_fsops_rename", ret);
 			releasewrite_mrsw(&todentry->meta_lock);
 			goto out_unlock;
 		}
@@ -824,7 +824,7 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 		free(namelist);
 	}
 	else {
-		ltfsmsg(LTFS_ERR, "11320E", "ltfs_fsops_rename", ret);
+		ltfsmsg(LTFS_ERR, 11320E, "ltfs_fsops_rename", ret);
 		releasewrite_mrsw(&fromdentry->meta_lock);
 		goto out_unlock;
 	}
@@ -857,7 +857,7 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 	/* Add fromdentry to new directory */
 	todir->child_list = fs_add_key_to_hash_table(todir->child_list, fromdentry, &ret);
 	if (ret != 0) {
-		ltfsmsg(LTFS_ERR, "11319E", "ltfs_fsops_rename", ret);
+		ltfsmsg(LTFS_ERR, 11319E, "ltfs_fsops_rename", ret);
 		releasewrite_mrsw(&fromdentry->meta_lock);
 		goto out_unlock;
 	}
@@ -1016,7 +1016,7 @@ int ltfs_fsops_setxattr(const char *path, const char *name, const char *value, s
 	ret = ltfs_test_unit_ready(vol);
 	if (ret < 0) {
 		/* Cannot set extended attribute: device is not ready */
-		ltfsmsg(LTFS_ERR, "11117E");
+		ltfsmsg(LTFS_ERR, 11117E);
 		return ret;
 	}
 
@@ -1027,13 +1027,13 @@ int ltfs_fsops_setxattr(const char *path, const char *name, const char *value, s
 	else if (ret == -LTFS_NAMETOOLONG)
 		return ret;
 	else if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11118E", ret);
+		ltfsmsg(LTFS_ERR, 11118E, ret);
 		return ret;
 	}
 	ret = pathname_format(name, &new_name, true, false);
 	if (ret < 0) {
 		if (ret != -LTFS_INVALID_PATH && ret != -LTFS_NAMETOOLONG)
-			ltfsmsg(LTFS_ERR, "11119E", ret);
+			ltfsmsg(LTFS_ERR, 11119E, ret);
 		goto out_free;
 	}
 
@@ -1046,7 +1046,7 @@ int ltfs_fsops_setxattr(const char *path, const char *name, const char *value, s
 	ret = pathname_validate_xattr_name(new_name_strip);
 	if (ret < 0) {
 		if (ret != -LTFS_INVALID_PATH && ret != -LTFS_NAMETOOLONG) /* normal errors */
-			ltfsmsg(LTFS_ERR, "11120E", ret);
+			ltfsmsg(LTFS_ERR, 11120E, ret);
 		goto out_free;
 	}
 
@@ -1056,7 +1056,7 @@ start:
 	if (! strcmp(new_name_strip, "ltfs.sync") && ! strcmp(path, "/")) {
 		ret = ltfs_fsops_flush(NULL, false, vol);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "11325E", ret);
+			ltfsmsg(LTFS_ERR, 11325E, ret);
 			goto out_free;
 		}
 		ret = ltfs_get_volume_lock(true, vol);
@@ -1074,7 +1074,7 @@ start:
 		ret = fs_path_lookup(new_path, 0, &d, vol->index);
 	if (ret < 0) {
 		if (ret != -LTFS_NO_DENTRY && ret != -LTFS_NAMETOOLONG) /* normal errors */
-			ltfsmsg(LTFS_ERR, "11121E", ret);
+			ltfsmsg(LTFS_ERR, 11121E, ret);
 		release_mrsw(&vol->lock);
 		goto out_free;
 	}
@@ -1132,7 +1132,7 @@ int ltfs_fsops_getxattr(const char *path, const char *name, char *value, size_t 
 	CHECK_ARG_NULL(name, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(vol, -LTFS_NULL_ARG);
 	if (size > 0 && ! value) {
-		ltfsmsg(LTFS_ERR, "11123E");
+		ltfsmsg(LTFS_ERR, 11123E);
 		return -LTFS_BAD_ARG;
 	}
 
@@ -1143,13 +1143,13 @@ int ltfs_fsops_getxattr(const char *path, const char *name, char *value, size_t 
 	else if (ret == -LTFS_NAMETOOLONG)
 		return ret;
 	else if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11124E", ret);
+		ltfsmsg(LTFS_ERR, 11124E, ret);
 		return ret;
 	}
 	ret = pathname_format(name, &new_name, true, false);
 	if (ret < 0) {
 		if (ret != -LTFS_INVALID_PATH && ret != -LTFS_NAMETOOLONG)
-			ltfsmsg(LTFS_ERR, "11125E", ret);
+			ltfsmsg(LTFS_ERR, 11125E, ret);
 		goto out_free;
 	}
 	new_name_strip = _xattr_strip_name(new_name);
@@ -1161,7 +1161,7 @@ int ltfs_fsops_getxattr(const char *path, const char *name, char *value, size_t 
 	ret = pathname_validate_xattr_name(new_name_strip);
 	if (ret < 0) {
 		if (ret != -LTFS_INVALID_PATH && ret != -LTFS_NAMETOOLONG) /* normal errors */
-			ltfsmsg(LTFS_ERR, "11126E", ret);
+			ltfsmsg(LTFS_ERR, 11126E, ret);
 		goto out_free;
 	}
 
@@ -1177,7 +1177,7 @@ start:
 		ret = fs_path_lookup(new_path, 0, &d, vol->index);
 	if (ret < 0) {
 		if (ret != -LTFS_NO_DENTRY && ret != -LTFS_NAMETOOLONG) /* normal errors */
-			ltfsmsg(LTFS_ERR, "11127E", ret);
+			ltfsmsg(LTFS_ERR, 11127E, ret);
 		releaseread_mrsw(&vol->lock);
 		goto out_free;
 	}
@@ -1216,7 +1216,7 @@ int ltfs_fsops_listxattr(const char *path, char *list, size_t size, ltfs_file_id
 	CHECK_ARG_NULL(path, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(vol, -LTFS_NULL_ARG);
 	if (size > 0 && ! list) {
-		ltfsmsg(LTFS_ERR, "11130E");
+		ltfsmsg(LTFS_ERR, 11130E);
 		return -LTFS_BAD_ARG;
 	}
 
@@ -1226,7 +1226,7 @@ int ltfs_fsops_listxattr(const char *path, char *list, size_t size, ltfs_file_id
 	else if (ret == -LTFS_NAMETOOLONG)
 		return ret;
 	else if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11131E", ret);
+		ltfsmsg(LTFS_ERR, 11131E, ret);
 		return ret;
 	}
 
@@ -1242,7 +1242,7 @@ int ltfs_fsops_listxattr(const char *path, char *list, size_t size, ltfs_file_id
 		ret = fs_path_lookup(new_path, 0, &d, vol->index);
 	if (ret < 0) {
 		if (ret != -LTFS_NO_DENTRY && ret != -LTFS_NAMETOOLONG) /* normal errors */
-			ltfsmsg(LTFS_ERR, "11132E", ret);
+			ltfsmsg(LTFS_ERR, 11132E, ret);
 		free(new_path);
 		releaseread_mrsw(&vol->lock);
 		return ret;
@@ -1284,7 +1284,7 @@ int ltfs_fsops_removexattr(const char *path, const char *name, ltfs_file_id *id,
 	ret = ltfs_test_unit_ready(vol);
 	if (ret < 0) {
 		/* Cannot remove extended attribute: device is not ready */
-		ltfsmsg(LTFS_ERR, "11135E");
+		ltfsmsg(LTFS_ERR, 11135E);
 		return ret;
 	}
 
@@ -1295,13 +1295,13 @@ int ltfs_fsops_removexattr(const char *path, const char *name, ltfs_file_id *id,
 	else if (ret == -LTFS_NAMETOOLONG)
 		return ret;
 	else if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11136E", ret);
+		ltfsmsg(LTFS_ERR, 11136E, ret);
 		return ret;
 	}
 	ret = pathname_format(name, &new_name, true, false);
 	if (ret < 0) {
 		if (ret != -LTFS_INVALID_PATH && ret != -LTFS_NAMETOOLONG)
-			ltfsmsg(LTFS_ERR, "11137E", ret);
+			ltfsmsg(LTFS_ERR, 11137E, ret);
 		goto out_free;
 	}
 	new_name_strip = _xattr_strip_name(new_name);
@@ -1313,7 +1313,7 @@ int ltfs_fsops_removexattr(const char *path, const char *name, ltfs_file_id *id,
 	ret = pathname_validate_xattr_name(new_name_strip);
 	if (ret < 0) {
 		if (ret != -LTFS_INVALID_PATH && ret != -LTFS_NAMETOOLONG) /* normal errors */
-			ltfsmsg(LTFS_ERR, "11138E", ret);
+			ltfsmsg(LTFS_ERR, 11138E, ret);
 		goto out_free;
 	}
 
@@ -1328,7 +1328,7 @@ int ltfs_fsops_removexattr(const char *path, const char *name, ltfs_file_id *id,
 		ret = fs_path_lookup(new_path, 0, &d, vol->index);
 	if (ret < 0) {
 		if (ret != -LTFS_NO_DENTRY && ret != -LTFS_NAMETOOLONG)
-			ltfsmsg(LTFS_ERR, "11139E", ret);
+			ltfsmsg(LTFS_ERR, 11139E, ret);
 		releaseread_mrsw(&vol->lock);
 		goto out_free;
 	}
@@ -1543,7 +1543,7 @@ int ltfs_fsops_utimens(struct dentry *d, const struct ltfs_timespec ts[2], struc
 		return ret;
 	ret = ltfs_test_unit_ready(vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11045E");
+		ltfsmsg(LTFS_ERR, 11045E);
 		return ret;
 	}
 
@@ -1556,8 +1556,8 @@ int ltfs_fsops_utimens(struct dentry *d, const struct ltfs_timespec ts[2], struc
 		d->access_time = ts[0];
 		ret = normalize_ltfs_time(&d->access_time);
 		if (ret == LTFS_TIME_OUT_OF_RANGE)
-			ltfsmsg(LTFS_WARN, "17217W", "atime",
-					d->platform_safe_name, d->uid, ts[0].tv_sec);
+			ltfsmsg(LTFS_WARN, 17217W, "atime",
+					d->platform_safe_name, (unsigned long long)d->uid, (unsigned long long)ts[0].tv_sec);
 		get_current_timespec(&d->change_time);
 		ltfs_set_index_dirty(true, true, vol->index);
 		d->dirty = true;
@@ -1566,8 +1566,8 @@ int ltfs_fsops_utimens(struct dentry *d, const struct ltfs_timespec ts[2], struc
 		d->modify_time = ts[1];
 		ret = normalize_ltfs_time(&d->modify_time);
 		if (ret == LTFS_TIME_OUT_OF_RANGE)
-			ltfsmsg(LTFS_WARN, "17217W", "mtime",
-					d->platform_safe_name, d->uid, ts[1].tv_sec);
+			ltfsmsg(LTFS_WARN, 17217W, "mtime",
+					d->platform_safe_name, (unsigned long long)d->uid, (unsigned long long)ts[1].tv_sec);
 		get_current_timespec(&d->change_time);
 		ltfs_set_index_dirty(true, false, vol->index);
 		d->dirty = true;
@@ -1619,7 +1619,7 @@ int ltfs_fsops_utimens_all(struct dentry *d, const struct ltfs_timespec ts[4], s
 		return ret;
 	ret = ltfs_test_unit_ready(vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11045E");
+		ltfsmsg(LTFS_ERR, 11045E);
 		return ret;
 	}
 
@@ -1633,8 +1633,8 @@ int ltfs_fsops_utimens_all(struct dentry *d, const struct ltfs_timespec ts[4], s
 		d->change_time = ts[3];
 		ret = normalize_ltfs_time(&d->change_time);
 		if (ret == LTFS_TIME_OUT_OF_RANGE)
-			ltfsmsg(LTFS_WARN, "17217W", "ctime",
-					d->platform_safe_name, d->uid, ts[3].tv_sec);
+			ltfsmsg(LTFS_WARN, 17217W, "ctime",
+					d->platform_safe_name, (unsigned long long)d->uid, (unsigned long long)ts[3].tv_sec);
 		isctime=true;
 		ltfs_set_index_dirty(true, false, vol->index);
 		d->dirty = true;
@@ -1643,8 +1643,8 @@ int ltfs_fsops_utimens_all(struct dentry *d, const struct ltfs_timespec ts[4], s
 		d->access_time = ts[0];
 		ret = normalize_ltfs_time(&d->access_time);
 		if (ret == LTFS_TIME_OUT_OF_RANGE)
-			ltfsmsg(LTFS_WARN, "17217W", "atime",
-					d->platform_safe_name, d->uid, ts[0].tv_sec);
+			ltfsmsg(LTFS_WARN, 17217W, "atime",
+					d->platform_safe_name, (unsigned long long)d->uid, (unsigned long long)ts[0].tv_sec);
 		if(!isctime) get_current_timespec(&d->change_time);
 		ltfs_set_index_dirty(true, true, vol->index);
 		d->dirty = true;
@@ -1653,8 +1653,8 @@ int ltfs_fsops_utimens_all(struct dentry *d, const struct ltfs_timespec ts[4], s
 		d->modify_time = ts[1];
 		ret = normalize_ltfs_time(&d->modify_time);
 		if (ret == LTFS_TIME_OUT_OF_RANGE)
-			ltfsmsg(LTFS_WARN, "17217W", "mtime",
-					d->platform_safe_name, d->uid, ts[1].tv_sec);
+			ltfsmsg(LTFS_WARN, 17217W, "mtime",
+					d->platform_safe_name, (unsigned long long)d->uid, (unsigned long long)ts[1].tv_sec);
 		if(!isctime) get_current_timespec(&d->change_time);
 		ltfs_set_index_dirty(true, false, vol->index);
 		d->dirty = true;
@@ -1663,8 +1663,8 @@ int ltfs_fsops_utimens_all(struct dentry *d, const struct ltfs_timespec ts[4], s
 		d->creation_time = ts[2];
 		ret = normalize_ltfs_time(&d->creation_time);
 		if (ret == LTFS_TIME_OUT_OF_RANGE)
-			ltfsmsg(LTFS_WARN, "17217W", "creation_time",
-					d->platform_safe_name, d->uid, ts[2].tv_sec);
+			ltfsmsg(LTFS_WARN, 17217W, "creation_time",
+					d->platform_safe_name, (unsigned long long)d->uid, (unsigned long long)ts[2].tv_sec);
 		if(!isctime) get_current_timespec(&d->change_time);
 		ltfs_set_index_dirty(true, false, vol->index);
 		d->dirty = true;
@@ -1693,7 +1693,7 @@ int ltfs_fsops_set_readonly(struct dentry *d, bool readonly, struct ltfs_volume 
 		return ret;
 	ret = ltfs_test_unit_ready(vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11046E");
+		ltfsmsg(LTFS_ERR, 11046E);
 		return ret;
 	}
 
@@ -1730,7 +1730,7 @@ int ltfs_fsops_set_readonly_path(const char *path, bool readonly, ltfs_file_id *
 		return ret;
 
 	if (d->is_appendonly || d->is_immutable) {
-		ltfsmsg(LTFS_ERR, "17237E", "chmod");
+		ltfsmsg(LTFS_ERR, 17237E, "chmod");
 		return -LTFS_WORM_ENABLED;
 	}
 
@@ -1754,7 +1754,7 @@ int ltfs_fsops_write(struct dentry *d, const char *buf, size_t count, off_t offs
 		return -LTFS_ISDIRECTORY;
 
 	if (d->is_immutable || (d->is_appendonly && (uint64_t) offset != d->size)) {
-		ltfsmsg(LTFS_ERR, "17237E", "write");
+		ltfsmsg(LTFS_ERR, 17237E, "write");
 		return -LTFS_WORM_ENABLED;
 	}
 
@@ -1808,7 +1808,7 @@ int ltfs_fsops_truncate(struct dentry *d, off_t length, struct ltfs_volume *vol)
 	CHECK_ARG_NULL(d, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(vol, -LTFS_NULL_ARG);
 	if (length < 0) {
-		ltfsmsg(LTFS_ERR, "11059E");
+		ltfsmsg(LTFS_ERR, 11059E);
 		return -LTFS_BAD_ARG;
 	} else if (d->isdir)
 		return -LTFS_ISDIRECTORY;
@@ -1818,13 +1818,13 @@ int ltfs_fsops_truncate(struct dentry *d, off_t length, struct ltfs_volume *vol)
 		return ret;
 
 	if (d->is_immutable || d->is_appendonly) {
-		ltfsmsg(LTFS_ERR, "17237E", "truncate");
+		ltfsmsg(LTFS_ERR, 17237E, "truncate");
 		return -LTFS_WORM_ENABLED;
 	}
 
 	ret = ltfs_test_unit_ready(vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11062E");
+		ltfsmsg(LTFS_ERR, 11062E);
 		return ret;
 	}
 
@@ -1898,7 +1898,7 @@ int ltfs_fsops_symlink_path(const char* to, const char* from, ltfs_file_id *id, 
 
 	if ( iosched_initialized(vol) ) use_iosche=true;
 
-	ltfsmsg(LTFS_DEBUG, "11322D", from, to);
+	ltfsmsg(LTFS_DEBUG, 11322D, from, to);
 
 	/* Create a node */
 	ret = ltfs_fsops_create(from, false, true, false, &d, vol);
@@ -1921,7 +1921,7 @@ int ltfs_fsops_symlink_path(const char* to, const char* from, ltfs_file_id *id, 
 		return -LTFS_NO_MEMORY;
 
 	size = strlen(value);
-	ltfsmsg(LTFS_DEBUG, "11323D", value);
+	ltfsmsg(LTFS_DEBUG, 11323D, value);
 	ret = xattr_set_mountpoint_length( d, value, size );
 	free(value);
 
@@ -1965,7 +1965,7 @@ int ltfs_fsops_readlink_path(const char* path, char* buf, size_t size, ltfs_file
 		memset( value, 0, sizeof(value));
 		ret = xattr_get(d, LTFS_LIVELINK_EA_NAME, value, sizeof(value), vol);
 		if ( ret > 0 ) {
-			ltfsmsg(LTFS_DEBUG, "11323D", value);
+			ltfsmsg(LTFS_DEBUG, 11323D, value);
 			ret = sscanf(value, "%d:%d", &num1, &num2);
 			if ( ( ret == 1 ) && ( num1 != 0 ) ){
 				memset( buf, 0, size);
@@ -1976,7 +1976,7 @@ int ltfs_fsops_readlink_path(const char* path, char* buf, size_t size, ltfs_file
 				strcpy(buf, vol->mountpoint);
 #endif
 				strcat(buf, d->target.name + num1);
-				ltfsmsg(LTFS_DEBUG, "11324D", d->target, buf);
+				ltfsmsg(LTFS_DEBUG, 11324D, d->target.name, buf);
 			}
 		}
 	}

--- a/src/libltfs/ltfs_fsops_raw.c
+++ b/src/libltfs/ltfs_fsops_raw.c
@@ -79,7 +79,7 @@ int ltfs_fsraw_open(const char *path, bool open_write, struct dentry **d, struct
 	if (ret < 0) {
 		/* Print message only if the error code is an unexpected one */
 		if (ret != -LTFS_NO_DENTRY && ret != -LTFS_NAMETOOLONG)
-			ltfsmsg(LTFS_ERR, "11040E", ret);
+			ltfsmsg(LTFS_ERR, 11040E, ret);
 		releaseread_mrsw(&vol->lock);
 		return ret;
 	}
@@ -128,7 +128,7 @@ int _ltfs_fsraw_write_data_unlocked(char partition, const char *buf, size_t coun
 
 	/* Validate partition ID */
 	if (partition != ltfs_dp_id(vol) && partition != ltfs_ip_id(vol)) {
-		ltfsmsg(LTFS_ERR, "11067E");
+		ltfsmsg(LTFS_ERR, 11067E);
 		writetoread_mrsw(&vol->lock);
 		return -LTFS_BAD_PARTNUM;
 	}
@@ -142,7 +142,7 @@ int _ltfs_fsraw_write_data_unlocked(char partition, const char *buf, size_t coun
 	/* Can only write multiple repetitions if the input buffer contains an integer
 	 * number of blocks */
 	if (repetitions > 1 && count % blocksize != 0) {
-		ltfsmsg(LTFS_ERR, "11068E");
+		ltfsmsg(LTFS_ERR, 11068E);
 		writetoread_mrsw(&vol->lock);
 		return -LTFS_BAD_ARG;
 	}
@@ -150,7 +150,7 @@ int _ltfs_fsraw_write_data_unlocked(char partition, const char *buf, size_t coun
 	/* Lock the device now, as we may need to issue multiple writes atomically */
 	ret = tape_device_lock(vol->device);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11004E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 11004E, __FUNCTION__);
 		writetoread_mrsw(&vol->lock);
 		return ret;
 	}
@@ -168,7 +168,7 @@ int _ltfs_fsraw_write_data_unlocked(char partition, const char *buf, size_t coun
 	else /* partition == ltfs_dp_id(vol) */
 		ret = ltfs_write_index_conditional(ltfs_ip_id(vol), vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11069E", ret);
+		ltfsmsg(LTFS_ERR, 11069E, ret);
 		writetoread_mrsw(&vol->lock);
 		goto out_unlock;
 	}
@@ -194,7 +194,7 @@ int _ltfs_fsraw_write_data_unlocked(char partition, const char *buf, size_t coun
 	/* Seek to partition append position (not necessarily end of data) */
 	ret = tape_seek_append_position(vol->device, ltfs_part_id2num(partition, vol), partition == vol->label->partid_ip);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11070E", partition);
+		ltfsmsg(LTFS_ERR, 11070E, partition);
 		goto out_unlock;
 	}
 
@@ -205,7 +205,7 @@ int _ltfs_fsraw_write_data_unlocked(char partition, const char *buf, size_t coun
 
 	ret = tape_get_position(vol->device, &start);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11071E", ret);
+		ltfsmsg(LTFS_ERR, 11071E, ret);
 		goto out_unlock;
 	}
 
@@ -221,7 +221,7 @@ int _ltfs_fsraw_write_data_unlocked(char partition, const char *buf, size_t coun
 			nwrite_last = tape_write(vol->device, buf + write_count, to_write, false, false);
 			if (nwrite_last < 0) {
 				ret = nwrite_last;
-				ltfsmsg(LTFS_ERR, "11072E", ret);
+				ltfsmsg(LTFS_ERR, 11072E, ret);
 				goto out_unlock;
 			}
 			write_count += to_write;
@@ -286,7 +286,7 @@ int _ltfs_fsraw_add_extent_unlocked(struct dentry *d, struct extent_info *ext, b
 	/* Copy the input extent now to avoid failing after the extent list has already been updated */
 	ext_copy = malloc(sizeof(struct extent_info));
 	if (! ext_copy) {
-		ltfsmsg(LTFS_ERR, "10001E", "ltfs_append_extent_unlocked: extent copy");
+		ltfsmsg(LTFS_ERR, 10001E, "ltfs_append_extent_unlocked: extent copy");
 		return -LTFS_NO_MEMORY;
 	}
 	*ext_copy = *ext;
@@ -331,7 +331,7 @@ int _ltfs_fsraw_add_extent_unlocked(struct dentry *d, struct extent_info *ext, b
 					/* Split entry */
 					splitentry = malloc(sizeof(struct extent_info));
 					if (! splitentry) {
-						ltfsmsg(LTFS_ERR, "10001E", "ltfs_append_extent_unlocked: splitentry");
+						ltfsmsg(LTFS_ERR, 10001E, "ltfs_append_extent_unlocked: splitentry");
 						free(ext_copy);
 						return -LTFS_NO_MEMORY;
 					}
@@ -454,7 +454,7 @@ int ltfs_fsraw_cleanup_extent(struct dentry *d, struct tc_position err_pos, unsi
 			else {
                 TAILQ_FOREACH_REVERSE_SAFE(ext, &entry->d->extentlist, extent_struct, list, preventry) {
 					if (err_pos.block <= (ext->start.block + ext->bytecount/blocksize)) {
-						ltfsmsg(LTFS_INFO, "11334I", entry->name, ext->start.block, ext->bytecount);
+						ltfsmsg(LTFS_INFO, 11334I, entry->name, (unsigned long long)ext->start.block, (unsigned long long)ext->bytecount);
 
 						ret = ltfs_get_volume_lock(false, vol);
 						if (ret < 0)
@@ -485,7 +485,7 @@ int ltfs_fsraw_write(struct dentry *d, const char *buf, size_t count, off_t offs
 	struct extent_info tmpext;
 	struct tape_offset logical_start = { .partition = partition, .block = 0 };
 
-	ltfsmsg(LTFS_DEBUG2, "11252D", d->platform_safe_name, (long long)offset, count);
+	ltfsmsg(LTFS_DEBUG2, 11252D, d->platform_safe_name, (long long)offset, (unsigned long long)count);
 
 	CHECK_ARG_NULL(d, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(buf, -LTFS_NULL_ARG);
@@ -508,7 +508,7 @@ start:
 		releaseread_mrsw(&vol->lock);
 		return ret;
 	} else if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11077E", ret);
+		ltfsmsg(LTFS_ERR, 11077E, ret);
 		releaseread_mrsw(&vol->lock);
 		return ret;
 	}
@@ -542,7 +542,7 @@ ssize_t ltfs_fsraw_read(struct dentry *d, char *buf, size_t count, off_t offset,
 	bool is_first_dp_locate = false;
 	struct ltfs_timespec ts_start, ts_end;
 
-	ltfsmsg(LTFS_DEBUG2, "11254D", d->platform_safe_name, (long long)offset, count);
+	ltfsmsg(LTFS_DEBUG2, 11254D, d->platform_safe_name, (long long)offset, (unsigned long long)count);
 
 	CHECK_ARG_NULL(vol, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(d, -LTFS_NULL_ARG);
@@ -567,7 +567,7 @@ start:
 		else
 			return ret;
 	} else if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11004E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 11004E, __FUNCTION__);
 		releaseread_mrsw(&d->contents_lock);
 		releaseread_mrsw(&vol->lock);
 		return ret;
@@ -577,7 +577,7 @@ start:
 	if (! vol->last_block) {
 		vol->last_block = malloc(vol->label->blocksize);
 		if (! vol->last_block) {
-			ltfsmsg(LTFS_ERR, "10001E", "ltfs_fsraw_read: block cache");
+			ltfsmsg(LTFS_ERR, 10001E, "ltfs_fsraw_read: block cache");
 			ret = -LTFS_NO_MEMORY;
 			goto out_unlock;
 		}
@@ -610,7 +610,7 @@ start:
 			/* Compute current position */
 			ret = tape_get_position(vol->device, &curpos);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "11085E", ret);
+				ltfsmsg(LTFS_ERR, 11085E, ret);
 				goto out_unlock;
 			}
 
@@ -634,7 +634,7 @@ start:
 
 				ret = tape_seek(vol->device, &seekpos);
 				if (ret < 0) {
-					ltfsmsg(LTFS_ERR, "11086E", ret, entry->start.partition, seekpos.block);
+					ltfsmsg(LTFS_ERR, 11086E, ret, entry->start.partition, (unsigned long long)seekpos.block);
 					goto out_unlock;
 				}
 
@@ -659,7 +659,7 @@ start:
 					seekpos.block == vol->last_pos.block &&
 					(seekpos.partition == curpos.partition && seekpos.block + 1 == curpos.block)) {
 					if (vol->last_size < blockbytes) {
-						ltfsmsg(LTFS_ERR, "11087E", blockbytes, vol->last_size);
+						ltfsmsg(LTFS_ERR, 11087E, (unsigned int)blockbytes, vol->last_size);
 						ret = -LTFS_SMALL_BLOCK;
 						goto out_unlock;
 					}
@@ -674,10 +674,10 @@ start:
 
 					if (nread < 0) {
 						ret = nread;
-						ltfsmsg(LTFS_ERR, "11088E", ret);
+						ltfsmsg(LTFS_ERR, 11088E, ret);
 						goto out_unlock;
 					} else if ((size_t) nread < blockbytes) {
-						ltfsmsg(LTFS_ERR, "11089E", blockbytes, (unsigned long)nread);
+						ltfsmsg(LTFS_ERR, 11089E, (unsigned int)blockbytes, (unsigned int)nread);
 						ret = -LTFS_SMALL_BLOCK;
 						goto out_unlock;
 					}
@@ -810,10 +810,10 @@ struct dentry *ltfs_fsraw_get_dentry(struct dentry *d, struct ltfs_volume *vol)
 void ltfs_fsraw_put_dentry(struct dentry *d, struct ltfs_volume *vol)
 {
 	if (! d) {
-		ltfsmsg(LTFS_WARN, "10006W", "d", __FUNCTION__);
+		ltfsmsg(LTFS_WARN, 10006W, "d", __FUNCTION__);
 		return;
 	} else if (! vol) {
-		ltfsmsg(LTFS_WARN, "10006W", "vol", __FUNCTION__);
+		ltfsmsg(LTFS_WARN, 10006W, "vol", __FUNCTION__);
 		return;
 	}
 	if (dcache_initialized(vol))

--- a/src/libltfs/ltfs_internal.c
+++ b/src/libltfs/ltfs_internal.c
@@ -80,27 +80,27 @@ int ltfs_index_alloc(struct ltfs_index **index, struct ltfs_volume *vol)
 
 	newindex = calloc(1, sizeof(struct ltfs_index));
 	if (!newindex) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 
 	ret = ltfs_mutex_init(&newindex->dirty_lock);
 	if (ret) {
-		ltfsmsg(LTFS_ERR, "11166E", ret);
+		ltfsmsg(LTFS_ERR, 11166E, ret);
 		ltfs_index_free(&newindex);
 		return -ret;
 	}
 
 	ret = ltfs_mutex_init(&newindex->refcount_lock);
 	if (ret) {
-		ltfsmsg(LTFS_ERR, "11166E", ret);
+		ltfsmsg(LTFS_ERR, 11166E, ret);
 		ltfs_index_free(&newindex);
 		return -ret;
 	}
 
 	ret = ltfs_mutex_init(&newindex->rename_lock);
 	if (ret) {
-		ltfsmsg(LTFS_ERR, "11166E", ret);
+		ltfsmsg(LTFS_ERR, 11166E, ret);
 		ltfs_index_free(&newindex);
 		return -ret;
 	}
@@ -112,7 +112,7 @@ int ltfs_index_alloc(struct ltfs_index **index, struct ltfs_volume *vol)
 
 	newindex->root = fs_allocate_dentry(NULL, "/", NULL, true, false, false, newindex);
 	if (! newindex->root) {
-		ltfsmsg(LTFS_ERR, "11168E");
+		ltfsmsg(LTFS_ERR, 11168E);
 		ltfs_index_free(&newindex);
 		return -LTFS_NO_MEMORY;
 	}
@@ -179,25 +179,25 @@ int ltfs_read_labels(bool trial, struct ltfs_volume *vol)
 
 	ret = label_alloc(&label0);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11169E", ret);
+		ltfsmsg(LTFS_ERR, 11169E, ret);
 		goto out_free;
 	}
 	ret = label_alloc(&label1);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11169E", ret);
+		ltfsmsg(LTFS_ERR, 11169E, ret);
 		goto out_free;
 	}
 
 	ret = ltfs_read_one_label(0, label0, vol);
 	if (ret < 0) {
 		if (! trial || ret != -LTFS_LABEL_INVALID)
-			ltfsmsg(LTFS_ERR, "11170E", ret);
+			ltfsmsg(LTFS_ERR, 11170E, ret);
 		goto out_free;
 	}
 	ret = ltfs_read_one_label(1, label1, vol);
 	if (ret < 0) {
 		if (! trial || ret != -LTFS_LABEL_INVALID)
-			ltfsmsg(LTFS_ERR, "11171E", ret);
+			ltfsmsg(LTFS_ERR, 11171E, ret);
 		goto out_free;
 	}
 
@@ -205,7 +205,7 @@ int ltfs_read_labels(bool trial, struct ltfs_volume *vol)
 	ret = label_compare(label0, label1);
 	if (ret < 0) {
 		if (! trial || ret != -LTFS_LABEL_MISMATCH)
-			ltfsmsg(LTFS_ERR, "11172E", ret);
+			ltfsmsg(LTFS_ERR, 11172E, ret);
 		goto out_free;
 	}
 
@@ -257,19 +257,19 @@ int ltfs_read_one_label(tape_partition_t partition, struct ltfs_label *label,
 
 	ret = tape_get_max_blocksize(vol->device, &bufsize);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17195E", "read label", ret);
+		ltfsmsg(LTFS_ERR, 17195E, "read label", ret);
 		return ret;
 	}
 
 	if (bufsize < LTFS_LABEL_MAX) {
-		ltfsmsg(LTFS_ERR, "17185E", bufsize);
+		ltfsmsg(LTFS_ERR, 17185E, bufsize);
 		return -LTFS_SMALL_BLOCKSIZE;
 	} else
 		bufsize = LTFS_LABEL_MAX;
 
 	buf = calloc(1, bufsize + LTFS_CRC_SIZE);
 	if (!buf) {
-		ltfsmsg(LTFS_ERR, "10001E", "ltfs_read_one_label: buffer");
+		ltfsmsg(LTFS_ERR, 10001E, "ltfs_read_one_label: buffer");
 		return -LTFS_NO_MEMORY;
 	}
 
@@ -278,7 +278,7 @@ int ltfs_read_one_label(tape_partition_t partition, struct ltfs_label *label,
 	seekpos.block = 0;
 	ret = tape_seek(vol->device, &seekpos);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11173E", ret, (unsigned long)partition);
+		ltfsmsg(LTFS_ERR, 11173E, ret, (unsigned long)partition);
 		/* Simple heuristic to detect an unpartitioned tape: seeking to partition 1 fails.
 		 * Note that the seek may fail for other reasons, which can't currently be distinguished
 		 * by looking at the backend return codes. */
@@ -291,18 +291,18 @@ int ltfs_read_one_label(tape_partition_t partition, struct ltfs_label *label,
 	memset(buf, 0, 81);
 	nread = tape_read(vol->device, buf, (size_t)bufsize, true, vol->kmi_handle);
 	if (nread < 0) {
-		ltfsmsg(LTFS_ERR, "11174E", (int)nread);
+		ltfsmsg(LTFS_ERR, 11174E, (int)nread);
 		if (nread == -EDEV_EOD_DETECTED || nread == -EDEV_RECORD_NOT_FOUND)
 			ret = -LTFS_LABEL_INVALID;
 		else
 			ret = nread;
 		goto out_free;
 	} else if (nread < 80) {
-		ltfsmsg(LTFS_ERR, "11175E", (int)nread);
+		ltfsmsg(LTFS_ERR, 11175E, (int)nread);
 		ret = -LTFS_LABEL_INVALID;
 		goto out_free;
 	} else if (nread > 80) {
-		ltfsmsg(LTFS_ERR, "11177E", (int)nread);
+		ltfsmsg(LTFS_ERR, 11177E, (int)nread);
 		too_long = true;
 	}
 
@@ -313,7 +313,7 @@ int ltfs_read_one_label(tape_partition_t partition, struct ltfs_label *label,
 	memcpy(ansi_sig, buf+24, 4);
 	ansi_sig[4] = '\0';
 	if (strcmp(ansi_sig, "LTFS")) {
-		ltfsmsg(LTFS_ERR, "11176E");
+		ltfsmsg(LTFS_ERR, 11176E);
 		ret = -LTFS_LABEL_INVALID;
 		goto out_free;
 	}
@@ -322,7 +322,7 @@ int ltfs_read_one_label(tape_partition_t partition, struct ltfs_label *label,
 	/* Check for file mark after ANSI label */
 	nread = tape_read(vol->device, buf, (size_t)bufsize, true, vol->kmi_handle);
 	if (nread < 0) {
-		ltfsmsg(LTFS_ERR, "11295E", (int)nread);
+		ltfsmsg(LTFS_ERR, 11295E, (int)nread);
 		if (nread == -EDEV_EOD_DETECTED)
 			ret = -LTFS_LABEL_INVALID;
 		else
@@ -330,7 +330,7 @@ int ltfs_read_one_label(tape_partition_t partition, struct ltfs_label *label,
 		goto out_free;
 	} else if (nread > 0) {
 		/* no file mark after ANSI label */
-		ltfsmsg(LTFS_ERR, "11296E");
+		ltfsmsg(LTFS_ERR, 11296E);
 		ret = -LTFS_LABEL_INVALID;
 		goto out_free;
 	}
@@ -338,7 +338,7 @@ int ltfs_read_one_label(tape_partition_t partition, struct ltfs_label *label,
 	/* Read XML label */
 	nread = tape_read(vol->device, buf, (size_t)bufsize, true, vol->kmi_handle);
 	if (nread < 0) {
-		ltfsmsg(LTFS_ERR, "11178E", (int)nread);
+		ltfsmsg(LTFS_ERR, 11178E, (int)nread);
 		if (nread == -EDEV_EOD_DETECTED)
 			ret = -LTFS_LABEL_INVALID;
 		else
@@ -347,14 +347,14 @@ int ltfs_read_one_label(tape_partition_t partition, struct ltfs_label *label,
 	}
 	ret = xml_label_from_mem(buf, nread, label);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11179E", ret);
+		ltfsmsg(LTFS_ERR, 11179E, ret);
 		goto out_free;
 	}
 
 	/* check for trailing file mark */
 	nread = tape_read(vol->device, buf, (size_t)bufsize, true, vol->kmi_handle);
 	if (nread < 0) {
-		ltfsmsg(LTFS_ERR, "11180E", (int)nread);
+		ltfsmsg(LTFS_ERR, 11180E, (int)nread);
 		if (nread == -EDEV_EOD_DETECTED)
 			ret = -LTFS_LABEL_INVALID;
 		else
@@ -362,7 +362,7 @@ int ltfs_read_one_label(tape_partition_t partition, struct ltfs_label *label,
 		goto out_free;
 	} else if (nread > 0) {
 		/* no file mark after XML label */
-		ltfsmsg(LTFS_ERR, "11181E");
+		ltfsmsg(LTFS_ERR, 11181E);
 		ret = -LTFS_LABEL_INVALID;
 		goto out_free;
 	}
@@ -398,14 +398,14 @@ int ltfs_read_index(uint64_t eod_pos, bool recover_symlink, struct ltfs_volume *
 
 	ret = tape_get_position(vol->device, &pos);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11193E", ret);
+		ltfsmsg(LTFS_ERR, 11193E, ret);
 		return ret;
 	}
 
 	ltfs_index_free(&vol->index);
 	ret = ltfs_index_alloc(&vol->index, vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11297E", ret);
+		ltfsmsg(LTFS_ERR, 11297E, ret);
 		return ret;
 	}
 
@@ -420,44 +420,44 @@ int ltfs_read_index(uint64_t eod_pos, bool recover_symlink, struct ltfs_volume *
 		}
 		else
 		{
-			ltfsmsg(LTFS_ERR, "11321E");
+			ltfsmsg(LTFS_ERR, 11321E);
 		}
 		free( vol->index->symlink_conflict );
 		vol->index->symerr_count=0;
 	}
 
 	if (ret < 0) {
-		ltfsmsg(LTFS_WARN, "11194W", ret);
+		ltfsmsg(LTFS_WARN, 11194W, ret);
 		return ret;
 	} else if (ret == 1)
 		end_fm = false;
 
 	/* check volume UUID */
 	if (strncmp(vol->index->vol_uuid, vol->label->vol_uuid, 36)) {
-		ltfsmsg(LTFS_WARN, "11195W");
+		ltfsmsg(LTFS_WARN, 11195W);
 		return -LTFS_INDEX_INVALID;
 	}
 
 	/* check self pointer */
 	if (vol->index->selfptr.partition != vol->label->part_num2id[pos.partition] ||
 		vol->index->selfptr.block != pos.block) {
-		ltfsmsg(LTFS_WARN, "11196W");
+		ltfsmsg(LTFS_WARN, 11196W);
 		return -LTFS_INDEX_INVALID;
 	}
 
 	/* basic back pointer checks */
 	if (vol->index->backptr.partition != 0 &&
 		vol->index->backptr.partition != vol->label->partid_dp) {
-		ltfsmsg(LTFS_ERR, "11197E");
+		ltfsmsg(LTFS_ERR, 11197E);
 		return -LTFS_INDEX_INVALID;
 	} else if (vol->index->backptr.partition == vol->index->selfptr.partition &&
 		vol->index->selfptr.block != 5 &&
 		vol->index->backptr.block != vol->index->selfptr.block &&
 		vol->index->backptr.block >= vol->index->selfptr.block - 2 ) {
-		ltfsmsg(LTFS_ERR, "11197E");
+		ltfsmsg(LTFS_ERR, 11197E);
 		return -LTFS_INDEX_INVALID;
 	} else if (vol->index->backptr.partition != 0 && vol->index->backptr.block < 5) {
-		ltfsmsg(LTFS_ERR, "11197E");
+		ltfsmsg(LTFS_ERR, 11197E);
 		return -LTFS_INDEX_INVALID;
 	}
 
@@ -465,7 +465,7 @@ int ltfs_read_index(uint64_t eod_pos, bool recover_symlink, struct ltfs_volume *
 	if (end_fm) {
 		ret = tape_spacefm(vol->device, 1);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "11198E", ret);
+			ltfsmsg(LTFS_ERR, 11198E, ret);
 			return ret;
 		}
 	}
@@ -485,7 +485,7 @@ bool ltfs_is_valid_partid(char id)
 	do { \
 		ret = (cmd); \
 		if (ret < 0) { \
-			ltfsmsg(LTFS_ERR, (msgid), ret); \
+			ltfsmsg(LTFS_ERR, msgid, ret); \
 			goto label; \
 		} \
 	} while (0)
@@ -516,51 +516,51 @@ int ltfs_seek_index(char partition, tape_block_t *eod_pos, tape_block_t *index_e
 	CHECK_ARG_NULL(blocks_after, -LTFS_NULL_ARG);
 
 	/* find EOD */
-	check_err(tape_seek_eod(vol->device, ltfs_part_id2num(partition, vol)), "11199E", out);
-	check_err(tape_get_position(vol->device, &eod), "11200E", out);
+	check_err(tape_seek_eod(vol->device, ltfs_part_id2num(partition, vol)), 11199E, out);
+	check_err(tape_get_position(vol->device, &eod), 11200E, out);
 	*eod_pos = eod.block;
 	if (eod.block <= 4) { /* nothing on the partition except the label */
 		return 1;
 	}
 
 	/* space back to the first candidate index file location */
-	check_err(tape_spacefm(vol->device, -1), "11201E", out);
-	check_err(tape_get_position(vol->device, &pos), "11200E", out);
+	check_err(tape_spacefm(vol->device, -1), 11201E, out);
+	check_err(tape_get_position(vol->device, &pos), 11200E, out);
 	if (pos.block == 3) { /* is this the end of the label? */
 		return 1;
 	} else if (pos.block == eod.block - 1)
-		check_err(tape_spacefm(vol->device, -1), "11201E", out);
+		check_err(tape_spacefm(vol->device, -1), 11201E, out);
 
 	have_index = false;
 	while (! have_index) {
 		/* did we reach the end of the partition label? */
-		check_err(tape_get_position(vol->device, &pos), "11200E", out);
+		check_err(tape_get_position(vol->device, &pos), 11200E, out);
 		if (pos.block == 3) {
 			return 1;
 		}
 
 		/* try to read an index file */
-		check_err(tape_spacefm(vol->device, 1), "11202E", out);
+		check_err(tape_spacefm(vol->device, 1), 11202E, out);
 		ret = ltfs_read_index(*eod_pos, recover_symlink, vol);
 
 		if (ret == 0 || ret == 1) { /* found an index file */
 			have_index = true;
 			*fm_after = (ret == 0);
-			check_err(tape_get_position(vol->device, &pos), "11200E", out);
+			check_err(tape_get_position(vol->device, &pos), 11200E, out);
 			*index_end_pos = pos.block;
 			*blocks_after = ! (pos.block == eod.block);
 		} else { /* no index file found: go back 2 file marks and try again */
-			ltfsmsg(LTFS_DEBUG, "11204D");
+			ltfsmsg(LTFS_DEBUG, 11204D);
 			if (!vol->ignore_wrong_version && ret == -LTFS_UNSUPPORTED_INDEX_VERSION)
 				goto out;
 			else
-				check_err(tape_spacefm(vol->device, -2), "11203E", out);
+				check_err(tape_spacefm(vol->device, -2), 11203E, out);
 		}
 	}
 
 	/* Check that partition searched is correct */
 	if (partition != vol->index->selfptr.partition) {
-		ltfsmsg(LTFS_ERR, "11328E", partition, vol->index->selfptr.partition);
+		ltfsmsg(LTFS_ERR, 11328E, partition, vol->index->selfptr.partition);
 		return -LTFS_INDEX_INVALID;
 	}
 
@@ -648,7 +648,7 @@ int _ltfs_check_pointers(struct ltfs_index *ip_index, struct ltfs_index *dp_inde
 	if (! dp_index) {
 		if (ip_index->backptr.partition != 0) {
 			/* IP backpointer to nonexistent DP index file */
-			ltfsmsg(LTFS_ERR, "11205E");
+			ltfsmsg(LTFS_ERR, 11205E);
 			return -LTFS_INDEX_INVALID;
 		} else {
 			/* IP index file is newer */
@@ -664,7 +664,7 @@ int _ltfs_check_pointers(struct ltfs_index *ip_index, struct ltfs_index *dp_inde
 			return 0;
 		} else if (ip_index->generation > dp_index->generation) {
 			/* IP backpointer doesn't match DP index file */
-			ltfsmsg(LTFS_ERR, "11206E");
+			ltfsmsg(LTFS_ERR, 11206E);
 			return -LTFS_INDEX_INVALID;
 		} else if (ip_index->generation == dp_index->generation &&
 				   ip_index->backptr.partition == 0) {
@@ -687,7 +687,7 @@ int _ltfs_check_pointers(struct ltfs_index *ip_index, struct ltfs_index *dp_inde
 				if (ip_index->backptr.partition == 0 &&
 					vol->index->generation < ip_index->generation) {
 					/* IP index file is missing its back pointer */
-					ltfsmsg(LTFS_ERR, "11207E");
+					ltfsmsg(LTFS_ERR, 11207E);
 					ltfs_index_free(&vol->index);
 					return -LTFS_INDEX_INVALID;
 				}
@@ -773,7 +773,7 @@ int _ltfs_populate_lost_found(char partition, tape_block_t part_lastref,
 			lf_dir = fs_allocate_dentry(vol->index->root, LTFS_LOSTANDFOUND_DIR, NULL, true, false, true,
 					vol->index);
 			if (! lf_dir) {
-				ltfsmsg(LTFS_ERR, "11209E");
+				ltfsmsg(LTFS_ERR, 11209E);
 				return -LTFS_NO_MEMORY;
 			}
 			++lf_dir->numhandles;
@@ -793,7 +793,7 @@ int _ltfs_populate_lost_found(char partition, tape_block_t part_lastref,
 
 	buf = malloc(vol->label->blocksize + LTFS_CRC_SIZE);
 	if (! buf) {
-		ltfsmsg(LTFS_ERR, "10001E", "_ltfs_populate_lost_found: buffer");
+		ltfsmsg(LTFS_ERR, 10001E, "_ltfs_populate_lost_found: buffer");
 		if (dcache_enabled)
 			dcache_close(lf_dir, true, lfdir_descend, vol);
 		else
@@ -804,7 +804,7 @@ int _ltfs_populate_lost_found(char partition, tape_block_t part_lastref,
 	/* Seek to first unreferenced block */
 	seekpos.partition = ltfs_part_id2num(partition, vol);
 	seekpos.block = (part_lastref > 4) ? part_lastref : 4;
-	check_err(tape_seek(vol->device, &seekpos), "11212E", out_free);
+	check_err(tape_seek(vol->device, &seekpos), 11212E, out_free);
 
 	/* Populate lost and found directory with index partition extents */
 	ret = 0;
@@ -816,13 +816,13 @@ int _ltfs_populate_lost_found(char partition, tape_block_t part_lastref,
 			 * to skip this block and continue on */
 			break;
 		} else if (nr == 0) {
-			ltfsmsg(LTFS_WARN, "11210W", (unsigned long)seekpos.partition);
+			ltfsmsg(LTFS_WARN, 11210W, (unsigned long)seekpos.partition);
 		} else {
 			/* generate a descriptive-but-probably-not-helpful filename */
 			ret = asprintf(&fname_path, "/%s/partition%"PRIu32"_block%"PRIu64"_%zdbytes",
 				LTFS_LOSTANDFOUND_DIR, seekpos.partition, seekpos.block, nr);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "10001E", "_ltfs_populate_lost_found: file name");
+				ltfsmsg(LTFS_ERR, 10001E, "_ltfs_populate_lost_found: file name");
 				ret = -LTFS_NO_MEMORY;
 				goto out_free;
 			}
@@ -845,7 +845,7 @@ int _ltfs_populate_lost_found(char partition, tape_block_t part_lastref,
 					free(fname_path);
 					if (ret < 0) {
 						/* Cannot populate lost and found directory: failed to allocate file data */
-						ltfsmsg(LTFS_ERR, "11211E");
+						ltfsmsg(LTFS_ERR, 11211E);
 						goto out_free;
 					}
 				} else {
@@ -853,7 +853,7 @@ int _ltfs_populate_lost_found(char partition, tape_block_t part_lastref,
 					free(fname_path);
 					if (! file) {
 						/* Cannot populate lost and found directory: failed to allocate file data */
-						ltfsmsg(LTFS_ERR, "11211E");
+						ltfsmsg(LTFS_ERR, 11211E);
 						ret = -LTFS_NO_MEMORY;
 						goto out_free;
 					}
@@ -861,7 +861,7 @@ int _ltfs_populate_lost_found(char partition, tape_block_t part_lastref,
 
 				ext = calloc(1, sizeof(struct extent_info));
 				if (! ext) {
-					ltfsmsg(LTFS_ERR, "10001E", "_ltfs_populate_lost_found: extent");
+					ltfsmsg(LTFS_ERR, 10001E, "_ltfs_populate_lost_found: extent");
 					ret = -LTFS_NO_MEMORY;
 					goto out_free;
 				}
@@ -999,7 +999,7 @@ int ltfs_check_medium(bool fix, bool deep, bool recover_extra, bool recover_syml
 
 	/* look for index files */
 	check_err(ltfs_seek_index(vol->label->partid_ip, &ip_eod, &ip_endofidx, &ip_fm_after,
-		&ip_blocks_after, recover_symlink, vol), "11214E", out_unlock);
+		&ip_blocks_after, recover_symlink, vol), 11214E, out_unlock);
 	ip_have_index = (ret == 0);
 	if (ip_have_index) {
 		ip_index = vol->index;
@@ -1007,7 +1007,7 @@ int ltfs_check_medium(bool fix, bool deep, bool recover_extra, bool recover_syml
 	}
 
 	check_err(ltfs_seek_index(vol->label->partid_dp, &dp_eod, &dp_endofidx, &dp_fm_after,
-		&dp_blocks_after, recover_symlink, vol), "11213E", out_unlock);
+		&dp_blocks_after, recover_symlink, vol), 11213E, out_unlock);
 	dp_have_index = (ret == 0);
 	if (dp_have_index) {
 		dp_index = vol->index;
@@ -1016,28 +1016,28 @@ int ltfs_check_medium(bool fix, bool deep, bool recover_extra, bool recover_syml
 
 	/* TODO: print more detailed diagnostic data here */
 	if (! ip_have_index && ! dp_have_index) {
-		ltfsmsg(LTFS_ERR, "11253E");
+		ltfsmsg(LTFS_ERR, 11253E);
 		ret = -LTFS_NO_INDEX;
 		goto out_unlock;
 	}
 
 	if (! ip_have_index)
-		ltfsmsg(LTFS_INFO, "11257I");
+		ltfsmsg(LTFS_INFO, 11257I);
 	if (! dp_have_index)
-		ltfsmsg(LTFS_INFO, "11258I");
+		ltfsmsg(LTFS_INFO, 11258I);
 
 	/* fill in missing file marks if necessary */
 	if (dp_have_index && ! dp_blocks_after && ! dp_fm_after) {
-		ltfsmsg(LTFS_INFO, "11255I");
-		check_err(tape_seek_eod(vol->device, dp_num), "11215E", out_unlock);
-		check_err(tape_write_filemark(vol->device, 1, true, true, false), "11217E", out_unlock);
+		ltfsmsg(LTFS_INFO, 11255I);
+		check_err(tape_seek_eod(vol->device, dp_num), 11215E, out_unlock);
+		check_err(tape_write_filemark(vol->device, 1, true, true, false), 11217E, out_unlock);
 		dp_fm_after = true;
 		++dp_eod;
 	}
 	if (ip_have_index && ! ip_blocks_after && ! ip_fm_after) {
-		ltfsmsg(LTFS_INFO, "11256I");
-		check_err(tape_seek_eod(vol->device, ip_num), "11216E", out_unlock);
-		check_err(tape_write_filemark(vol->device, 1, true, true, false), "11218E", out_unlock);
+		ltfsmsg(LTFS_INFO, 11256I);
+		check_err(tape_seek_eod(vol->device, ip_num), 11216E, out_unlock);
+		check_err(tape_write_filemark(vol->device, 1, true, true, false), 11218E, out_unlock);
 		ip_fm_after = true;
 		++ip_eod;
 	}
@@ -1047,19 +1047,19 @@ int ltfs_check_medium(bool fix, bool deep, bool recover_extra, bool recover_syml
 		(ip_have_index && ip_blocks_after) || (! ip_have_index && ip_eod != 4);
 
 	if (! deep && extra_blocks) {
-		ltfsmsg(LTFS_ERR, "11220E");
+		ltfsmsg(LTFS_ERR, 11220E);
 		ret = -LTFS_INCONSISTENT;
 		goto out_unlock;
 	}
 
 	/* Verify sanity of back/self pointers and Decide which index file to use. */
-	check_err(_ltfs_check_pointers(ip_index, dp_index, vol), "11219E", out_unlock);
+	check_err(_ltfs_check_pointers(ip_index, dp_index, vol), 11219E, out_unlock);
 
 	if (! dp_have_index && ! ip_have_index) {
 		/* no index file on the tape. set up an empty index. */
 		ltfs_index_free(&dp_index);
 		ltfs_index_free(&ip_index);
-		check_err(ltfs_index_alloc(&vol->index, vol), "11225E", out_unlock);
+		check_err(ltfs_index_alloc(&vol->index, vol), 11225E, out_unlock);
 		strcpy(vol->index->vol_uuid, vol->label->vol_uuid);
 		vol->index->mod_time = vol->label->format_time;
 		vol->index->root->creation_time = vol->index->mod_time;
@@ -1083,7 +1083,7 @@ int ltfs_check_medium(bool fix, bool deep, bool recover_extra, bool recover_syml
 				vol->index = ip_index;
 			ltfs_set_index_dirty(true, false, vol->index);
 		} else
-			ltfsmsg(LTFS_ERR, "11221E");
+			ltfsmsg(LTFS_ERR, 11221E);
 
 	} else {
 		/* we have index files on both partitions. return the newer index file. */
@@ -1101,16 +1101,16 @@ int ltfs_check_medium(bool fix, bool deep, bool recover_extra, bool recover_syml
 	/* Set append position for index partition. */
 	if (ip_have_index && ! ip_blocks_after) {
 		check_err(tape_set_append_position(vol->device, ip_num, ip_index->selfptr.block - 1),
-			"11222E", out_unlock);
+			11222E, out_unlock);
 	}
 
 	/* Recover extra blocks or schedule them to be erased. */
 	if (deep && extra_blocks) {
 		if (recover_extra) {
-			ltfsmsg(LTFS_INFO, "11223I");
+			ltfsmsg(LTFS_INFO, 11223I);
 			ret = _ltfs_make_lost_found(ip_eod, dp_eod, ip_endofidx, dp_endofidx, vol);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "11224E", ret);
+				ltfsmsg(LTFS_ERR, 11224E, ret);
 				goto out_unlock;
 			}
 		} else {
@@ -1119,33 +1119,33 @@ int ltfs_check_medium(bool fix, bool deep, bool recover_extra, bool recover_syml
 			/* Set index partition append position. */
 			if (ip_have_index && ip_blocks_after) {
 				if (lastblock_i >= ip_endofidx && lastblock_i < ip_eod) {
-					ltfsmsg(LTFS_INFO, "11226I");
+					ltfsmsg(LTFS_INFO, 11226I);
 					check_err(tape_set_append_position(vol->device, ip_num, lastblock_i),
-						"11229E", out_unlock);
+						11229E, out_unlock);
 				} else if (lastblock_i < ip_endofidx) {
-					ltfsmsg(LTFS_INFO, "11226I");
+					ltfsmsg(LTFS_INFO, 11226I);
 					check_err(tape_set_append_position(vol->device, ip_num,
-						ip_index->selfptr.block - 1), "11229E", out_unlock);
+						ip_index->selfptr.block - 1), 11229E, out_unlock);
 				}
 			} else if (! ip_have_index && ip_eod > 4) {
-				ltfsmsg(LTFS_INFO, "11226I");
-				check_err(tape_set_append_position(vol->device, ip_num, 4), "11229E",out_unlock);
+				ltfsmsg(LTFS_INFO, 11226I);
+				check_err(tape_set_append_position(vol->device, ip_num, 4), 11229E,out_unlock);
 			}
 
 			/* Set data partition append position. */
 			if (dp_have_index && dp_blocks_after) {
 				if (lastblock_d >= dp_endofidx && lastblock_d < dp_eod) {
-					ltfsmsg(LTFS_INFO, "11227I");
+					ltfsmsg(LTFS_INFO, 11227I);
 					check_err(tape_set_append_position(vol->device, dp_num, lastblock_d),
-						"11228E", out_unlock);
+						11228E, out_unlock);
 				} else if (lastblock_d < dp_endofidx) {
-					ltfsmsg(LTFS_INFO, "11227I");
+					ltfsmsg(LTFS_INFO, 11227I);
 					check_err(tape_set_append_position(vol->device, dp_num, dp_endofidx),
-						"11228E", out_unlock);
+						11228E, out_unlock);
 				}
 			} else if (! dp_have_index && dp_eod > 4) {
-				ltfsmsg(LTFS_INFO, "11227I");
-				check_err(tape_set_append_position(vol->device, dp_num, 4), "11228E",out_unlock);
+				ltfsmsg(LTFS_INFO, 11227I);
+				check_err(tape_set_append_position(vol->device, dp_num, 4), 11228E,out_unlock);
 			}
 		}
 
@@ -1160,7 +1160,7 @@ int ltfs_check_medium(bool fix, bool deep, bool recover_extra, bool recover_syml
 	/* If necessary, restore consistency by writing index files. */
 	if (vol->index->dirty) {
 		if (fix) {
-			ltfsmsg(LTFS_INFO, "11230I");
+			ltfsmsg(LTFS_INFO, 11230I);
 			/* Check index position written in Date Partition */
 			/* The index position must be higher than position located by index */
 			lastblock_d = 0;
@@ -1168,7 +1168,7 @@ int ltfs_check_medium(bool fix, bool deep, bool recover_extra, bool recover_syml
 			_ltfs_last_ref(vol->index->root, &lastblock_d, &lastblock_i, vol);
 			if (vol->device->append_pos[dp_num] != 0) {
 				if (lastblock_d > vol->device->append_pos[dp_num]) {
-					ltfsmsg(LTFS_ERR, "11329E", lastblock_d, vol->device->append_pos[dp_num], dp_num);
+					ltfsmsg(LTFS_ERR, 11329E, (unsigned long long)lastblock_d, (unsigned long long)vol->device->append_pos[dp_num], dp_num);
 					ret = -LTFS_INDEX_INVALID;
 					goto out_unlock;
 				}
@@ -1179,13 +1179,13 @@ int ltfs_check_medium(bool fix, bool deep, bool recover_extra, bool recover_syml
 			if (!ret)
 				ltfs_write_index(vol->label->partid_ip, SYNC_RECOVERY, vol);
 		} else {
-			ltfsmsg(LTFS_ERR, "11231E");
-			ltfsmsg(LTFS_ERR, "11232E");
+			ltfsmsg(LTFS_ERR, 11231E);
+			ltfsmsg(LTFS_ERR, 11232E);
 			ret = -LTFS_INCONSISTENT;
 		}
 
 	} else {
-		ltfsmsg(LTFS_INFO, "11233I");
+		ltfsmsg(LTFS_INFO, 11233I);
 		ltfs_update_cart_coherency(vol);
 	}
 

--- a/src/libltfs/ltfs_locking.h
+++ b/src/libltfs/ltfs_locking.h
@@ -95,9 +95,9 @@ static inline void backtrace_info(void)
 
 	for( i = 0; i < back_num; ++i ) {
 		if (funcs && funcs[i])
-			ltfsmsg( LTFS_INFO, "17193I", i, address[i], funcs[i]);
+			ltfsmsg(LTFS_INFO, 17193I, (int)i, address[i], funcs[i]);
 		else
-			ltfsmsg( LTFS_INFO, "17194I", i, address[i]);
+			ltfsmsg(LTFS_INFO, 17194I, (int)i, address[i]);
 	}
 
 	return;
@@ -287,7 +287,7 @@ releaseread_mrsw(MultiReaderSingleWriter *mrsw)
 
 	if ( mrsw->read_count<=0 ) {
 		mrsw->read_count=0;
-		ltfsmsg(LTFS_ERR, "17186E");
+		ltfsmsg(LTFS_ERR, 17186E);
 
 	} else {
 		mrsw->read_count--;

--- a/src/libltfs/ltfslogging.c
+++ b/src/libltfs/ltfslogging.c
@@ -274,7 +274,7 @@ int ltfsprintf_load_plugin(const char *bundle_name, void *bundle_data, void **me
 	udata_setAppData(bundle_name, bundle_data, &err);
 	if (U_FAILURE(err)) {
 		if (libltfs_dat_init)
-			ltfsmsg(LTFS_ERR, "11287E", err);
+			ltfsmsg(LTFS_ERR, 11287E, err);
 		else
 			fprintf(stderr, "LTFS11287E Cannot load messages: failed to register message data (%d)\n", err);
 		return -1;
@@ -284,7 +284,7 @@ int ltfsprintf_load_plugin(const char *bundle_name, void *bundle_data, void **me
 	pl = calloc(1, sizeof(struct plugin_bundle));
 	if (! pl) {
 		if (libltfs_dat_init)
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		else
 			fprintf(stderr, "LTFS10001E Memory allocation failed (%s)\n", __FUNCTION__);
 		return -LTFS_NO_MEMORY;
@@ -294,7 +294,7 @@ int ltfsprintf_load_plugin(const char *bundle_name, void *bundle_data, void **me
 	pl->bundle_root = ures_open(bundle_name, NULL, &err);
 	if (U_FAILURE(err)) {
 		if (libltfs_dat_init)
-			ltfsmsg(LTFS_ERR, "11286E", err);
+			ltfsmsg(LTFS_ERR, 11286E, err);
 		else
 			fprintf(stderr, "LTFS11286E Cannot load messages: failed to open resource bundle (%d)\n", err);
 		free(pl);
@@ -303,7 +303,7 @@ int ltfsprintf_load_plugin(const char *bundle_name, void *bundle_data, void **me
 	pl->bundle_messages = ures_getByKey(pl->bundle_root, "messages", NULL, &err);
 	if (U_FAILURE(err)) {
 		if (libltfs_dat_init)
-			ltfsmsg(LTFS_ERR, "11281E", err);
+			ltfsmsg(LTFS_ERR, 11281E, err);
 		else
 			fprintf(stderr, "LTFS11281E Cannot load messages: failed to get message table (%d)\n", err);
 		ures_close(pl->bundle_root);
@@ -315,7 +315,7 @@ int ltfsprintf_load_plugin(const char *bundle_name, void *bundle_data, void **me
 	bundle = ures_getByKey(pl->bundle_messages, "start_id", NULL, &err);
 	if (U_FAILURE(err)) {
 		if (libltfs_dat_init)
-			ltfsmsg(LTFS_ERR, "11282E", err);
+			ltfsmsg(LTFS_ERR, 11282E, err);
 		else
 			fprintf(stderr, "LTFS11282E Cannot load messages: failed to determine first message ID (ures_getByKey: %d)\n", err);
 		ures_close(pl->bundle_messages);
@@ -327,7 +327,7 @@ int ltfsprintf_load_plugin(const char *bundle_name, void *bundle_data, void **me
 	pl->start_id = ures_getInt(bundle, &err);
 	if (U_FAILURE(err)) {
 		if (libltfs_dat_init)
-			ltfsmsg(LTFS_ERR, "11283E", err);
+			ltfsmsg(LTFS_ERR, 11283E, err);
 		else
 			fprintf(stderr, "LTFS11283E Cannot load messages: failed to determine first message ID (ures_getInt: %d)\n", err);
 		ures_close(bundle);
@@ -344,7 +344,7 @@ int ltfsprintf_load_plugin(const char *bundle_name, void *bundle_data, void **me
 		pl->end_id = ures_getInt(bundle, &err);
 		if (U_FAILURE(err)) {
 			if (libltfs_dat_init)
-				ltfsmsg(LTFS_WARN, "11288W");
+				ltfsmsg(LTFS_WARN, 11288W);
 			else
 				fprintf(stderr, "LTFS11288W No end ID found for this message bundle, assigning 1000 message IDs\n");
 			pl->end_id = pl->start_id + 999;

--- a/src/libltfs/ltfslogging.h
+++ b/src/libltfs/ltfslogging.h
@@ -64,27 +64,49 @@ extern bool ltfs_print_thread_id;
 
 /* Wrapper for ltfsmsg_internal. It only invokes the message print function if the requested
  * log level is not too verbose. */
+#ifdef MSG_CHECK
+#include "ltfsmsg.h"
+#define ltfsmsg(level, id, ...)					\
+	do {										\
+		printf(LTFS ## id, ##__VA_ARGS__);		\
+	} while(0)
+#else
 #define ltfsmsg(level, id, ...) \
 	do { \
 		if (level <= ltfs_log_level) \
-			ltfsmsg_internal(true, level, NULL, id, ##__VA_ARGS__);	\
+			ltfsmsg_internal(true, level, NULL, #id, ##__VA_ARGS__);	\
 	} while (0)
+#endif
 
 /* Wrapper for ltfsmsg_internal. It only invokes the message print function if the requested
  * log level is not too verbose. */
+#ifdef MSG_CHECK
+#define ltfsmsg_buffer(level, id, ...)			\
+	do {										\
+		printf(LTFS ## id, ##__VA_ARGS__);		\
+	} while(0)
+#else
 #define ltfsmsg_buffer(level, id, buffer, ...)	\
 	do { \
 		*buffer = NULL; \
 		if (level <= ltfs_log_level) \
-			ltfsmsg_internal(true, level, buffer, id, ##__VA_ARGS__);	\
+			ltfsmsg_internal(true, level, buffer, #id, ##__VA_ARGS__);	\
 	} while (0)
+#endif
 
 /* Wrapper for ltfsmsg_internal that prints a message without the LTFSnnnnn prefix. It
  * always invokes the message print function, regardless of the message level. */
-#define ltfsresult(id, ...) \
-	do { \
-		ltfsmsg_internal(false, LTFS_TRACE + 1, NULL, id, ##__VA_ARGS__); \
+#ifdef MSG_CHECK
+#define ltfsresult(id, ...)						\
+	do {										\
+		printf(LTFS ## id, ##__VA_ARGS__);		\
+	} while(0)
+#else
+#define ltfsresult(id, ...)						\
+	do {																\
+		ltfsmsg_internal(false, LTFS_TRACE + 1, NULL, #id, ##__VA_ARGS__); \
 	} while (0)
+#endif
 
 /* Shortcut for asserting that a function argument is not NULL. It generates an error-level
  * message if the given argument is NULL. Functions for which a NULL argument is a warning
@@ -92,7 +114,7 @@ extern bool ltfs_print_thread_id;
 #define CHECK_ARG_NULL(var, ret) \
 	do { \
 		if (! (var)) { \
-			ltfsmsg(LTFS_ERR, "10005E", #var, __FUNCTION__); \
+			ltfsmsg(LTFS_ERR, 10005E, #var, __FUNCTION__); \
 			return ret; \
 		} \
 	} while (0)

--- a/src/libltfs/ltfssnmp.c
+++ b/src/libltfs/ltfssnmp.c
@@ -91,7 +91,7 @@ int read_trap_def_file(char *deffile)
 	fp = fopen(trapfile, TABLE_FILE_MODE);
 	if (! fp) {
 		ret = -errno;
-		ltfsmsg(LTFS_ERR, "11268E", trapfile, ret);
+		ltfsmsg(LTFS_ERR, 11268E, trapfile, ret);
 		return ret;
 	}
 
@@ -99,7 +99,7 @@ int read_trap_def_file(char *deffile)
 	if (!ret) {
 		while(fgets(line, 65536, fp) != NULL) {
 			if (strlen(line) == 65535) {
-				ltfsmsg(LTFS_ERR, "11269E");
+				ltfsmsg(LTFS_ERR, 11269E);
 				ret = -LTFS_CONFIG_INVALID;
 				return ret;
 			}
@@ -118,7 +118,7 @@ int read_trap_def_file(char *deffile)
 			if (tok) {
 				entry = (struct trap_entry *) calloc(1, sizeof(struct trap_entry));
 				if (! entry) {
-					ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+					ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 					return -LTFS_NO_MEMORY;
 				}
 				entry->id = strdup(tok);

--- a/src/libltfs/ltfstrace.c
+++ b/src/libltfs/ltfstrace.c
@@ -228,20 +228,20 @@ static int ltfs_request_trace_init(void)
 
 	req_trace = calloc(1, sizeof(struct request_trace));
 	if (!req_trace) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 
 	ret = ltfs_mutex_init(&req_trace->req_trace_lock);
 	if (ret) {
-		ltfsmsg(LTFS_ERR, "10002E", ret);
+		ltfsmsg(LTFS_ERR, 10002E, ret);
 		free(req_trace);
 		return -LTFS_MUTEX_INIT;
 	}
 
 	ret = ltfs_mutex_init(&req_trace->req_profiler_lock);
 	if (ret) {
-		ltfsmsg(LTFS_ERR, "10002E", ret);
+		ltfsmsg(LTFS_ERR, 10002E, ret);
 		free(req_trace);
 		return -LTFS_MUTEX_INIT;
 	}
@@ -278,14 +278,14 @@ int ltfs_fn_trace_start(FUNCTION_TRACE_TYPE type, uint32_t tid)
 		struct filesystem_function_trace *tr_data = NULL;
 		item = (struct filesystem_trace_list *) calloc(1, sizeof(struct filesystem_trace_list));
 		if (!item) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 		item->tid = tid;
 
 		tr_data = (struct filesystem_function_trace *) calloc(1, sizeof(struct filesystem_function_trace));
 		if (!tr_data) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 		tr_data->max_index = FS_FN_TRACE_ENTRIES - 1;
@@ -298,14 +298,14 @@ int ltfs_fn_trace_start(FUNCTION_TRACE_TYPE type, uint32_t tid)
 		struct admin_function_trace *tr_data = NULL;
 		item = (struct admin_trace_list *) calloc(1, sizeof(struct admin_trace_list));
 		if (!item) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 		item->tid = tid;
 
 		tr_data = (struct admin_function_trace *) calloc(1, sizeof(struct admin_function_trace));
 		if (!tr_data) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 		tr_data->max_index = ADMIN_FN_TRACE_ENTRIES - 1;
@@ -450,7 +450,7 @@ int ltfs_request_profiler_start(const char *work_dir)
 
 	ret = asprintf(&path, "%s/%s", work_dir, REQ_PROFILER_FILE);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10001E", __FILE__);
+		ltfsmsg(LTFS_ERR, 10001E, __FILE__);
 		return -LTFS_NO_MEMORY;
 	}
 
@@ -483,7 +483,7 @@ int ltfs_header_init(void)
 	/* Trace header */
 	trc_header = calloc(1, sizeof(struct trace_header));
 	if (!trc_header) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 	strncpy(trc_header->signature, LTFS_TRACE_SIGNATURE, strlen(LTFS_TRACE_SIGNATURE));
@@ -498,7 +498,7 @@ int ltfs_header_init(void)
 	/* Request trace header */
 	req_header = calloc(1, sizeof(struct request_header));
 	if (!trc_header) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 	req_header->header_size = sizeof(struct request_header);
@@ -508,7 +508,7 @@ int ltfs_header_init(void)
 	/* Function trace header */
 	fn_trc_header = calloc(1, sizeof(struct function_trace_header));
 	if (!fn_trc_header) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 	fn_trc_header->crc = 0xDEADBEEF;
@@ -584,19 +584,19 @@ int ltfs_dump(char *fname, const char *work_dir)
 
 	ret = asprintf(&path, "%s/%s", work_dir, fname);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10001E", __FILE__);
+		ltfsmsg(LTFS_ERR, 10001E, __FILE__);
 		return -LTFS_NO_MEMORY;
 	}
 
 	ret = asprintf(&pid, "%ld", (long)getpid());
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10001E", __FILE__);
+		ltfsmsg(LTFS_ERR, 10001E, __FILE__);
 		return -LTFS_NO_MEMORY;
 	}
 
 	fork_pid = fork();
 	if (fork_pid < 0) {
-		ltfsmsg(LTFS_ERR, "17233E");
+		ltfsmsg(LTFS_ERR, 17233E);
 	} else  if (fork_pid == 0) {
 		args[num_args++] = "/usr/bin/gcore";
 		args[num_args++] = "-o";
@@ -627,7 +627,7 @@ int ltfs_trace_dump(char *fname, const char *work_dir)
 
 	ret = asprintf(&path, "%s/%s", work_dir, fname);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10001E", __FILE__);
+		ltfsmsg(LTFS_ERR, 10001E, __FILE__);
 		return -LTFS_NO_MEMORY;
 	}
 
@@ -658,7 +658,7 @@ int ltfs_trace_dump(char *fname, const char *work_dir)
 		fn_trc_header->req_t_desc =
 			(struct function_trace_descriptor *) calloc(num_of_fn_trace, sizeof(struct function_trace_descriptor));
 		if (!fn_trc_header->req_t_desc) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 
@@ -740,12 +740,12 @@ int ltfs_get_trace_status(char **val)
 
 	ret = asprintf(&trstat, "%s", (trace_enable == true) ? "on" : "off" );
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10001E", __FILE__);
+		ltfsmsg(LTFS_ERR, 10001E, __FILE__);
 		return -LTFS_NO_MEMORY;
 	}
 	*val = strdup(trstat);
 	if (! (*val)) {
-		ltfsmsg(LTFS_ERR, "10001E", __FILE__);
+		ltfsmsg(LTFS_ERR, 10001E, __FILE__);
 		return -LTFS_NO_MEMORY;
 	}
 	free(trstat);

--- a/src/libltfs/pathname.c
+++ b/src/libltfs/pathname.c
@@ -314,7 +314,7 @@ int pathname_validate_xattr_value(const char *name, size_t size)
 	while (i < (ssize_t) size) {
 		U8_NEXT(name, i, (int32_t) size, c);
 		if (c < 0) {
-			ltfsmsg(LTFS_ERR, "11234E");
+			ltfsmsg(LTFS_ERR, 11234E);
 			return -LTFS_ICU_ERROR;
 		}
 
@@ -416,7 +416,7 @@ int _pathname_validate(const char *name, bool allow_slash)
 	while (i < len) {
 		U8_NEXT(name, i, len, c);
 		if (c < 0) {
-			ltfsmsg(LTFS_ERR, "11235E");
+			ltfsmsg(LTFS_ERR, 11235E);
 			return -LTFS_ICU_ERROR;
 		}
 
@@ -621,20 +621,20 @@ int _pathname_foldcase_icu(const UChar *src, UChar **dest)
 
 	destlen = u_strFoldCase(NULL, 0, src, -1, U_FOLD_CASE_DEFAULT, &err);
 	if (U_FAILURE(err) && err != U_BUFFER_OVERFLOW_ERROR) {
-		ltfsmsg(LTFS_ERR, "11236E", err);
+		ltfsmsg(LTFS_ERR, 11236E, err);
 		return -LTFS_ICU_ERROR;
 	}
 	err = U_ZERO_ERROR;
 
 	*dest = malloc((destlen + 1) * sizeof(UChar));
 	if (! *dest) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 
 	u_strFoldCase(*dest, destlen + 1, src, -1, U_FOLD_CASE_DEFAULT, &err);
 	if (U_FAILURE(err)) {
-		ltfsmsg(LTFS_ERR, "11237E", err);
+		ltfsmsg(LTFS_ERR, 11237E, err);
 		free(*dest);
 		*dest = NULL;
 		return -LTFS_ICU_ERROR;
@@ -666,20 +666,20 @@ int _pathname_normalize_nfc_icu(const UChar *src, UChar **dest)
 
 	destlen = unorm_normalize(src, -1, UNORM_NFC, 0, NULL, 0, &err);
 	if (U_FAILURE(err) && err != U_BUFFER_OVERFLOW_ERROR) {
-		ltfsmsg(LTFS_ERR, "11238E", err);
+		ltfsmsg(LTFS_ERR, 11238E, err);
 		return -LTFS_ICU_ERROR;
 	}
 	err = U_ZERO_ERROR;
 
 	*dest = malloc((destlen + 1) * sizeof(UChar));
 	if (! *dest) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 
 	unorm_normalize(src, -1, UNORM_NFC, 0, *dest, destlen + 1, &err);
 	if (U_FAILURE(err)) {
-		ltfsmsg(LTFS_ERR, "11239E", err);
+		ltfsmsg(LTFS_ERR, 11239E, err);
 		free(*dest);
 		*dest = NULL;
 		return -LTFS_ICU_ERROR;
@@ -708,20 +708,20 @@ int _pathname_normalize_nfd_icu(const UChar *src, UChar **dest)
 
 	destlen = unorm_normalize(src, -1, UNORM_NFD, 0, NULL, 0, &err);
 	if (U_FAILURE(err) && err != U_BUFFER_OVERFLOW_ERROR) {
-		ltfsmsg(LTFS_ERR, "11240E", err);
+		ltfsmsg(LTFS_ERR, 11240E, err);
 		return -LTFS_ICU_ERROR;
 	}
 	err = U_ZERO_ERROR;
 
 	*dest = malloc((destlen + 1) * sizeof(UChar));
 	if (! *dest) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 
 	unorm_normalize(src, -1, UNORM_NFD, 0, *dest, destlen + 1, &err);
 	if (U_FAILURE(err)) {
-		ltfsmsg(LTFS_ERR, "11241E", err);
+		ltfsmsg(LTFS_ERR, 11241E, err);
 		free(*dest);
 		*dest = NULL;
 		return -LTFS_ICU_ERROR;
@@ -744,21 +744,21 @@ int _pathname_utf8_to_utf16_icu(const char *src, UChar **dest)
 	/* get required buffer size */
 	u_strFromUTF8(NULL, 0, &destlen, src, -1, &err);
 	if (U_FAILURE(err) && err != U_BUFFER_OVERFLOW_ERROR) {
-		ltfsmsg(LTFS_ERR, "11242E", err);
+		ltfsmsg(LTFS_ERR, 11242E, err);
 		return -LTFS_ICU_ERROR;
 	}
 	err = U_ZERO_ERROR;
 
 	*dest = malloc((destlen + 1) * sizeof(UChar));
 	if (! *dest) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 
 	/* convert to ICU's UTF-16 representation */
 	u_strFromUTF8(*dest, destlen + 1, NULL, src, -1, &err);
 	if (U_FAILURE(err)) {
-		ltfsmsg(LTFS_ERR, "11243E", err);
+		ltfsmsg(LTFS_ERR, 11243E, err);
 		free(*dest);
 		*dest = NULL;
 		return -LTFS_ICU_ERROR;
@@ -781,20 +781,20 @@ int _pathname_utf16_to_utf8_icu(const UChar *src, char **dest)
 
 	u_strToUTF8(NULL, 0, &destlen, src, -1, &err);
 	if (U_FAILURE(err) && err != U_BUFFER_OVERFLOW_ERROR) {
-		ltfsmsg(LTFS_ERR, "11244E", err);
+		ltfsmsg(LTFS_ERR, 11244E, err);
 		return -LTFS_ICU_ERROR;
 	}
 	err = U_ZERO_ERROR;
 
 	*dest = malloc(destlen + 1);
 	if (! *dest) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 
 	u_strToUTF8(*dest, destlen + 1, NULL, src, -1, &err);
 	if (U_FAILURE(err)) {
-		ltfsmsg(LTFS_ERR, "11245E", err);
+		ltfsmsg(LTFS_ERR, 11245E, err);
 		free(*dest);
 		*dest = NULL;
 		return -LTFS_ICU_ERROR;
@@ -819,13 +819,13 @@ int _pathname_system_to_utf16_icu(const char *src, UChar **dest)
 	/* open converter for the system locale */
 	syslocale = ucnv_open(NULL, &err);
 	if (U_FAILURE(err)) {
-		ltfsmsg(LTFS_ERR, "11246E", err);
+		ltfsmsg(LTFS_ERR, 11246E, err);
 		return -LTFS_ICU_ERROR;
 	}
 
 	ucnv_setToUCallBack(syslocale, UCNV_TO_U_CALLBACK_STOP, NULL, NULL, NULL, &err);
 	if (U_FAILURE(err)) {
-		ltfsmsg(LTFS_ERR, "11247E", err);
+		ltfsmsg(LTFS_ERR, 11247E, err);
 		ucnv_close(syslocale);
 		return -LTFS_ICU_ERROR;
 	}
@@ -833,7 +833,7 @@ int _pathname_system_to_utf16_icu(const char *src, UChar **dest)
 	/* perform the conversion */
 	destlen = ucnv_toUChars(syslocale, NULL, 0, src, -1, &err);
 	if (U_FAILURE(err) && err != U_BUFFER_OVERFLOW_ERROR) {
-		ltfsmsg(LTFS_ERR, "11248E", err, src);
+		ltfsmsg(LTFS_ERR, 11248E, err, src);
 		ucnv_close(syslocale);
 		return -LTFS_ICU_ERROR;
 	}
@@ -841,14 +841,14 @@ int _pathname_system_to_utf16_icu(const char *src, UChar **dest)
 
 	*dest = malloc((destlen + 1) * sizeof(UChar));
 	if (! *dest) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		ucnv_close(syslocale);
 		return -LTFS_NO_MEMORY;
 	}
 
 	ucnv_toUChars(syslocale, *dest, destlen + 1, src, -1, &err);
 	if (U_FAILURE(err)) {
-		ltfsmsg(LTFS_ERR, "11249E", err, src);
+		ltfsmsg(LTFS_ERR, 11249E, err, src);
 		ucnv_close(syslocale);
 		free(*dest);
 		*dest = NULL;
@@ -884,20 +884,20 @@ int _pathname_utf8_to_system_icu(const char *src, char **dest)
 	/* System locale doesn't match internal usage, so really do the conversion */
 	destlen = ucnv_convert(NULL, "UTF-8", NULL, 0, src, -1, &err);
 	if (U_FAILURE(err) && err != U_BUFFER_OVERFLOW_ERROR) {
-		ltfsmsg(LTFS_ERR, "11250E", err);
+		ltfsmsg(LTFS_ERR, 11250E, err);
 		return -LTFS_ICU_ERROR;
 	}
 	err = U_ZERO_ERROR;
 
 	*dest = malloc(destlen + 1);
 	if (! *dest) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 
 	ucnv_convert(NULL, "UTF-8", *dest, destlen + 1, src, -1, &err);
 	if (U_FAILURE(err)) {
-		ltfsmsg(LTFS_ERR, "11251E", err);
+		ltfsmsg(LTFS_ERR, 11251E, err);
 		free(*dest);
 		*dest = NULL;
 		return -LTFS_ICU_ERROR;

--- a/src/libltfs/periodic_sync.c
+++ b/src/libltfs/periodic_sync.c
@@ -87,16 +87,16 @@ ltfs_thread_return periodic_sync_thread(void* data)
 
 		ltfs_request_trace(FUSE_REQ_ENTER(REQ_SYNC), 0, 0);
 
-		ltfsmsg(LTFS_DEBUG, "17067D", "Sync-by-Time");
+		ltfsmsg(LTFS_DEBUG, 17067D, "Sync-by-Time");
 		ret = ltfs_fsops_flush(NULL, false, priv->vol);
 		if (ret < 0) {
 			/* Failed to flush file data */
-			ltfsmsg(LTFS_WARN, "17063W", __FUNCTION__);
+			ltfsmsg(LTFS_WARN, 17063W, __FUNCTION__);
 		}
 
 		ret = ltfs_sync_index(SYNC_PERIODIC, true, priv->vol);
 		if (ret < 0) {
-			ltfsmsg(LTFS_INFO, "11030I", ret);
+			ltfsmsg(LTFS_INFO, 11030I, ret);
 			priv->keepalive = false;
 		}
 
@@ -104,7 +104,7 @@ ltfs_thread_return periodic_sync_thread(void* data)
 	}
 	ltfs_thread_mutex_unlock(&priv->periodic_sync_thread_mutex);
 
-	ltfsmsg(LTFS_DEBUG, "17064D", "Sync-by-Time");
+	ltfsmsg(LTFS_DEBUG, 17064D, "Sync-by-Time");
 	ltfs_thread_exit();
 
 	return LTFS_THREAD_RC_NULL;
@@ -144,7 +144,7 @@ int periodic_sync_thread_init(int sec, struct ltfs_volume *vol)
 
 	priv = calloc(1, sizeof(struct periodic_sync_data));
 	if (! priv) {
-		ltfsmsg(LTFS_ERR, "10001E", "periodic_sync_thread_init: periodic sync data");
+		ltfsmsg(LTFS_ERR, 10001E, "periodic_sync_thread_init: periodic sync data");
 		return -LTFS_NO_MEMORY;
 	}
 
@@ -154,13 +154,13 @@ int periodic_sync_thread_init(int sec, struct ltfs_volume *vol)
 
 	ret = ltfs_thread_cond_init(&priv->periodic_sync_thread_cond);
 	if (ret) {
-		ltfsmsg(LTFS_ERR, "10003E", ret);
+		ltfsmsg(LTFS_ERR, 10003E, ret);
 		free(priv);
 		return -ret;
 	}
 	ret = ltfs_thread_mutex_init(&priv->periodic_sync_thread_mutex);
 	if (ret) {
-		ltfsmsg(LTFS_ERR, "10002E", ret);
+		ltfsmsg(LTFS_ERR, 10002E, ret);
 		ltfs_thread_cond_destroy(&priv->periodic_sync_thread_cond);
 		free(priv);
 		return -ret;
@@ -168,14 +168,14 @@ int periodic_sync_thread_init(int sec, struct ltfs_volume *vol)
 	ret = ltfs_thread_create(&priv->periodic_sync_thread_id, periodic_sync_thread, priv);
 	if (ret < 0) {
 		/* Failed to spawn the periodic sync thread (%d) */
-		ltfsmsg(LTFS_ERR, "17099E", ret);
+		ltfsmsg(LTFS_ERR, 17099E, ret);
 		ltfs_thread_mutex_destroy(&priv->periodic_sync_thread_mutex);
 		ltfs_thread_cond_destroy(&priv->periodic_sync_thread_cond);
 		free(priv);
 		return -ret;
 	}
 
-	ltfsmsg(LTFS_DEBUG, "17065D");
+	ltfsmsg(LTFS_DEBUG, 17065D);
 	vol->periodic_sync_handle = priv;
 
 	return 0;
@@ -205,6 +205,6 @@ int periodic_sync_thread_destroy(struct ltfs_volume *vol)
 
 	vol->periodic_sync_handle = NULL;
 
-	ltfsmsg(LTFS_DEBUG, "17066D");
+	ltfsmsg(LTFS_DEBUG, 17066D);
 	return 0;
 }

--- a/src/libltfs/plugin.c
+++ b/src/libltfs/plugin.c
@@ -86,18 +86,18 @@ int plugin_load(struct libltfs_plugin *pl, const char *type, const char *name,
 
 	lib_path = config_file_get_lib(type, name, config);
 	if (! lib_path) {
-		ltfsmsg(LTFS_ERR, "11260E", name);
+		ltfsmsg(LTFS_ERR, 11260E, name);
 		return -LTFS_NO_PLUGIN;
 	}
 
 	pl->lib_handle = dlopen(lib_path, RTLD_NOW);
 	if (! pl->lib_handle) {
-		ltfsmsg(LTFS_ERR, "11261E", dlerror());
+		ltfsmsg(LTFS_ERR, 11261E, dlerror());
 		return -LTFS_PLUGIN_LOAD;
 	}
 
 	/* Show loading plugins */
-	ltfsmsg(LTFS_INFO, "17085I", name, type);
+	ltfsmsg(LTFS_INFO, 17085I, name, type);
 
 	/* Make sure the plugin knows how to describe its supported operations */
 	if (! strcmp(type, "iosched"))
@@ -115,7 +115,7 @@ int plugin_load(struct libltfs_plugin *pl, const char *type, const char *name,
 	/* config_file_get_lib already verified that "type" contains one of the values above */
 
 	if (! get_ops) {
-		ltfsmsg(LTFS_ERR, "11263E", dlerror());
+		ltfsmsg(LTFS_ERR, 11263E, dlerror());
 		dlclose(pl->lib_handle);
 		pl->lib_handle = NULL;
 		return -LTFS_PLUGIN_LOAD;
@@ -137,7 +137,7 @@ int plugin_load(struct libltfs_plugin *pl, const char *type, const char *name,
 	/* config_file_get_lib already verified that "type" contains one of the values above */
 
 	if (! get_messages) {
-		ltfsmsg(LTFS_ERR, "11284E", dlerror());
+		ltfsmsg(LTFS_ERR, 11284E, dlerror());
 		dlclose(pl->lib_handle);
 		pl->lib_handle = NULL;
 		return -LTFS_PLUGIN_LOAD;
@@ -146,7 +146,7 @@ int plugin_load(struct libltfs_plugin *pl, const char *type, const char *name,
 	/* Ask the plugin what operations and messages it provides */
 	pl->ops = get_ops();
 	if (! pl->ops) {
-		ltfsmsg(LTFS_ERR, "11264E");
+		ltfsmsg(LTFS_ERR, 11264E);
 		dlclose(pl->lib_handle);
 		pl->lib_handle = NULL;
 		return -LTFS_PLUGIN_LOAD;
@@ -156,7 +156,7 @@ int plugin_load(struct libltfs_plugin *pl, const char *type, const char *name,
 	if (message_bundle_name) {
 		ret = ltfsprintf_load_plugin(message_bundle_name, message_bundle_data, &pl->messages);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "11285E", type, name, ret);
+			ltfsmsg(LTFS_ERR, 11285E, type, name, ret);
 			return ret;
 		}
 	}
@@ -173,7 +173,7 @@ int plugin_unload(struct libltfs_plugin *pl)
 #ifndef VALGRIND_FRIENDLY
 	/* Valgrind cannot resolve function name after closing shared library */
 	if (dlclose(pl->lib_handle)) {
-		ltfsmsg(LTFS_ERR, "11262E", dlerror());
+		ltfsmsg(LTFS_ERR, 11262E, dlerror());
 		return -LTFS_PLUGIN_UNLOAD;
 	}
 #endif
@@ -190,19 +190,19 @@ int plugin_unload(struct libltfs_plugin *pl)
 static void print_help_message(void *ops, const char * const type)
 {
 	if (! ops) {
-		ltfsmsg(LTFS_WARN, "10006W", "ops", __FUNCTION__);
+		ltfsmsg(LTFS_WARN, 10006W, "ops", __FUNCTION__);
 		return;
 	}
 
 	if (! strcmp(type, "kmi")) {
 		int ret = kmi_print_help_message(ops);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "11316E");
+			ltfsmsg(LTFS_ERR, 11316E);
 		}
 	} else if (! strcmp(type, "driver"))
 		tape_print_help_message(ops);
 	else
-		ltfsmsg(LTFS_ERR, "11317E", type);
+		ltfsmsg(LTFS_ERR, 11317E, type);
 }
 
 void plugin_usage(const char *type, struct config_file *config)
@@ -214,7 +214,7 @@ void plugin_usage(const char *type, struct config_file *config)
 	backends = config_file_get_plugins(type, config);
 	if (! backends) {
 		if (! strcmp(type, "driver"))
-			ltfsresult("14403I"); /* -o devname=<dev> */
+			ltfsresult(14403I); /* -o devname=<dev> */
 		return;
 	}
 

--- a/src/libltfs/tape.c
+++ b/src/libltfs/tape.c
@@ -101,7 +101,7 @@ extern bool ltfs_is_interrupted(void);
 #define INTERRUPTED_RETURN()					\
 	do{											\
 		if (ltfs_is_interrupted()) {			\
-			ltfsmsg(LTFS_INFO, "17159I");		\
+			ltfsmsg(LTFS_INFO, 17159I);		\
 			free(buf);							\
 			return -LTFS_INTERRUPTED;			\
 		}										\
@@ -118,26 +118,26 @@ int tape_device_alloc(struct device_data **device)
 
 	struct device_data *newdev = calloc(1, sizeof(struct device_data));
 	if (! newdev) {
-		ltfsmsg(LTFS_ERR, "10001E", "tape_device_alloc: device data");
+		ltfsmsg(LTFS_ERR, 10001E, "tape_device_alloc: device data");
 		return -LTFS_NO_MEMORY;
 	}
 
 	ret = ltfs_mutex_init(&newdev->backend_mutex);
 	if (ret) {
-		ltfsmsg(LTFS_ERR, "12008E", ret);
+		ltfsmsg(LTFS_ERR, 12008E, ret);
 		free(newdev);
 		return -LTFS_MUTEX_INIT;
 	}
 	ret = ltfs_mutex_init(&newdev->read_only_flag_mutex);
 	if (ret) {
-		ltfsmsg(LTFS_ERR, "12008E", ret);
+		ltfsmsg(LTFS_ERR, 12008E, ret);
 		ltfs_mutex_destroy(&newdev->backend_mutex);
 		free(newdev);
 		return -LTFS_MUTEX_INIT;
 	}
 	ret = ltfs_mutex_init(&newdev->append_pos_mutex);
 	if (ret) {
-		ltfsmsg(LTFS_ERR, "12008E", ret);
+		ltfsmsg(LTFS_ERR, 12008E, ret);
 		free(newdev);
 		return -LTFS_MUTEX_INIT;
 	}
@@ -199,7 +199,7 @@ int tape_device_open(struct device_data *device, const char *devname, struct tap
 	/* Validate the tape operations structure. */
 	for (i=0; i<sizeof(struct tape_ops)/sizeof(void *); ++i) {
 		if ((((void **)ops)[i]) == NULL) {
-			ltfsmsg(LTFS_ERR, "12004E");
+			ltfsmsg(LTFS_ERR, 12004E);
 			return -LTFS_PLUGIN_INCOMPLETE;
 		}
 	}
@@ -210,7 +210,7 @@ int tape_device_open(struct device_data *device, const char *devname, struct tap
 	ret = device->backend->open(devname, &device->backend_data);
 	if (ret < 0) {
 		/* Cannot open device: backend open call failed */
-		ltfsmsg(LTFS_ERR, "12012E");
+		ltfsmsg(LTFS_ERR, 12012E);
 		goto out_free;
 	}
 
@@ -223,7 +223,7 @@ int tape_device_open(struct device_data *device, const char *devname, struct tap
 	}
 	if (ret < 0) {
 		/* Cannot open device: failed to reserve the device (%d) */
-		ltfsmsg(LTFS_ERR, "12014E", ret);
+		ltfsmsg(LTFS_ERR, 12014E, ret);
 		tape_device_close(device, kmi_handle, false);
 		goto out_free;
 	}
@@ -261,7 +261,7 @@ int tape_device_reopen(struct device_data *device, const char *devname)
 	ret = device->backend->reopen(devname, device->backend_data);
 	if (ret < 0) {
 		/* Cannot reopen device: backend reopen call failed */
-		ltfsmsg(LTFS_ERR, "17181E");
+		ltfsmsg(LTFS_ERR, 17181E);
 	}
 
 	return ret;
@@ -278,7 +278,7 @@ void _tape_device_close(struct device_data *device, void * const kmi_handle,
 						bool skip_aom_setting, bool force_release)
 {
 	if (! device) {
-		ltfsmsg(LTFS_WARN, "10006W", "device", __FUNCTION__);
+		ltfsmsg(LTFS_WARN, 10006W, "device", __FUNCTION__);
 		return;
 	}
 
@@ -308,7 +308,7 @@ void _tape_device_close(struct device_data *device, void * const kmi_handle,
 void tape_device_close_raw(struct device_data *device)
 {
 	if (! device) {
-		ltfsmsg(LTFS_WARN, "10006W", "device", __FUNCTION__);
+		ltfsmsg(LTFS_WARN, 10006W, "device", __FUNCTION__);
 		return;
 	}
 
@@ -363,7 +363,7 @@ int tape_load_tape(struct device_data *dev, void * const kmi_handle, bool force)
 	do {
 		ret = dev->backend->load(dev->backend_data, &dev->position);
 		if (ret == -EDEV_NO_MEDIUM) {
-			ltfsmsg(LTFS_ERR, "12016E");
+			ltfsmsg(LTFS_ERR, 12016E);
 			return -LTFS_NO_MEDIUM;
 		} else if (ret < 0 && ! NEED_REVAL(ret)) {
 			if (ret == -EDEV_MEDIUM_FORMAT_ERROR)
@@ -378,19 +378,19 @@ int tape_load_tape(struct device_data *dev, void * const kmi_handle, bool force)
 
 	ret = tape_wait_device_ready(dev, kmi_handle);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "12017E", ret);
+		ltfsmsg(LTFS_ERR, 12017E, ret);
 		return -LTFS_DEVICE_UNREADY;
 	}
 
 	ret = tape_prevent_medium_removal(dev);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "12018E", ret);
+		ltfsmsg(LTFS_ERR, 12018E, ret);
 		return ret;
 	}
 
 	ret = dev->backend->readpos(dev->backend_data, &dev->position);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "12019E", ret);
+		ltfsmsg(LTFS_ERR, 12019E, ret);
 		return ret;
 	}
 
@@ -400,7 +400,7 @@ int tape_load_tape(struct device_data *dev, void * const kmi_handle, bool force)
 	 */
 	ret = dev->backend->set_default(dev->backend_data);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "12020E", ret);
+		ltfsmsg(LTFS_ERR, 12020E, ret);
 		return ret;
 	}
 
@@ -411,14 +411,14 @@ int tape_load_tape(struct device_data *dev, void * const kmi_handle, bool force)
 	/* Get remaining capacity of the tape */
 	ret = tape_get_capacity(dev, &cap);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11999E", ret);
+		ltfsmsg(LTFS_ERR, 11999E, ret);
 		return ret;
 	}
 
 	/* Query device parameters */
 	ret = dev->backend->get_parameters(dev->backend_data, &param);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "12021E", ret);
+		ltfsmsg(LTFS_ERR, 12021E, ret);
 		return ret;
 	}
 	dev->max_block_size = param.max_blksize;
@@ -426,7 +426,7 @@ int tape_load_tape(struct device_data *dev, void * const kmi_handle, bool force)
 	/* Get programmable early warning size */
 	ret = tape_get_pews(dev, &pews);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17105E", ret);
+		ltfsmsg(LTFS_ERR, 17105E, ret);
 		return ret;
 	}
 	pews += 10; /* 10MB is extra space not to miss PEW */
@@ -464,7 +464,7 @@ int tape_unload_tape(bool keep_on_drive, struct device_data *dev)
 	CHECK_ARG_NULL(dev, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(dev->backend, -LTFS_NULL_ARG);
 
-	ltfsmsg(LTFS_INFO, "12022I");
+	ltfsmsg(LTFS_INFO, 12022I);
 
 	/* Invalidate previous drive presence */
 	dev->previous_exist.tv_sec = 0;
@@ -568,11 +568,11 @@ int tape_reserve_device(struct device_data *dev)
 	ret = 0;
 	if (! dev->device_reserved) {
 		do {
-			ltfsmsg(LTFS_DEBUG, "12023D");
+			ltfsmsg(LTFS_DEBUG, 12023D);
 			ret = dev->backend->reserve_unit(dev->backend_data);
 		} while (NEED_REVAL(ret));
 		if (ret != 0) {
-			ltfsmsg(LTFS_ERR, "12024E", ret);
+			ltfsmsg(LTFS_ERR, 12024E, ret);
 			ret = (ret < 0) ? ret : -ret;
 		} else
 			dev->device_reserved = true;
@@ -589,16 +589,16 @@ void tape_release_device(struct device_data *dev)
 	int ret;
 
 	if (! dev) {
-		ltfsmsg(LTFS_WARN, "10006W", "dev", __FUNCTION__);
+		ltfsmsg(LTFS_WARN, 10006W, "dev", __FUNCTION__);
 		return;
 	} else if (! dev->backend) {
-		ltfsmsg(LTFS_WARN, "10006W", "dev->backend", __FUNCTION__);
+		ltfsmsg(LTFS_WARN, 10006W, "dev->backend", __FUNCTION__);
 		return;
 	}
 
 	if (dev->device_reserved) {
 		do {
-			ltfsmsg(LTFS_DEBUG, "12025D");
+			ltfsmsg(LTFS_DEBUG, 12025D);
 			ret = dev->backend->release_unit(dev->backend_data);
 		} while (NEED_REVAL(ret));
 		dev->device_reserved = (ret == 0) ? false : true;
@@ -620,11 +620,11 @@ int tape_prevent_medium_removal(struct device_data *dev)
 	ret = 0;
 	if (! dev->medium_locked) {
 		do {
-			ltfsmsg(LTFS_DEBUG, "12026D");
+			ltfsmsg(LTFS_DEBUG, 12026D);
 			ret = dev->backend->prevent_medium_removal(dev->backend_data);
 		} while (NEED_REVAL(ret));
 		if (ret != 0) {
-			ltfsmsg(LTFS_ERR, "12027E", ret);
+			ltfsmsg(LTFS_ERR, 12027E, ret);
 			ret = (ret < 0) ? ret : -ret;
 		} else
 			dev->medium_locked = true;
@@ -641,16 +641,16 @@ void tape_allow_medium_removal(struct device_data *dev, bool force_release)
 	int ret;
 
 	if (! dev) {
-		ltfsmsg(LTFS_WARN, "10006W", "dev", __FUNCTION__);
+		ltfsmsg(LTFS_WARN, 10006W, "dev", __FUNCTION__);
 		return;
 	} else if (! dev->backend) {
-		ltfsmsg(LTFS_WARN, "10006W", "dev->backend", __FUNCTION__);
+		ltfsmsg(LTFS_WARN, 10006W, "dev->backend", __FUNCTION__);
 		return;
 	}
 
 	if (dev->medium_locked || force_release) {
 		do {
-			ltfsmsg(LTFS_DEBUG, "12028D");
+			ltfsmsg(LTFS_DEBUG, 12028D);
 			ret = dev->backend->allow_medium_removal(dev->backend_data);
 		} while (NEED_REVAL(ret));
 		dev->medium_locked = (ret == 0) ? false : true;
@@ -686,7 +686,7 @@ int tape_test_unit_ready(struct device_data *dev)
 
 	ret = _tape_test_unit_ready(dev);
 	if (ret < 0)
-		ltfsmsg(LTFS_ERR, "12029E", ret);
+		ltfsmsg(LTFS_ERR, 12029E, ret);
 
 	dev->previous_exist.tv_sec = ts_now.tv_sec;
 	dev->previous_exist.tv_nsec = ts_now.tv_nsec;
@@ -710,7 +710,7 @@ int tape_get_capacity(struct device_data *dev, struct tc_remaining_cap *cap)
 
 	ret = dev->backend->remaining_capacity(dev->backend_data, cap);
 	if (ret < 0)
-		ltfsmsg(LTFS_ERR, "12030E", ret);
+		ltfsmsg(LTFS_ERR, 12030E, ret);
 	return ret;
 }
 
@@ -729,7 +729,7 @@ int tape_set_compression(struct device_data *dev, bool use_compression)
 
 	ret = dev->backend->set_compression(dev->backend_data, use_compression, &dev->position);
 	if (ret < 0)
-		ltfsmsg(LTFS_ERR, "12031E", ret);
+		ltfsmsg(LTFS_ERR, 12031E, ret);
 	return ret;
 }
 
@@ -743,7 +743,7 @@ int tape_get_append_position(struct device_data *dev, tape_partition_t prt, tape
 	CHECK_ARG_NULL(dev, -LTFS_NULL_ARG);
 
 	if (prt > 1) {
-		ltfsmsg(LTFS_ERR, "12032E", (unsigned long)prt);
+		ltfsmsg(LTFS_ERR, 12032E, (unsigned long)prt);
 		return -LTFS_BAD_PARTNUM;
 	}
 
@@ -781,7 +781,7 @@ int tape_set_append_position(struct device_data *dev, tape_partition_t prt, tape
 
 	CHECK_ARG_NULL(dev, -LTFS_NULL_ARG);
 	if (prt > 1) {
-		ltfsmsg(LTFS_ERR, "12032E", (unsigned long)prt);
+		ltfsmsg(LTFS_ERR, 12032E, (unsigned long)prt);
 		return -LTFS_BAD_PARTNUM;
 	}
 
@@ -813,7 +813,7 @@ int tape_seek_append_position(struct device_data *dev, tape_partition_t prt, boo
 		new_pos.block = TAPE_BLOCK_MAX;
 	ret = tape_seek(dev, &new_pos);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "12033E", ret);
+		ltfsmsg(LTFS_ERR, 12033E, ret);
 		dev->write_error = true;
 		return ret;
 	}
@@ -845,7 +845,7 @@ int tape_get_params(struct device_data *dev, struct tc_current_param *param)
 
 	ret = dev->backend->get_parameters(dev->backend_data, param);
 	if (ret < 0)
-		ltfsmsg(LTFS_ERR, "12034E", ret);
+		ltfsmsg(LTFS_ERR, 12034E, ret);
 
 	return ret;
 }
@@ -946,7 +946,7 @@ int tape_rewind(struct device_data *dev)
 
 	ret = dev->backend->rewind(dev->backend_data, &dev->position);
 	if (ret < 0)
-		ltfsmsg(LTFS_ERR, "12035E", ret);
+		ltfsmsg(LTFS_ERR, 12035E, ret);
 	return ret;
 }
 
@@ -970,7 +970,7 @@ int tape_seek(struct device_data *dev, struct tc_position *pos)
 		/* Explicitly seek to (0,0) to detect known upper generation tape */
 		ret = dev->backend->locate(dev->backend_data, *pos, &dev->position);
 		if (ret < 0)
-			ltfsmsg(LTFS_ERR, "12037E", ret);
+			ltfsmsg(LTFS_ERR, 12037E, ret);
 		else {
 			ltfs_mutex_lock(&dev->read_only_flag_mutex);
 			if (dev->position.early_warning)
@@ -986,7 +986,7 @@ int tape_seek(struct device_data *dev, struct tc_position *pos)
 
 	if (ret == 0 && (dev->position.partition != pos->partition ||
 		(pos->block != TAPE_BLOCK_MAX && pos->block != dev->position.block))) {
-		ltfsmsg(LTFS_ERR, "12036E");
+		ltfsmsg(LTFS_ERR, 12036E);
 		ret = -LTFS_BAD_LOCATE;
 	}
 
@@ -1008,19 +1008,19 @@ int tape_seek_eod(struct device_data *dev, tape_partition_t partition)
 	CHECK_ARG_NULL(dev->backend, -LTFS_NULL_ARG);
 
 	if (partition > 1) {
-		ltfsmsg(LTFS_ERR, "12038E", (unsigned long)partition);
+		ltfsmsg(LTFS_ERR, 12038E, (unsigned long)partition);
 		return -LTFS_BAD_PARTNUM;
 	}
 
 	ret = dev->backend->locate(dev->backend_data, seekpos, &dev->position);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "12039E", ret);
+		ltfsmsg(LTFS_ERR, 12039E, ret);
 		return ret;
 	}
 
 	/* Check that partition searched is correct */
 	if (partition != dev->position.partition) {
-		ltfsmsg(LTFS_ERR, "11327E", partition, dev->position.partition);
+		ltfsmsg(LTFS_ERR, 11327E, partition, dev->position.partition);
 		return -LTFS_BAD_LOCATE;
 	}
 
@@ -1062,7 +1062,7 @@ int tape_update_position(struct device_data *dev, struct tc_position *pos)
 
 	ret = dev->backend->readpos(dev->backend_data, &dev->position);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17132E");
+		ltfsmsg(LTFS_ERR, 17132E);
 		return ret;
 	}
 
@@ -1080,19 +1080,19 @@ int tape_get_physical_block_position(struct device_data *dev, struct tc_position
 
 	ret = dev->backend->readpos(dev->backend_data, &dev->position);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17132E");
+		ltfsmsg(LTFS_ERR, 17132E);
 		return ret;
 	}
 
 	ret = dev->backend->get_block_in_buffer(dev->backend_data, &block);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17132E");
+		ltfsmsg(LTFS_ERR, 17132E);
 		return ret;
 	}
 
 	memcpy(pos, &dev->position, sizeof(struct tc_position));
 
-	ltfsmsg(LTFS_DEBUG, "11335D", pos->block, block);
+	ltfsmsg(LTFS_DEBUG, 11335D, (int)pos->block, block);
 	pos->block -= block;
 
 	return 0;
@@ -1117,7 +1117,7 @@ int tape_spacefm(struct device_data *dev, int count)
 		ret = dev->backend->space(dev->backend_data, -count, TC_SPACE_FM_B, &dev->position);
 
 	if (ret < 0)
-		ltfsmsg(LTFS_ERR, "12041E", ret);
+		ltfsmsg(LTFS_ERR, 12041E, ret);
 	return ret;
 }
 
@@ -1137,26 +1137,26 @@ ssize_t tape_write(struct device_data *dev, const char *buf, size_t count, bool 
 	CHECK_ARG_NULL(dev, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(buf, -LTFS_NULL_ARG);
 	if (! dev->backend || ! dev->backend_data) {
-		ltfsmsg(LTFS_ERR, "12042E");
+		ltfsmsg(LTFS_ERR, 12042E);
 		return -LTFS_NULL_ARG;
 	}
 
 	ret = 0;
 	ltfs_mutex_lock(&dev->read_only_flag_mutex);
 	if (dev->write_protected) {
-		ltfsmsg(LTFS_ERR, "12043E");
+		ltfsmsg(LTFS_ERR, 12043E);
 		ret = -LTFS_WRITE_PROTECT;
 	} else if (dev->write_error) {
-		ltfsmsg(LTFS_ERR, "12043E");
+		ltfsmsg(LTFS_ERR, 12043E);
 		ret = -LTFS_WRITE_ERROR;
 	} else if (dev->partition_space[dev->position.partition] == PART_NO_SPACE && !ignore_nospc) {
-		ltfsmsg(LTFS_ERR, "12064E");
+		ltfsmsg(LTFS_ERR, 12064E);
 		ret = -LTFS_NO_SPACE;
 	} else if (dev->partition_space[dev->position.partition] == PART_LESS_SPACE && !ignore_less) {
-		ltfsmsg(LTFS_ERR, "12064E");
+		ltfsmsg(LTFS_ERR, 12064E);
 		ret = -LTFS_LESS_SPACE;
 	} else if (count > dev->max_block_size) {
-		ltfsmsg(LTFS_ERR, "12044E", count, (unsigned long)dev->max_block_size);
+		ltfsmsg(LTFS_ERR, 12044E, (unsigned int)count, (unsigned long)dev->max_block_size);
 		ret = -LTFS_LARGE_BLOCKSIZE;
 	}
 	ltfs_mutex_unlock(&dev->read_only_flag_mutex);
@@ -1167,7 +1167,7 @@ ssize_t tape_write(struct device_data *dev, const char *buf, size_t count, bool 
 	if (ret < 0) {
 		/* If a "real" write error occurs, refuse any additional writes */
 		if (! NEED_REVAL(ret)) {
-			ltfsmsg(LTFS_ERR, "12045E", ret);
+			ltfsmsg(LTFS_ERR, 12045E, (int)ret);
 			ltfs_mutex_lock(&dev->read_only_flag_mutex);
 			dev->write_error = true;
 			ltfs_mutex_unlock(&dev->read_only_flag_mutex);
@@ -1209,7 +1209,7 @@ int tape_write_filemark(struct device_data *dev, uint8_t count, bool ignore_less
 
 	CHECK_ARG_NULL(dev, -LTFS_NULL_ARG);
 	if (! dev->backend || ! dev->backend_data) {
-		ltfsmsg(LTFS_ERR, "12046E");
+		ltfsmsg(LTFS_ERR, 12046E);
 		return -LTFS_NULL_ARG;
 	}
 
@@ -1231,7 +1231,7 @@ int tape_write_filemark(struct device_data *dev, uint8_t count, bool ignore_less
 	if (ret < 0) {
 		/* If a "real" write error occurs, refuse all further writes */
 		if (! NEED_REVAL(ret)) {
-			ltfsmsg(LTFS_ERR, "12047E", ret);
+			ltfsmsg(LTFS_ERR, 12047E, ret);
 			ltfs_mutex_lock(&dev->read_only_flag_mutex);
 			dev->write_error = true;
 			ltfs_mutex_unlock(&dev->read_only_flag_mutex);
@@ -1275,7 +1275,7 @@ ssize_t tape_read(struct device_data *dev, char *buf, size_t count, const bool u
 	CHECK_ARG_NULL(dev, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(buf, -LTFS_NULL_ARG);
 	if (! dev->backend || ! dev->backend_data) {
-		ltfsmsg(LTFS_ERR, "12048E");
+		ltfsmsg(LTFS_ERR, 12048E);
 		return -LTFS_BAD_DEVICE_DATA;
 	}
 
@@ -1288,21 +1288,21 @@ ssize_t tape_read(struct device_data *dev, char *buf, size_t count, const bool u
 		do {
 			tmp = tape_get_keyalias(dev, &keyalias);
 			if (tmp < 0) {
-				ltfsmsg(LTFS_ERR, "17175E", tmp);
+				ltfsmsg(LTFS_ERR, 17175E, tmp);
 				break;
 			}
 			tmp = kmi_get_key(&keyalias, &key, kmi_handle);
 			if (tmp < 0) {
-				ltfsmsg(LTFS_ERR, "17176E", tmp);
+				ltfsmsg(LTFS_ERR, 17176E, tmp);
 				break;
 			}
 			if (! key) {
-				ltfsmsg(LTFS_ERR, "17177E");
+				ltfsmsg(LTFS_ERR, 17177E);
 				break;
 			}
 			tmp = tape_set_key(dev, keyalias, key);
 			if (tmp < 0) {
-				ltfsmsg(LTFS_ERR, "17178E", tmp);
+				ltfsmsg(LTFS_ERR, 17178E, tmp);
 				break;
 			}
 
@@ -1312,9 +1312,9 @@ ssize_t tape_read(struct device_data *dev, char *buf, size_t count, const bool u
 	}
 
 	if (ret == -EDEV_CRYPTO_ERROR || ret == -EDEV_KEY_REQUIRED)
-		ltfsmsg(LTFS_WARN, "17192W");
+		ltfsmsg(LTFS_WARN, 17192W);
 	if (ret < 0)
-		ltfsmsg(LTFS_ERR, "12049E", ret);
+		ltfsmsg(LTFS_ERR, 12049E, (int)ret);
 	return ret;
 }
 
@@ -1332,7 +1332,7 @@ int tape_erase(struct device_data *dev, bool long_erase)
 
 	ret = dev->backend->erase(dev->backend_data, &dev->position, long_erase);
 	if (ret < 0)
-		ltfsmsg(LTFS_ERR, "17149E", ret);
+		ltfsmsg(LTFS_ERR, 17149E, ret);
 
 	return ret;
 }
@@ -1359,14 +1359,14 @@ int tape_reset_capacity(struct device_data *dev)
 	 */
 	ret = dev->backend->load(dev->backend_data, &dev->position);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "12050E", ret);
+		ltfsmsg(LTFS_ERR, 12050E, ret);
 		return ret;
 	}
 
 	/* Issue Set Capacity */
 	ret = dev->backend->setcap(dev->backend_data, 0xFFFF);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17164E", ret);
+		ltfsmsg(LTFS_ERR, 17164E, ret);
 		return ret;
 	}
 
@@ -1385,7 +1385,7 @@ static int tape_update_density(struct device_data *dev, int density_code)
 	ret = dev->backend->modesense(dev->backend_data, TC_MP_READ_WRITE_CTRL, TC_MP_PC_CURRENT, 0x00,
 								  mp_read_write_ctrl, TC_MP_READ_WRITE_CTRL_SIZE);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17239E", "modesense", ret);
+		ltfsmsg(LTFS_ERR, 17239E, "modesense", ret);
 		return ret;
 	}
 
@@ -1396,10 +1396,10 @@ static int tape_update_density(struct device_data *dev, int density_code)
 
 	ret = dev->backend->modeselect(dev->backend_data, mp_read_write_ctrl, TC_MP_READ_WRITE_CTRL_SIZE);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17239E", "modeselect", ret);
+		ltfsmsg(LTFS_ERR, 17239E, "modeselect", ret);
 	}
 
-	ltfsmsg(LTFS_INFO, "17240I", density_code);
+	ltfsmsg(LTFS_INFO, 17240I, density_code);
 
 	return 0;
 }
@@ -1425,7 +1425,7 @@ int tape_format(struct device_data *dev, tape_partition_t index_part, int densit
 	 */
 	ret = dev->backend->load(dev->backend_data, &dev->position);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "12050E", ret);
+		ltfsmsg(LTFS_ERR, 12050E, ret);
 		return ret;
 	}
 
@@ -1434,7 +1434,7 @@ int tape_format(struct device_data *dev, tape_partition_t index_part, int densit
 	ret = dev->backend->modesense(dev->backend_data, TC_MP_MEDIUM_PARTITION, TC_MP_PC_CURRENT, 0x00,
 		mp_medium_partition, TC_MP_MEDIUM_PARTITION_SIZE);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "12051E", ret);
+		ltfsmsg(LTFS_ERR, 12051E, ret);
 		return ret;
 	}
 
@@ -1443,7 +1443,7 @@ int tape_format(struct device_data *dev, tape_partition_t index_part, int densit
 			&& mp_medium_partition[2]!=TC_MP_JK && mp_medium_partition[2]!=TC_MP_JL
 			&& mp_medium_partition[2]!=TC_MP_JY && mp_medium_partition[2]!=TC_MP_JZ
 			&& mp_medium_partition[2]!=TC_MP_LTO7D_CART){
-			ltfsmsg(LTFS_ERR, "17239E", "unsupported cartridge", mp_medium_partition[2]);
+			ltfsmsg(LTFS_ERR, 17239E, "unsupported cartridge", mp_medium_partition[2]);
 			return -LTFS_OP_NOT_ALLOWED;
 		}
 
@@ -1488,7 +1488,7 @@ int tape_format(struct device_data *dev, tape_partition_t index_part, int densit
 	/* Issue Format Medium (destroy all medium data and make 2-partitition medium) */
 	ret = dev->backend->format(dev->backend_data, TC_FORMAT_DEST_PART);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "12053E", ret);
+		ltfsmsg(LTFS_ERR, 12053E, ret);
 		return ret;
 	}
 
@@ -1513,14 +1513,14 @@ int tape_unformat(struct device_data *dev)
 	/* Locate block 0 @ P0 */
 	ret = dev->backend->locate(dev->backend_data, bom, &dev->position);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "12054E", ret);
+		ltfsmsg(LTFS_ERR, 12054E, ret);
 		return ret;
 	}
 
 	/* Issue Format Medium */
 	ret = dev->backend->format(dev->backend_data, TC_FORMAT_DEFAULT);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "12055E", ret);
+		ltfsmsg(LTFS_ERR, 12055E, ret);
 		return ret;
 	}
 
@@ -1555,7 +1555,7 @@ int tape_get_volume_change_reference(struct device_data *dev, uint64_t *volume_c
 		if (*volume_change_ref == UINT32_MAX)
 			*volume_change_ref = UINT64_MAX; /* maintain "unusable VCR" state correctly */
 	} else {
-		ltfsmsg(LTFS_WARN, "12056W", ret);
+		ltfsmsg(LTFS_WARN, 12056W, ret);
 		*volume_change_ref = UINT64_MAX; /* disallow use of VCR */
 	}
 
@@ -1587,12 +1587,12 @@ int tape_get_cart_coherency(struct device_data *dev, const tape_partition_t part
 		uint8_t  vcr_size = coh_data[5];
 
 		if (id != TC_MAM_PAGE_COHERENCY) {
-			ltfsmsg(LTFS_WARN, "12058W", id);
+			ltfsmsg(LTFS_WARN, 12058W, id);
 			return -LTFS_UNEXPECTED_VALUE;
 		}
 
 		if (len != TC_MAM_PAGE_COHERENCY_SIZE) {
-			ltfsmsg(LTFS_WARN, "12059W", len);
+			ltfsmsg(LTFS_WARN, 12059W, len);
 			return -LTFS_UNEXPECTED_VALUE;
 		}
 
@@ -1604,7 +1604,7 @@ int tape_get_cart_coherency(struct device_data *dev, const tape_partition_t part
 				coh->volume_change_ref = ltfs_betou64(coh_data + 6);
 				break;
 			default:
-				ltfsmsg(LTFS_WARN, "12060W", vcr_size);
+				ltfsmsg(LTFS_WARN, 12060W, vcr_size);
 				return -LTFS_UNEXPECTED_VALUE;
 		}
 
@@ -1616,10 +1616,10 @@ int tape_get_cart_coherency(struct device_data *dev, const tape_partition_t part
 		 */
 		uint16_t ap_clent_specific_len = ltfs_betou16(coh_data + 30);
 		if (ap_clent_specific_len != 42 && ap_clent_specific_len != 43) {
-			ltfsmsg(LTFS_WARN, "12061W", ap_clent_specific_len);
+			ltfsmsg(LTFS_WARN, 12061W, ap_clent_specific_len);
 			return -LTFS_UNEXPECTED_VALUE;
 		} else if (strncmp((char *)coh_data + 32, "LTFS", sizeof("LTFS")) != 0) {
-			ltfsmsg(LTFS_WARN, "12062W");
+			ltfsmsg(LTFS_WARN, 12062W);
 			return -LTFS_UNEXPECTED_VALUE;
 		}
 
@@ -1630,7 +1630,7 @@ int tape_get_cart_coherency(struct device_data *dev, const tape_partition_t part
 		 */
 		coh->version = coh_data[74];
 	} else
-		ltfsmsg(LTFS_WARN, "12057W", ret);
+		ltfsmsg(LTFS_WARN, 12057W, ret);
 
 	return ret;
 }
@@ -1670,7 +1670,7 @@ int tape_set_cart_coherency(struct device_data *dev, const tape_partition_t part
 
 	ret = dev->backend->write_attribute(dev->backend_data, part, coh_data, sizeof(coh_data));
 	if (ret < 0)
-		ltfsmsg(LTFS_WARN, "12063W", ret);
+		ltfsmsg(LTFS_WARN, 12063W, ret);
 	return ret;
 }
 
@@ -1693,23 +1693,23 @@ int tape_get_cart_volume_lock_status(struct device_data *dev, int *status)
 		uint16_t len = ltfs_betou16(attr_data + 3);
 
 		if (id != TC_MAM_VOLUME_LOCKED) {
-			ltfsmsg(LTFS_WARN, "17196W", id);
+			ltfsmsg(LTFS_WARN, 17196W, id);
 			return -LTFS_UNEXPECTED_VALUE;
 		}
 		if (len != TC_MAM_VOLUME_LOCKED_SIZE) {
-			ltfsmsg(LTFS_WARN, "17197W", len);
+			ltfsmsg(LTFS_WARN, 17197W, len);
 			return -LTFS_UNEXPECTED_VALUE;
 		}
 
 		*status = (int)(attr_data[TC_MAM_PAGE_HEADER_SIZE]); /* TC_MAM_LOCKED_SIZE is 1 byte field */
-		ltfsmsg(LTFS_DEBUG, "11339D", "Read", *status);
+		ltfsmsg(LTFS_DEBUG, 11339D, "Read", *status);
 
 	} else if (ret == -EDEV_INVALID_FIELD_CDB) {
-		ltfsmsg(LTFS_INFO, "11336I");
+		ltfsmsg(LTFS_INFO, 11336I);
 		*status = VOLUME_UNLOCKED;
 		ret = 0;
 	} else
-		ltfsmsg(LTFS_DEBUG, "17198D", TC_MAM_VOLUME_LOCKED, "tape_get_cart_volume_lock_status");
+		ltfsmsg(LTFS_DEBUG, 17198D, TC_MAM_VOLUME_LOCKED, "tape_get_cart_volume_lock_status");
 
 	return ret;
 }
@@ -1726,11 +1726,11 @@ int tape_set_cart_volume_lock_status(struct ltfs_volume *vol, int status)
 		return 0;
 	} else if (cur_stat == VOLUME_PERM_LOCKED) {
 		/* perm locked cartridge cannot be updated */
-		ltfsmsg(LTFS_WARN, "17199W", TC_MAM_VOLUME_LOCKED, "tape_set_cart_volume_lock_status : perm locked");
+		ltfsmsg(LTFS_WARN, 17199W, TC_MAM_VOLUME_LOCKED, "tape_set_cart_volume_lock_status : perm locked");
 		return -LTFS_UNEXPECTED_VALUE;
 	} else if (status > VOLUME_WRITE_PERM_BOTH) {
 		/* invalid status */
-		ltfsmsg(LTFS_WARN, "17199W", TC_MAM_VOLUME_LOCKED, "tape_set_cart_volume_lock_status : invalid stat");
+		ltfsmsg(LTFS_WARN, 17199W, TC_MAM_VOLUME_LOCKED, "tape_set_cart_volume_lock_status : invalid stat");
 		return -LTFS_UNEXPECTED_VALUE;
 	}
 
@@ -1740,7 +1740,7 @@ int tape_set_cart_volume_lock_status(struct ltfs_volume *vol, int status)
 	/* update CM MAM attribute */
 	ret = update_tape_attribute(vol, value, TC_MAM_VOLUME_LOCKED, TC_MAM_VOLUME_LOCKED_SIZE);
 	if (ret < 0) {
-		ltfsmsg(LTFS_WARN, "17199W", TC_MAM_VOLUME_LOCKED, "tape_set_cart_volume_lock_status");
+		ltfsmsg(LTFS_WARN, 17199W, TC_MAM_VOLUME_LOCKED, "tape_set_cart_volume_lock_status");
 		return ret;
 	}
 
@@ -1861,7 +1861,7 @@ int tape_set_media_pool_info(struct ltfs_volume *vol, const char *new_val, int s
 	/* update CM MAM attribute */
 	ret = update_tape_attribute(vol, value, TC_MAM_MEDIA_POOL, strlen(value));
 	if (ret < 0) {
-		ltfsmsg(LTFS_WARN, "17199W", TC_MAM_MEDIA_POOL, "tape_get_media_pool_info");
+		ltfsmsg(LTFS_WARN, 17199W, TC_MAM_MEDIA_POOL, "tape_get_media_pool_info");
 	}
 
 	free(v);
@@ -1915,29 +1915,29 @@ int tape_recover_eod_status(struct device_data *dev, void * const kmi_handle)
 
 	ret = tape_get_max_blocksize(dev, &recover_block_size);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17195E", "eod", ret);
+		ltfsmsg(LTFS_ERR, 17195E, "eod", ret);
 		return ret;
 	}
 
 	buf = calloc(1, recover_block_size + LTFS_CRC_SIZE);
 	if (! buf) {
-		ltfsmsg(LTFS_ERR, "10001E", "tape_recover_eod_status: data buffer");
+		ltfsmsg(LTFS_ERR, 10001E, "tape_recover_eod_status: data buffer");
 		return -LTFS_NO_MEMORY;
 	}
 
 	/* Read forward by hitting read perm (actual EOD), or EOD */
-	ltfsmsg(LTFS_INFO, "17127I");
+	ltfsmsg(LTFS_INFO, 17127I);
 	ret = 0;
 	while ( ret >= 0) {
 		INTERRUPTED_RETURN();
 		ret = tape_read(dev, buf, (size_t)recover_block_size, true, kmi_handle);
 		if(ret == -EDEV_EOD_DETECTED) {
-			ltfsmsg(LTFS_INFO, "17169I");
+			ltfsmsg(LTFS_INFO, 17169I);
 		} else if (ret == -EDEV_READ_PERM)
-			ltfsmsg(LTFS_INFO, "17130I");
+			ltfsmsg(LTFS_INFO, 17130I);
 		else {
 			if(ret < 0)
-				ltfsmsg(LTFS_WARN, "17129W");
+				ltfsmsg(LTFS_WARN, 17129W);
 		}
 	}
 	free(buf);
@@ -1946,37 +1946,37 @@ int tape_recover_eod_status(struct device_data *dev, void * const kmi_handle)
 	/* Read position to specify the erase position */
 	ret = dev->backend->readpos(dev->backend_data, &eod_pos);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17132E");
+		ltfsmsg(LTFS_ERR, 17132E);
 		return ret;
 	}
 
 	/* Unload -> Load -> locate(erase point) -> erase to avoid drive fence behavior */
 	INTERRUPTED_RETURN();
-	ltfsmsg(LTFS_INFO, "17131I", eod_pos.partition, eod_pos.block);
+	ltfsmsg(LTFS_INFO, 17131I, (unsigned long long)eod_pos.partition, (unsigned long long)eod_pos.block);
 	ret = tape_unload_tape(false, dev);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17133E");
+		ltfsmsg(LTFS_ERR, 17133E);
 		return ret;
 	}
 
 	INTERRUPTED_RETURN();
 	ret = tape_load_tape(dev, kmi_handle, true);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17134E");
+		ltfsmsg(LTFS_ERR, 17134E);
 		return ret;
 	}
 
 	INTERRUPTED_RETURN();
 	ret = tape_seek(dev, &eod_pos);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17135E");
+		ltfsmsg(LTFS_ERR, 17135E);
 		return ret;
 	}
 
 	INTERRUPTED_RETURN();
 	ret = tape_erase(dev, false);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17136E");
+		ltfsmsg(LTFS_ERR, 17136E);
 		return ret;
 	}
 
@@ -2007,7 +2007,7 @@ int tape_get_device_list(struct tape_ops *ops, struct tc_drive_info *buf, int co
 void tape_print_help_message(struct tape_ops *ops)
 {
 	if (! ops) {
-		ltfsmsg(LTFS_WARN, "10006W", "ops", __FUNCTION__);
+		ltfsmsg(LTFS_WARN, 10006W, "ops", __FUNCTION__);
 		return;
 	}
 
@@ -2026,7 +2026,7 @@ int tape_parse_opts(struct device_data *dev, void *opt_args)
 	ret = dev->backend->parse_opts(dev->backend_data, opt_args);
 	if (ret < 0)
 		/* Cannot parse backend options: backend call failed (%d) */
-		ltfsmsg(LTFS_ERR, "12040E", ret);
+		ltfsmsg(LTFS_ERR, 12040E, ret);
 
 	return ret;
 }
@@ -2042,7 +2042,7 @@ int tape_parse_library_backend_opts(void *opts, void *opt_args)
 	rc = backend->parse_opts(NULL, opt_args);
 	if (rc < 0)
 		/* Cannot parse backend options: backend call failed (%d) */
-		ltfsmsg(LTFS_ERR, "12040E", rc);
+		ltfsmsg(LTFS_ERR, 12040E, rc);
 
 	return rc;
 }
@@ -2065,7 +2065,7 @@ int tape_inquiry(struct device_data *dev, struct tc_inq *inq)
 	ret = dev->backend->inquiry(dev->backend_data, inq);
 	if (ret < 0) {
 		/* Failed to inquiry the tape: backend call failed (%d) */
-		ltfsmsg(LTFS_ERR, "12013E", ret);
+		ltfsmsg(LTFS_ERR, 12013E, ret);
 	}
 
 	return ret;
@@ -2090,7 +2090,7 @@ int tape_inquiry_page(struct device_data *dev, unsigned char page, struct tc_inq
 	ret = dev->backend->inquiry_page(dev->backend_data, page, inq);
 	if (ret < 0) {
 		/* Failed to inquiry tape page: backend call failed (%d) */
-		ltfsmsg(LTFS_ERR, "12013E", ret);
+		ltfsmsg(LTFS_ERR, 12013E, ret);
 	}
 
 	return ret;
@@ -2300,7 +2300,7 @@ int tape_set_pews(struct device_data *dev, bool set_value)
 	/* Get remaining capacity of the tape */
 	ret = tape_get_capacity(dev, &cap);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11999E", ret);
+		ltfsmsg(LTFS_ERR, 11999E, ret);
 		return ret;
 	}
 
@@ -2319,7 +2319,7 @@ int tape_set_pews(struct device_data *dev, bool set_value)
 	ret = dev->backend->modesense(dev->backend_data, TC_MP_DEV_CONFIG_EXT, TC_MP_PC_CURRENT, 0x01,
 		mp_dev_config_ext, TC_MP_DEV_CONFIG_EXT_SIZE);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17102E", ret);
+		ltfsmsg(LTFS_ERR, 17102E, ret);
 		return ret;
 	}
 
@@ -2337,7 +2337,7 @@ int tape_set_pews(struct device_data *dev, bool set_value)
 		);
 
 	if (ret < 0)
-		ltfsmsg(LTFS_ERR, "17103E", ret);
+		ltfsmsg(LTFS_ERR, 17103E, ret);
 	return ret;
 }
 
@@ -2362,7 +2362,7 @@ int tape_get_pews(struct device_data *dev, uint16_t *pews)
 	ret = dev->backend->modesense(dev->backend_data, TC_MP_DEV_CONFIG_EXT, TC_MP_PC_CURRENT, 0x01,
 		mp_dev_config_ext, TC_MP_DEV_CONFIG_EXT_SIZE);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17104E", ret);
+		ltfsmsg(LTFS_ERR, 17104E, ret);
 		return ret;
 	}
 
@@ -2399,7 +2399,7 @@ int tape_enable_append_only_mode(struct device_data *dev, bool enable)
 	ret = dev->backend->modesense(dev->backend_data, TC_MP_DEV_CONFIG_EXT, TC_MP_PC_CURRENT, 0x01,
 		mp_dev_config_ext, TC_MP_DEV_CONFIG_EXT_SIZE);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17154E", ret);
+		ltfsmsg(LTFS_ERR, 17154E, ret);
 		return ret;
 	}
 
@@ -2408,7 +2408,7 @@ int tape_enable_append_only_mode(struct device_data *dev, bool enable)
 	if (loaded && !enable && (mp_dev_config_ext[21]& 0xF0) == 0x10) {
 		ret = dev->backend->unload(dev->backend_data, &dev->position);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "17151E", ret);
+			ltfsmsg(LTFS_ERR, 17151E, ret);
 			return ret;
 		}
 		reload = true;
@@ -2419,7 +2419,7 @@ int tape_enable_append_only_mode(struct device_data *dev, bool enable)
 		if (ret == -EDEV_MEDIUM_FORMAT_ERROR)
 			ret = -LTFS_UNSUPPORTED_MEDIUM;
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "17152E", "BOP", ret);
+			ltfsmsg(LTFS_ERR, 17152E, "BOP", ret);
 			return ret;
 		}
 	}
@@ -2436,14 +2436,14 @@ int tape_enable_append_only_mode(struct device_data *dev, bool enable)
 		mp_dev_config_ext,
 		TC_MP_DEV_CONFIG_EXT_SIZE);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17155E", ret);
+		ltfsmsg(LTFS_ERR, 17155E, ret);
 		return ret;
 	}
 
 	if (reload) {
 		ret = dev->backend->load(dev->backend_data, &dev->position);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "17152E", "Reload", ret);
+			ltfsmsg(LTFS_ERR, 17152E, "Reload", ret);
 			return ret;
 		}
 	}
@@ -2474,7 +2474,7 @@ int tape_get_append_only_mode_setting(struct device_data *dev, bool *enabled)
 	ret = dev->backend->modesense(dev->backend_data, TC_MP_DEV_CONFIG_EXT, TC_MP_PC_CURRENT, 0x01,
 		mp_dev_config_ext, TC_MP_DEV_CONFIG_EXT_SIZE);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17156E", ret);
+		ltfsmsg(LTFS_ERR, 17156E, ret);
 		return ret;
 	}
 
@@ -2543,14 +2543,14 @@ make_ready:
 			if (!print_message) {
 				switch (ret) {
 				case -EDEV_NEED_INITIALIZE:
-					ltfsmsg(LTFS_INFO, "17189I", ret);
+					ltfsmsg(LTFS_INFO, 17189I, ret);
 					break;
 				case -EDEV_BECOMING_READY:
-					ltfsmsg(LTFS_INFO, "17189I", ret);
+					ltfsmsg(LTFS_INFO, 17189I, ret);
 					print_message = true;
 					break;
 				default:
-					ltfsmsg(LTFS_ERR, "17187E", ret);
+					ltfsmsg(LTFS_ERR, 17187E, ret);
 					break;
 				}
 			}
@@ -2562,7 +2562,7 @@ make_ready:
 				const uint64_t any_cleaning_media = cleaning_media | expired_cleaning_tape | invalid_cleaning_tape;
 
 				if ((tape_alert & any_cleaning_media) != 0) {
-					ltfsmsg(LTFS_INFO, "17179I", tape_alert);
+					ltfsmsg(LTFS_INFO, 17179I, (unsigned long long)tape_alert);
 					return ret;
 				}
 
@@ -2580,7 +2580,7 @@ make_ready:
 	for(i = 0; i < 30 && ret < 0; i++) {
 		ret = _tape_test_unit_ready(dev);
 		if (ret != -EDEV_BECOMING_READY)
-			ltfsmsg(LTFS_INFO, "17188I", ret);
+			ltfsmsg(LTFS_INFO, 17188I, ret);
 		if (ret == DEVICE_GOOD || ret == -EDEV_NO_MEDIUM || ret == -EDEV_DRIVER_ERROR ||
 			IS_MEDIUM_ERROR(-ret) || IS_HARDWARE_ERROR(-ret) )
 			break;
@@ -2614,11 +2614,11 @@ int tape_set_key(struct device_data *dev, const unsigned char *keyalias, const u
 	if (0 <= ret) {
 		static int last_message_id = 0;
 		if (keyalias && key) {
-			ltfsmsg(LTFS_INFO, "17190I"); /* Show the message at every DK setting because the difference DK may set. */
+			ltfsmsg(LTFS_INFO, 17190I); /* Show the message at every DK setting because the difference DK may set. */
 			last_message_id = 17190;
 		} else {
 			if (last_message_id != 17191) {
-				ltfsmsg(LTFS_INFO, "17191I"); /* Do not show the message at redundant clear. */
+				ltfsmsg(LTFS_INFO, 17191I); /* Do not show the message at redundant clear. */
 				last_message_id = 17191;
 			}
 		}
@@ -2825,12 +2825,12 @@ void set_tape_attribute(struct ltfs_volume *vol, struct tape_attr *t_attr)
 	int len_volname = 0;
 
 	if (!vol) {
-		ltfsmsg(LTFS_ERR, "17231E", "set", "dev");
+		ltfsmsg(LTFS_ERR, 17231E, "set", "dev");
 		return;
 	}
 
 	if (!t_attr) {
-		ltfsmsg(LTFS_ERR, "17231E", "set", "t_attr");
+		ltfsmsg(LTFS_ERR, 17231E, "set", "t_attr");
 		return;
 	}
 
@@ -2852,7 +2852,7 @@ void set_tape_attribute(struct ltfs_volume *vol, struct tape_attr *t_attr)
 	if ( vol->index->volume_name.name ) {
 		len_volname = strlen(vol->index->volume_name.name);
 		if ( len_volname > TC_MAM_USER_MEDIUM_LABEL_SIZE - 1) {
-			ltfsmsg(LTFS_DEBUG, "17229D", "USER MEDIUM TEXT LABEL",
+			ltfsmsg(LTFS_DEBUG, 17229D, "USER MEDIUM TEXT LABEL",
 					vol->index->volume_name.name, TC_MAM_USER_MEDIUM_LABEL_SIZE - 1);
 			len_volname = u_get_truncate_size(vol->index->volume_name.name, len_volname, TC_MAM_USER_MEDIUM_LABEL_SIZE);
 			if (len_volname == -LTFS_ICU_ERROR)
@@ -2867,11 +2867,11 @@ void set_tape_attribute(struct ltfs_volume *vol, struct tape_attr *t_attr)
 	/* BARCODE set */
 	if ( vol->label->barcode[0] ) {
 		if ( strlen(vol->label->barcode) > TC_MAM_BARCODE_SIZE)
-			ltfsmsg(LTFS_WARN, "17203W", "BARCODE", vol->label->barcode, TC_MAM_BARCODE_SIZE);
+			ltfsmsg(LTFS_WARN, 17203W, "BARCODE", vol->label->barcode, TC_MAM_BARCODE_SIZE);
 		strncpy(t_attr->barcode, vol->label->barcode, TC_MAM_BARCODE_SIZE);
 		parse_vol(t_attr->barcode, strlen(vol->label->barcode), TC_MAM_BARCODE_SIZE);
 	} else {
-		ltfsmsg(LTFS_WARN, "17230W");
+		ltfsmsg(LTFS_WARN, 17230W);
 		parse_vol(t_attr->barcode, 0, TC_MAM_BARCODE_SIZE);
 	}
 
@@ -2933,7 +2933,7 @@ int tape_set_attribute_to_cm(struct device_data *dev, struct tape_attr *t_attr, 
 		attr_size = TC_MAM_MEDIA_POOL_SIZE;
 		format = TEXT_FORMAT;
 	} else {
-		ltfsmsg(LTFS_WARN, "17204W", type, "tape_set_attribute_to_cm");
+		ltfsmsg(LTFS_WARN, 17204W, type, "tape_set_attribute_to_cm");
 		return -1;
 	}
 
@@ -2970,7 +2970,7 @@ int tape_set_attribute_to_cm(struct device_data *dev, struct tape_attr *t_attr, 
 	                                      sizeof(attr_data));
 
 	if (ret < 0)
-		ltfsmsg(LTFS_ERR, "17205E", type, "tape_set_attribute_to_cm");
+		ltfsmsg(LTFS_ERR, 17205E, type, "tape_set_attribute_to_cm");
 
 	return ret;
 
@@ -3084,7 +3084,7 @@ int tape_get_attribute_from_cm(struct device_data *dev, struct tape_attr *t_attr
 		attr_len = TC_MAM_MEDIA_POOL_SIZE;
 		break;
 	default:
-		ltfsmsg(LTFS_WARN, "17204W", type, "tape_get_attribute_from_cm");
+		ltfsmsg(LTFS_WARN, 17204W, type, "tape_get_attribute_from_cm");
 		return -LTFS_BAD_ARG;
 		break;
 	}
@@ -3102,11 +3102,11 @@ int tape_get_attribute_from_cm(struct device_data *dev, struct tape_attr *t_attr
 		uint16_t len = ltfs_betou16(attr_data + 3);
 
 		if (id != type) {
-			ltfsmsg(LTFS_WARN, "17196W", id);
+			ltfsmsg(LTFS_WARN, 17196W, id);
 			return -LTFS_UNEXPECTED_VALUE;
 		}
 		if (len != attr_len) {
-			ltfsmsg(LTFS_WARN, "17197W", len);
+			ltfsmsg(LTFS_WARN, 17197W, len);
 			return -LTFS_UNEXPECTED_VALUE;
 		}
 
@@ -3137,7 +3137,7 @@ int tape_get_attribute_from_cm(struct device_data *dev, struct tape_attr *t_attr
 			t_attr->media_pool[attr_len] = '\0';
 		}
 	} else
-		ltfsmsg(LTFS_DEBUG, "17198D", type, "tape_get_attribute_from_cm");
+		ltfsmsg(LTFS_DEBUG, 17198D, type, "tape_get_attribute_from_cm");
 
 	return ret;
 }
@@ -3153,12 +3153,12 @@ void tape_load_all_attribute_from_cm(struct device_data *dev, struct tape_attr *
 	int ret;
 
 	if (!dev) {
-		ltfsmsg(LTFS_ERR, "17231E", "get", "dev");
+		ltfsmsg(LTFS_ERR, 17231E, "get", "dev");
 		return;
 	}
 
 	if (!t_attr) {
-		ltfsmsg(LTFS_ERR, "17231E", "get", "t_attr");
+		ltfsmsg(LTFS_ERR, 17231E, "get", "t_attr");
 		return;
 	}
 
@@ -3207,15 +3207,15 @@ void tape_load_all_attribute_from_cm(struct device_data *dev, struct tape_attr *
 	if (ret < 0)
 		t_attr->media_pool[0] = '\0';
 
-	ltfsmsg(LTFS_INFO, "17227I", "Vendor", t_attr->vender);
-	ltfsmsg(LTFS_INFO, "17227I", "Application Name", t_attr->app_name);
-	ltfsmsg(LTFS_INFO, "17227I", "Application Version", t_attr->app_ver);
-	ltfsmsg(LTFS_INFO, "17227I", "Medium Label", t_attr->medium_label);
-	ltfsmsg(LTFS_INFO, "17228I", "Text Localization ID", t_attr->tli);
-	ltfsmsg(LTFS_INFO, "17227I", "Barcode", t_attr->barcode);
-	ltfsmsg(LTFS_INFO, "17227I", "Application Format Version", t_attr->app_format_ver);
-	ltfsmsg(LTFS_INFO, "17228I", "Volume Lock Status", t_attr->vollock);
-	ltfsmsg(LTFS_INFO, "17227I", "Media Pool name", t_attr->media_pool);
+	ltfsmsg(LTFS_INFO, 17227I, "Vendor", t_attr->vender);
+	ltfsmsg(LTFS_INFO, 17227I, "Application Name", t_attr->app_name);
+	ltfsmsg(LTFS_INFO, 17227I, "Application Version", t_attr->app_ver);
+	ltfsmsg(LTFS_INFO, 17227I, "Medium Label", t_attr->medium_label);
+	ltfsmsg(LTFS_INFO, 17228I, "Text Localization ID", t_attr->tli);
+	ltfsmsg(LTFS_INFO, 17227I, "Barcode", t_attr->barcode);
+	ltfsmsg(LTFS_INFO, 17227I, "Application Format Version", t_attr->app_format_ver);
+	ltfsmsg(LTFS_INFO, 17228I, "Volume Lock Status", t_attr->vollock);
+	ltfsmsg(LTFS_INFO, 17227I, "Media Pool name", t_attr->media_pool);
 
 	return;
 }
@@ -3238,7 +3238,7 @@ int update_tape_attribute(struct ltfs_volume *vol, const char *new_value, int ty
 	/* type check */
 	if (type != TC_MAM_USER_MEDIUM_LABEL && type != TC_MAM_BARCODE
 	 && type != TC_MAM_VOLUME_LOCKED && type != TC_MAM_MEDIA_POOL) {
-		ltfsmsg(LTFS_WARN, "17204W", type, "update_tape_attribute");
+		ltfsmsg(LTFS_WARN, 17204W, type, "update_tape_attribute");
 		return -1;
 	}
 
@@ -3248,7 +3248,7 @@ int update_tape_attribute(struct ltfs_volume *vol, const char *new_value, int ty
 	/* Attribute size check */
 	if ( type == TC_MAM_USER_MEDIUM_LABEL ) {
 		if ( size > TC_MAM_USER_MEDIUM_LABEL_SIZE - 1) {
-			ltfsmsg(LTFS_DEBUG, "17229D", "USER MEDIUM TEXT LABEL",
+			ltfsmsg(LTFS_DEBUG, 17229D, "USER MEDIUM TEXT LABEL",
 					vol->index->volume_name.name, TC_MAM_USER_MEDIUM_LABEL_SIZE - 1);
 			size = u_get_truncate_size(vol->index->volume_name.name, size, TC_MAM_USER_MEDIUM_LABEL_SIZE);
 			if (size == -LTFS_ICU_ERROR)
@@ -3256,7 +3256,7 @@ int update_tape_attribute(struct ltfs_volume *vol, const char *new_value, int ty
 		}
 		pre_attr = strdup(vol->t_attr->medium_label);
 		if (! pre_attr) {
-			ltfsmsg(LTFS_ERR, "10001E", "update_tape_attribute: pre_attr");
+			ltfsmsg(LTFS_ERR, 10001E, "update_tape_attribute: pre_attr");
 		    ret = -ENOMEM;
 		    return ret;
 		}
@@ -3266,12 +3266,12 @@ int update_tape_attribute(struct ltfs_volume *vol, const char *new_value, int ty
 		}
 	} else if (type == TC_MAM_BARCODE) {
 		if ( size > TC_MAM_BARCODE_SIZE) {
-			ltfsmsg(LTFS_WARN, "17226W", "BARCODE", TC_MAM_BARCODE_SIZE);
+			ltfsmsg(LTFS_WARN, 17226W, "BARCODE", TC_MAM_BARCODE_SIZE);
 			return -LTFS_LARGE_XATTR;
 		}
 		pre_attr = strdup(vol->t_attr->barcode);
 		if (! pre_attr) {
-		    ltfsmsg(LTFS_ERR, "10001E", "update_tape_attribute: pre_attr");
+		    ltfsmsg(LTFS_ERR, 10001E, "update_tape_attribute: pre_attr");
 		    ret = -ENOMEM;
 		    return ret;
 		}
@@ -3282,7 +3282,7 @@ int update_tape_attribute(struct ltfs_volume *vol, const char *new_value, int ty
 		parse_vol(vol->t_attr->barcode, strlen(new_value), TC_MAM_BARCODE_SIZE);
 	} else if (type == TC_MAM_VOLUME_LOCKED) {
 		if ( size > TC_MAM_VOLUME_LOCKED_SIZE) {
-			ltfsmsg(LTFS_WARN, "17226W", "VOLLOCK", TC_MAM_VOLUME_LOCKED_SIZE);
+			ltfsmsg(LTFS_WARN, 17226W, "VOLLOCK", TC_MAM_VOLUME_LOCKED_SIZE);
 			return -LTFS_LARGE_XATTR;
 		}
 
@@ -3291,7 +3291,7 @@ int update_tape_attribute(struct ltfs_volume *vol, const char *new_value, int ty
 		}
 	} else if (type == TC_MAM_MEDIA_POOL) {
 		if ( size > TC_MAM_MEDIA_POOL_SIZE) {
-			ltfsmsg(LTFS_WARN, "17226W", "MEDIAPOOL", TC_MAM_MEDIA_POOL_SIZE);
+			ltfsmsg(LTFS_WARN, 17226W, "MEDIAPOOL", TC_MAM_MEDIA_POOL_SIZE);
 			return -LTFS_LARGE_XATTR;
 		}
 		memset(vol->t_attr->media_pool, '\0', TC_MAM_MEDIA_POOL_SIZE + 1);
@@ -3365,7 +3365,7 @@ int read_tape_attribute(struct ltfs_volume *vol, char **val, const char *name)
 	}
 
 	if (!*val) {
-		ltfsmsg(LTFS_ERR, "10001E", "read_tape_attribute: *val");
+		ltfsmsg(LTFS_ERR, 10001E, "read_tape_attribute: *val");
 		return -LTFS_UNEXPECTED_VALUE;
 	}
 

--- a/src/libltfs/xattr.c
+++ b/src/libltfs/xattr.c
@@ -112,12 +112,12 @@ int xattr_do_set(struct dentry *d, const char *name, const char *value, size_t s
 	} else {
 		xattr = (struct xattr_info *) calloc(1, sizeof(struct xattr_info));
 		if (! xattr) {
-			ltfsmsg(LTFS_ERR, "10001E", "xattr_do_set: xattr");
+			ltfsmsg(LTFS_ERR, 10001E, "xattr_do_set: xattr");
 			return -LTFS_NO_MEMORY;
 		}
 		xattr->key.name = strdup(name);
 		if (! xattr->key.name) {
-			ltfsmsg(LTFS_ERR, "10001E", "xattr_do_set: xattr key");
+			ltfsmsg(LTFS_ERR, 10001E, "xattr_do_set: xattr key");
 			ret = -LTFS_NO_MEMORY;
 			goto out_free;
 		}
@@ -130,7 +130,7 @@ int xattr_do_set(struct dentry *d, const char *name, const char *value, size_t s
 	if (size > 0) {
 		xattr->value = (char *)malloc(size);
 		if (! xattr->value) {
-			ltfsmsg(LTFS_ERR, "10001E", "xattr_do_set: xattr value");
+			ltfsmsg(LTFS_ERR, 10001E, "xattr_do_set: xattr value");
 			ret = -LTFS_NO_MEMORY;
 			goto out_remove;
 		}
@@ -184,7 +184,7 @@ int xattr_set(struct dentry *d, const char *name, const char *value, size_t size
 
 	ret = tape_get_worm_status(vol->device, &is_worm_cart);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17237E", "set xattr: cart stat");
+		ltfsmsg(LTFS_ERR, 17237E, "set xattr: cart stat");
 		ret = -LTFS_XATTR_ERR;
 		goto out_unlock;
 	}
@@ -192,7 +192,7 @@ int xattr_set(struct dentry *d, const char *name, const char *value, size_t size
 	if ((is_worm_cart && (d->is_immutable || (d->is_appendonly && strcmp(name, "ltfs.vendor.IBM.immutable"))))
 		|| (!is_worm_cart && (d->is_immutable || d->is_appendonly) && !_xattr_is_worm_ea(name))) {
 		/* EA cannot be set in case of immutable/appendonly */
-		ltfsmsg(LTFS_ERR, "17237E", "set xattr: WORM entry");
+		ltfsmsg(LTFS_ERR, 17237E, "set xattr: WORM entry");
 		ret = -LTFS_RDONLY_XATTR;
 		goto out_unlock;
 	}
@@ -218,7 +218,7 @@ int xattr_set(struct dentry *d, const char *name, const char *value, size_t size
 	/* Search for existing xattr with this name. */
 	ret = _xattr_seek(&xattr, d, name);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11122E", ret);
+		ltfsmsg(LTFS_ERR, 11122E, ret);
 		releasewrite_mrsw(&d->meta_lock);
 		goto out_unlock;
 	}
@@ -235,7 +235,7 @@ int xattr_set(struct dentry *d, const char *name, const char *value, size_t size
 		disable_worm_ea = (strncmp(value, "0", size) == 0);
 
 		if (is_worm_cart && disable_worm_ea) {
-			ltfsmsg(LTFS_ERR, "17237E", "set xattr: clear WORM");
+			ltfsmsg(LTFS_ERR, 17237E, "set xattr: clear WORM");
 			releasewrite_mrsw(&d->meta_lock);
 			ret = -LTFS_XATTR_ERR;
 			goto out_unlock;
@@ -266,11 +266,11 @@ int xattr_set(struct dentry *d, const char *name, const char *value, size_t size
 	/* update metadata */
 	if (!strcmp(name, "ltfs.vendor.IBM.immutable")) {
 		d->is_immutable = !disable_worm_ea;
-		ltfsmsg(LTFS_INFO, "17238I", "immutable", d->is_immutable, d->name);
+		ltfsmsg(LTFS_INFO, 17238I, "immutable", d->is_immutable, d->name.name);
 	}
 	else if (!strcmp(name, "ltfs.vendor.IBM.appendonly")) {
 		d->is_appendonly = !disable_worm_ea;
-		ltfsmsg(LTFS_INFO, "17238I", "appendonly", d->is_appendonly, d->name);
+		ltfsmsg(LTFS_INFO, 17238I, "appendonly", d->is_appendonly, d->name.name);
 	}
 
 	get_current_timespec(&d->change_time);
@@ -310,7 +310,7 @@ int xattr_get(struct dentry *d, const char *name, char *value, size_t size,
 	CHECK_ARG_NULL(name, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(vol, -LTFS_NULL_ARG);
 	if (size > 0 && ! value) {
-		ltfsmsg(LTFS_ERR, "11123E");
+		ltfsmsg(LTFS_ERR, 11123E);
 		return -LTFS_BAD_ARG;
 	}
 
@@ -336,7 +336,7 @@ int xattr_get(struct dentry *d, const char *name, char *value, size_t size,
 		}else if (ret != -LTFS_NO_XATTR) {
 			/* if ltfs.sync is specified, don't print any message */
 			if (ret < 0 && ret != -LTFS_RDONLY_XATTR)
-				ltfsmsg(LTFS_ERR, "11128E", ret);
+				ltfsmsg(LTFS_ERR, 11128E, ret);
 			goto out_unlock;
 		}
 	}
@@ -346,7 +346,7 @@ int xattr_get(struct dentry *d, const char *name, char *value, size_t size,
 	/* Look for a real xattr. */
 	ret = _xattr_seek(&xattr, d, name);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11129E", ret);
+		ltfsmsg(LTFS_ERR, 11129E, ret);
 		releaseread_mrsw(&d->meta_lock);
 		goto out_unlock;
 	}
@@ -390,7 +390,7 @@ int xattr_list(struct dentry *d, char *list, size_t size, struct ltfs_volume *vo
 	CHECK_ARG_NULL(d, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(vol, -LTFS_NULL_ARG);
 	if (size > 0 && ! list) {
-		ltfsmsg(LTFS_ERR, "11130E");
+		ltfsmsg(LTFS_ERR, 11130E);
 		return -LTFS_BAD_ARG;
 	}
 
@@ -402,7 +402,7 @@ int xattr_list(struct dentry *d, char *list, size_t size, struct ltfs_volume *vo
 
 	ret = _xattr_list_physicals(d, list, size);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11133E", ret);
+		ltfsmsg(LTFS_ERR, 11133E, ret);
 		goto out;
 	}
 	nbytes += ret;
@@ -444,7 +444,7 @@ int xattr_do_remove(struct dentry *d, const char *name, bool force, struct ltfs_
 	/* Look for a real extended attribute. */
 	ret = _xattr_seek(&xattr, d, name);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11140E", ret);
+		ltfsmsg(LTFS_ERR, 11140E, ret);
 		releasewrite_mrsw(&d->meta_lock);
 		return ret;
 	} else if (! xattr) {
@@ -497,7 +497,7 @@ int xattr_remove(struct dentry *d, const char *name, struct ltfs_volume *vol)
 
 	ret = tape_get_worm_status(vol->device, &is_worm_cart);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17237E", "remove xattr: cart stat");
+		ltfsmsg(LTFS_ERR, 17237E, "remove xattr: cart stat");
 		ret = -LTFS_XATTR_ERR;
 		goto out_dunlk;
 	}
@@ -505,7 +505,7 @@ int xattr_remove(struct dentry *d, const char *name, struct ltfs_volume *vol)
 	if ((d->is_immutable || d->is_appendonly)
 		&& (is_worm_cart || !_xattr_is_worm_ea(name))) {
 		/* EA cannot be removed in case of immutable/appendonly */
-		ltfsmsg(LTFS_ERR, "17237E", "remove xattr: WORM entry");
+		ltfsmsg(LTFS_ERR, 17237E, "remove xattr: WORM entry");
 		ret = -LTFS_RDONLY_XATTR;
 		goto out_dunlk;
 	}
@@ -524,11 +524,11 @@ int xattr_remove(struct dentry *d, const char *name, struct ltfs_volume *vol)
 
 	if (!strcmp(name, "ltfs.vendor.IBM.immutable")) {
 		d->is_immutable = false;
-		ltfsmsg(LTFS_INFO, "17238I", "immutable", d->is_immutable, d->name);
+		ltfsmsg(LTFS_INFO, 17238I, "immutable", d->is_immutable, d->name.name);
 	}
 	else if (!strcmp(name, "ltfs.vendor.IBM.appendonly")) {
 		d->is_appendonly = false;
-		ltfsmsg(LTFS_INFO, "17238I", "appendonly", d->is_appendonly, d->name);
+		ltfsmsg(LTFS_INFO, 17238I, "appendonly", d->is_appendonly, d->name.name);
 	}
 
 	d->dirty = true;
@@ -561,7 +561,7 @@ int xattr_set_mountpoint_length(struct dentry *d, const char* value, size_t size
 	acquireread_mrsw(&d->meta_lock);
 	ret = _xattr_seek(&xattr, d, LTFS_LIVELINK_EA_NAME);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11129E", ret);
+		ltfsmsg(LTFS_ERR, 11129E, ret);
 		releaseread_mrsw(&d->meta_lock);
 		goto out_set;
 	}
@@ -675,7 +675,7 @@ int _xattr_list_physicals(struct dentry *d, char *list, size_t size)
 #if ((!defined (__APPLE__)) && (!defined (mingw_PLATFORM)))
 	ret = pathname_unformat("user.", &prefix);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "11141E", ret);
+		ltfsmsg(LTFS_ERR, 11141E, ret);
 		return ret;
 	}
 	prefixlen = strlen(prefix);
@@ -684,7 +684,7 @@ int _xattr_list_physicals(struct dentry *d, char *list, size_t size)
 	TAILQ_FOREACH(entry, &d->xattrlist, list) {
 		ret = pathname_unformat(entry->key.name, &new_name);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "11142E", ret);
+			ltfsmsg(LTFS_ERR, 11142E, ret);
 			goto out;
 		}
 
@@ -853,31 +853,31 @@ int _xattr_get_virtual(struct dentry *d, char *buf, size_t buf_size, const char 
 	if (! strcmp(name, "ltfs.createTime")) {
 		ret = _xattr_get_dentry_time(d, &d->creation_time, &val, name);
 		if (ret == LTFS_TIME_OUT_OF_RANGE) {
-			ltfsmsg(LTFS_WARN, "17222W", name, d->name, d->uid, d->creation_time);
+			ltfsmsg(LTFS_WARN, 17222W, name, d->name.name, (unsigned long long)d->uid, (long long)d->creation_time.tv_sec);
 			ret = 0;
 		}
 	} else if (! strcmp(name, "ltfs.modifyTime")) {
 		ret = _xattr_get_dentry_time(d, &d->modify_time, &val, name);
 		if (ret == LTFS_TIME_OUT_OF_RANGE) {
-			ltfsmsg(LTFS_WARN, "17222W", name, d->name, d->uid, d->modify_time);
+			ltfsmsg(LTFS_WARN, 17222W, name, d->name.name, (unsigned long long)d->uid, (long long)d->modify_time.tv_sec);
 			ret = 0;
 		}
 	} else if (! strcmp(name, "ltfs.accessTime")) {
 		ret = _xattr_get_dentry_time(d, &d->access_time, &val, name);
 		if (ret == LTFS_TIME_OUT_OF_RANGE) {
-			ltfsmsg(LTFS_WARN, "17222W", name, d->name, d->uid, d->access_time);
+			ltfsmsg(LTFS_WARN, 17222W, name, d->name.name, (unsigned long long)d->uid, (long long)d->access_time.tv_sec);
 			ret = 0;
 		}
 	} else if (! strcmp(name, "ltfs.changeTime")) {
 		ret = _xattr_get_dentry_time(d, &d->change_time, &val, name);
 		if (ret == LTFS_TIME_OUT_OF_RANGE) {
-			ltfsmsg(LTFS_WARN, "17222W", name, d->name, d->uid, d->change_time);
+			ltfsmsg(LTFS_WARN, 17222W, name, d->name.name, (unsigned long long)d->uid, (long long)d->change_time.tv_sec);
 			ret = 0;
 		}
 	} else if (! strcmp(name, "ltfs.backupTime")) {
 		ret = _xattr_get_dentry_time(d, &d->backup_time, &val, name);
 		if (ret == LTFS_TIME_OUT_OF_RANGE) {
-			ltfsmsg(LTFS_WARN, "17222W", name, d->name, d->uid, d->backup_time);
+			ltfsmsg(LTFS_WARN, 17222W, name, d->name.name, (unsigned long long)d->uid, (long long)d->backup_time.tv_sec);
 			ret = 0;
 		}
 	} else if (! strcmp(name, "ltfs.driveCaptureDump")) {
@@ -906,46 +906,46 @@ int _xattr_get_virtual(struct dentry *d, char *buf, size_t buf_size, const char 
 	} else if (! strcmp(name, "ltfs.vendor.IBM.logLevel")) {
 		ret = asprintf(&val, "%d", ltfs_log_level);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "10001E", name);
+			ltfsmsg(LTFS_ERR, 10001E, name);
 			val = NULL;
 			ret = -LTFS_NO_MEMORY;
 		}
 	} else if (! strcmp(name, "ltfs.vendor.IBM.syslogLevel")) {
 		ret = asprintf(&val, "%d", ltfs_syslog_level);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "10001E", name);
+			ltfsmsg(LTFS_ERR, 10001E, name);
 			val = NULL;
 			ret = -LTFS_NO_MEMORY;
 		}
 	} else if (! strcmp(name, "ltfs.vendor.IBM.profiler")) {
 		ret = ltfs_trace_get_offset(&val);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "10001E", name);
+			ltfsmsg(LTFS_ERR, 10001E, name);
 			val = NULL;
 			ret = -LTFS_NO_MEMORY;
 		}
 	} else if (! strcmp(name, "ltfs.mamBarcode")) {
 		ret = read_tape_attribute (vol, &val, name);
 		if (ret < 0) {
-			ltfsmsg(LTFS_DEBUG, "17198D", TC_MAM_BARCODE, "_xattr_get_virtual");
+			ltfsmsg(LTFS_DEBUG, 17198D, TC_MAM_BARCODE, "_xattr_get_virtual");
 			val = NULL;
 		}
 	} else if (! strcmp(name, "ltfs.mamApplicationVendor")) {
 		ret = read_tape_attribute (vol, &val, name);
 		if (ret < 0) {
-			ltfsmsg(LTFS_DEBUG, "17198D", TC_MAM_APP_VENDER, "_xattr_get_virtual");
+			ltfsmsg(LTFS_DEBUG, 17198D, TC_MAM_APP_VENDER, "_xattr_get_virtual");
 			val = NULL;
 		}
 	} else if (! strcmp(name, "ltfs.mamApplicationVersion")) {
 		ret = read_tape_attribute (vol, &val, name);
 		if (ret < 0) {
-			ltfsmsg(LTFS_DEBUG, "17198D", TC_MAM_APP_VERSION, "_xattr_get_virtual");
+			ltfsmsg(LTFS_DEBUG, 17198D, TC_MAM_APP_VERSION, "_xattr_get_virtual");
 			val = NULL;
 		}
 	} else if (! strcmp(name, "ltfs.mamApplicationFormatVersion")) {
 		ret = read_tape_attribute (vol, &val, name);
 		if (ret < 0) {
-			ltfsmsg(LTFS_DEBUG, "17198D", TC_MAM_APP_FORMAT_VERSION, "_xattr_get_virtual");
+			ltfsmsg(LTFS_DEBUG, 17198D, TC_MAM_APP_FORMAT_VERSION, "_xattr_get_virtual");
 			val = NULL;
 		}
 	} else if (! strcmp(name, "ltfs.volumeLockState")) {
@@ -990,7 +990,7 @@ int _xattr_get_virtual(struct dentry *d, char *buf, size_t buf_size, const char 
 			ret = 0;
 			val = malloc(2 * sizeof(char));
 			if (! val) {
-				ltfsmsg(LTFS_ERR, "10001E", name);
+				ltfsmsg(LTFS_ERR, 10001E, name);
 				ret = -LTFS_NO_MEMORY;
 			} else {
 				val[0] = TAILQ_FIRST(&d->extentlist)->start.partition;
@@ -1012,7 +1012,7 @@ int _xattr_get_virtual(struct dentry *d, char *buf, size_t buf_size, const char 
 		} else if (! strcmp(name, "ltfs.volumeFormatTime")) {
 			ret = _xattr_get_time(&vol->label->format_time, &val, name);
 			if (ret == LTFS_TIME_OUT_OF_RANGE) {
-				ltfsmsg(LTFS_WARN, "17222W", name, "root", 0, vol->label->format_time.tv_sec);
+				ltfsmsg(LTFS_WARN, 17222W, name, "root", (unsigned long long)0, (unsigned long long)vol->label->format_time.tv_sec);
 				ret = 0;
 			}
 		} else if (! strcmp(name, "ltfs.volumeBlocksize")) {
@@ -1022,7 +1022,7 @@ int _xattr_get_virtual(struct dentry *d, char *buf, size_t buf_size, const char 
 		} else if (! strcmp(name, "ltfs.indexTime")) {
 			ret = _xattr_get_time(&vol->index->mod_time, &val, name);
 			if (ret == LTFS_TIME_OUT_OF_RANGE) {
-				ltfsmsg(LTFS_WARN, "17222W", name, "root", 0, vol->label->format_time.tv_sec);
+				ltfsmsg(LTFS_WARN, 17222W, name, "root", (unsigned long long)0, (unsigned long long)vol->label->format_time.tv_sec);
 				ret = 0;
 			}
 		} else if (! strcmp(name, "ltfs.policyExists")) {
@@ -1085,7 +1085,7 @@ int _xattr_get_virtual(struct dentry *d, char *buf, size_t buf_size, const char 
 			else {
 				ret = asprintf(&val, "0x%016"PRIx64, tape_alert);
 				if (ret < 0) {
-					ltfsmsg(LTFS_ERR, "10001E", name);
+					ltfsmsg(LTFS_ERR, 10001E, name);
 					val = NULL;
 					ret = -LTFS_NO_MEMORY;
 				}
@@ -1122,7 +1122,7 @@ int _xattr_get_virtual(struct dentry *d, char *buf, size_t buf_size, const char 
 		} else if (! strcmp(name, "ltfs.vendor.IBM.cartridgeMountNode")) {
 			ret = asprintf(&val, "localhost");
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "10001E", name);
+				ltfsmsg(LTFS_ERR, 10001E, name);
 				val = NULL;
 				ret = -LTFS_NO_MEMORY;
 			}
@@ -1171,7 +1171,7 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 		char *value_null_terminated, *new_value;
 
 		if (size > INDEX_MAX_COMMENT_LEN) {
-			ltfsmsg(LTFS_ERR, "11308E");
+			ltfsmsg(LTFS_ERR, 11308E);
 			ret = -LTFS_LARGE_XATTR;
 		}
 
@@ -1185,7 +1185,7 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 		} else {
 			value_null_terminated = malloc(size + 1);
 			if (! value_null_terminated) {
-				ltfsmsg(LTFS_ERR, "10001E", "_xattr_set_virtual: commit_message");
+				ltfsmsg(LTFS_ERR, 10001E, "_xattr_set_virtual: commit_message");
 				ltfs_mutex_unlock(&vol->index->dirty_lock);
 				return -LTFS_NO_MEMORY;
 			}
@@ -1218,12 +1218,12 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 			/* Clear tape attribute(TC_MAM_USER_MEDIUM_LABEL) */
 			ret =  update_tape_attribute (vol, NULL, TC_MAM_USER_MEDIUM_LABEL, 0);
 			if ( ret < 0 ) {
-				ltfsmsg(LTFS_WARN, "17199W", TC_MAM_USER_MEDIUM_LABEL, "_xattr_set_virtual");
+				ltfsmsg(LTFS_WARN, 17199W, TC_MAM_USER_MEDIUM_LABEL, "_xattr_set_virtual");
 			}
 		} else {
 			value_null_terminated = malloc(size + 1);
 			if (! value_null_terminated) {
-				ltfsmsg(LTFS_ERR, "10001E", "_xattr_set_virtual: volume name");
+				ltfsmsg(LTFS_ERR, 10001E, "_xattr_set_virtual: volume name");
 				ltfs_mutex_unlock(&vol->index->dirty_lock);
 				return -LTFS_NO_MEMORY;
 			}
@@ -1245,7 +1245,7 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 			/* Update tape attribute(TC_MAM_USER_MEDIUM_LABEL) */
 			ret =  update_tape_attribute (vol, new_value, TC_MAM_USER_MEDIUM_LABEL, size);
 			if ( ret < 0 ) {
-				ltfsmsg(LTFS_WARN, "17199W", TC_MAM_USER_MEDIUM_LABEL, "_xattr_set_virtual");
+				ltfsmsg(LTFS_WARN, 17199W, TC_MAM_USER_MEDIUM_LABEL, "_xattr_set_virtual");
 				return ret;
 			}
 		}
@@ -1256,32 +1256,32 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 	} else if (! strcmp(name, "ltfs.createTime")) {
 		ret = _xattr_set_time(d, &d->creation_time, value, size, name, vol);
 		if (ret == LTFS_TIME_OUT_OF_RANGE) {
-			ltfsmsg(LTFS_WARN, "17221W", name, d->name, d->uid, value);
+			ltfsmsg(LTFS_WARN, 17221W, name, d->name.name, (unsigned long long)d->uid, value);
 			ret = 0;
 		}
 	} else if (! strcmp(name, "ltfs.modifyTime")) {
 		get_current_timespec(&d->change_time);
 		ret = _xattr_set_time(d, &d->modify_time, value, size, name, vol);
 		if (ret == LTFS_TIME_OUT_OF_RANGE) {
-			ltfsmsg(LTFS_WARN, "17221W", name, d->name, d->uid, value);
+			ltfsmsg(LTFS_WARN, 17221W, name, d->name.name, (unsigned long long)d->uid, value);
 			ret = 0;
 		}
 	} else if (! strcmp(name, "ltfs.changeTime")) {
 		ret = _xattr_set_time(d, &d->change_time, value, size, name, vol);
 		if (ret == LTFS_TIME_OUT_OF_RANGE) {
-			ltfsmsg(LTFS_WARN, "17221W", name, d->name, d->uid, value);
+			ltfsmsg(LTFS_WARN, 17221W, name, d->name.name, (unsigned long long)d->uid, value);
 			ret = 0;
 		}
 	} else if (! strcmp(name, "ltfs.accessTime")) {
 		ret = _xattr_set_time(d, &d->access_time, value, size, name, vol);
 		if (ret == LTFS_TIME_OUT_OF_RANGE) {
-			ltfsmsg(LTFS_WARN, "17221W", name, d->name, d->uid, value);
+			ltfsmsg(LTFS_WARN, 17221W, name, d->name.name, (unsigned long long)d->uid, value);
 			ret = 0;
 		}
 	} else if (! strcmp(name, "ltfs.backupTime")) {
 		ret = _xattr_set_time(d, &d->backup_time, value, size, name, vol);
 		if (ret == LTFS_TIME_OUT_OF_RANGE) {
-			ltfsmsg(LTFS_WARN, "17221W", name, d->name, d->uid, value);
+			ltfsmsg(LTFS_WARN, 17221W, name, d->name.name, (unsigned long long)d->uid, value);
 			ret = 0;
 		}
 	} else if (! strcmp(name, "ltfs.driveCaptureDump")) {
@@ -1292,7 +1292,7 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 
 		v = strndup(value, size);
 		if (! v) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 
@@ -1309,7 +1309,7 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 
 		v = strndup(value, size);
 		if (! v) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 
@@ -1327,7 +1327,7 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 
 		v = strndup(value, size);
 		if (! v) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 
@@ -1344,7 +1344,7 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 
 		v = strndup(value, size);
 		if (! v) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 
@@ -1355,7 +1355,7 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 
 		v = strndup(value, size);
 		if (! v) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 
@@ -1366,7 +1366,7 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 
 		v = strndup(value, size);
 		if (! v) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 
@@ -1378,7 +1378,7 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 
 		v = strndup(value, size);
 		if (! v) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 
@@ -1401,7 +1401,7 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 	} else if (! strcmp(name, "ltfs.mamBarcode")) {
 		ret =  update_tape_attribute (vol, value, TC_MAM_BARCODE, size);
 		if ( ret < 0 ) {
-			ltfsmsg(LTFS_WARN, "17199W", TC_MAM_USER_MEDIUM_LABEL, "_xattr_set_virtual");
+			ltfsmsg(LTFS_WARN, 17199W, TC_MAM_USER_MEDIUM_LABEL, "_xattr_set_virtual");
 			return ret;
 		}
 	} else if (! strcmp(name, "ltfs.volumeLockState")) {
@@ -1410,7 +1410,7 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 
 		v = strndup(value, size);
 		if (! v) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 
@@ -1450,7 +1450,7 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 				new = VOLUME_UNLOCKED;
 
 			if (vol->file_open_count != 0) {
-				ltfsmsg(LTFS_DEBUG, "10021D", "_xattr_set_virtual", "file open", vol->file_open_count, 0);
+				ltfsmsg(LTFS_DEBUG, 10021D, "_xattr_set_virtual", "file open", vol->file_open_count, 0);
 				return -LTFS_XATTR_ERR;
 			}
 
@@ -1460,7 +1460,7 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 			/* update MAM attribute */
 			ret =  update_tape_attribute(vol, status_mam, TC_MAM_VOLUME_LOCKED, TC_MAM_VOLUME_LOCKED_SIZE);
 			if ( ret < 0 ) {
-				ltfsmsg(LTFS_WARN, "17199W", TC_MAM_VOLUME_LOCKED, "_xattr_set_virtual");
+				ltfsmsg(LTFS_WARN, 17199W, TC_MAM_VOLUME_LOCKED, "_xattr_set_virtual");
 				return ret;
 			}
 
@@ -1472,7 +1472,7 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 			ret = ltfs_sync_index(SYNC_ADV_LOCK, false, vol);
 			ret = tape_device_lock(vol->device);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "12010E", __FUNCTION__);
+				ltfsmsg(LTFS_ERR, 12010E, __FUNCTION__);
 				return ret;
 			}
 			ret = ltfs_write_index(ltfs_ip_id(vol), SYNC_EA, vol);
@@ -1519,7 +1519,7 @@ int _xattr_remove_virtual(struct dentry *d, const char *name, struct ltfs_volume
 		/* Clear tape attribute(TC_MAM_USER_MEDIUM_LABEL) */
 		ret =  update_tape_attribute (vol, NULL, TC_MAM_USER_MEDIUM_LABEL, 0);
 		if ( ret < 0 ) {
-			ltfsmsg(LTFS_WARN, "17199W", TC_MAM_USER_MEDIUM_LABEL, "_xattr_set_virtual");
+			ltfsmsg(LTFS_WARN, 17199W, TC_MAM_USER_MEDIUM_LABEL, "_xattr_set_virtual");
 		}
 		ltfs_mutex_unlock(&vol->index->dirty_lock);
 	} else
@@ -1535,7 +1535,7 @@ int _xattr_get_cartridge_health(cartridge_health_info *h, int64_t *val, char **o
 	if (ret == 0) {
 		ret = asprintf(outval, "%"PRId64, *val);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "10001E", msg);
+			ltfsmsg(LTFS_ERR, 10001E, msg);
 			*outval = NULL;
 			return -LTFS_NO_MEMORY;
 		}
@@ -1551,14 +1551,14 @@ int _xattr_get_cartridge_health_u64(cartridge_health_info *h, uint64_t *val, cha
 	if (ret == 0 && (int64_t)(*val) != UNSUPPORTED_CARTRIDGE_HEALTH) {
 		ret = asprintf(outval, "%"PRIu64, *val);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "10001E", msg);
+			ltfsmsg(LTFS_ERR, 10001E, msg);
 			*outval = NULL;
 			ret = -LTFS_NO_MEMORY;
 		}
 	} else if (ret == 0) {
 		ret = asprintf(outval, "%"PRId64, UNSUPPORTED_CARTRIDGE_HEALTH);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "10001E", msg);
+			ltfsmsg(LTFS_ERR, 10001E, msg);
 			*outval = NULL;
 			ret = -LTFS_NO_MEMORY;
 		}
@@ -1575,7 +1575,7 @@ int _xattr_get_cartridge_capacity(struct device_capacity *cap, unsigned long *va
 	if (ret == 0) {
 		ret = asprintf(outval, "%lu", (unsigned long)((*val) * scale));
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "10001E", msg);
+			ltfsmsg(LTFS_ERR, 10001E, msg);
 			*outval = NULL;
 			return -LTFS_NO_MEMORY;
 		}
@@ -1590,7 +1590,7 @@ int _xattr_get_time(struct ltfs_timespec *val, char **outval, const char *msg)
 
 	ret = xml_format_time(*val, outval);
 	if (! (*outval)) {
-		ltfsmsg(LTFS_ERR, "11145E", msg);
+		ltfsmsg(LTFS_ERR, 11145E, msg);
 		return -LTFS_NO_MEMORY;
 	}
 
@@ -1613,7 +1613,7 @@ int _xattr_get_string(const char *val, char **outval, const char *msg)
 		return 0;
 	*outval = strdup(val);
 	if (! (*outval)) {
-		ltfsmsg(LTFS_ERR, "10001E", msg);
+		ltfsmsg(LTFS_ERR, 10001E, msg);
 		return -LTFS_NO_MEMORY;
 	}
 	return 0;
@@ -1623,7 +1623,7 @@ int _xattr_get_u64(uint64_t val, char **outval, const char *msg)
 {
 	int ret = asprintf(outval, "%"PRIu64, val);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10001E", msg);
+		ltfsmsg(LTFS_ERR, 10001E, msg);
 		*outval = NULL;
 		ret = -LTFS_NO_MEMORY;
 	}
@@ -1634,7 +1634,7 @@ int _xattr_get_tapepos(struct tape_offset *val, char **outval, const char *msg)
 {
 	int ret = asprintf(outval, "%c:%"PRIu64, val->partition, val->block);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10001E", msg);
+		ltfsmsg(LTFS_ERR, 10001E, msg);
 		return -LTFS_NO_MEMORY;
 	}
 	return 0;
@@ -1644,7 +1644,7 @@ int _xattr_get_partmap(struct ltfs_label *label, char **outval, const char *msg)
 {
 	int ret = asprintf(outval, "I:%c,D:%c", label->partid_ip, label->partid_dp);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10001E", msg);
+		ltfsmsg(LTFS_ERR, 10001E, msg);
 		return -LTFS_NO_MEMORY;
 	}
 	return 0;
@@ -1656,13 +1656,13 @@ int _xattr_get_version(int version, char **outval, const char *msg)
 	if (version == 10000) {
 		*outval = strdup("1.0");
 		if (! (*outval)) {
-			ltfsmsg(LTFS_ERR, "10001E", msg);
+			ltfsmsg(LTFS_ERR, 10001E, msg);
 			return -LTFS_NO_MEMORY;
 		}
 	} else {
 		ret = asprintf(outval, "%d.%d.%d", version/10000, (version % 10000)/100, version % 100);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "10001E", msg);
+			ltfsmsg(LTFS_ERR, 10001E, msg);
 			return -LTFS_NO_MEMORY;
 		}
 	}
@@ -1678,7 +1678,7 @@ int _xattr_set_time(struct dentry *d, struct ltfs_timespec *out, const char *val
 
 	value_null_terminated = malloc(size + 1);
 	if (! value_null_terminated) {
-		ltfsmsg(LTFS_ERR, "10001E", msg);
+		ltfsmsg(LTFS_ERR, 10001E, msg);
 		return -LTFS_NO_MEMORY;
 	}
 	memcpy(value_null_terminated, value, size);

--- a/src/libltfs/xml.h
+++ b/src/libltfs/xml.h
@@ -105,7 +105,7 @@ int xml_format_time(struct ltfs_timespec t, char** out);
 #define xml_mktag(val, retval) \
 	do { \
 		if ((val) < 0) { \
-			ltfsmsg(LTFS_ERR, "17042E", __FUNCTION__); \
+			ltfsmsg(LTFS_ERR, 17042E, __FUNCTION__); \
 			return (retval); \
 		} \
 	} while (0)
@@ -156,7 +156,7 @@ int xml_format_time(struct ltfs_timespec t, char** out);
 #define check_required_tags() do { \
 	for (i=0; i<ntags_req; ++i) { \
 		if (! have_required_tags[i]) { \
-			ltfsmsg(LTFS_ERR, "17000E", parent_tag); \
+			ltfsmsg(LTFS_ERR, 17000E, parent_tag); \
 			return -1; \
 		} \
 	} \
@@ -165,7 +165,7 @@ int xml_format_time(struct ltfs_timespec t, char** out);
 /* used for detecting missing and duplicated required tags during parsing */
 #define check_required_tag(i) do { \
 	if (have_required_tags[i]) { \
-		ltfsmsg(LTFS_ERR, "17001E", name); \
+		ltfsmsg(LTFS_ERR, 17001E, name); \
 		return -1; \
 	} \
 	have_required_tags[i] = true; \
@@ -174,7 +174,7 @@ int xml_format_time(struct ltfs_timespec t, char** out);
 /* used for detecting missing and duplicated optional tags during parsing */
 #define check_optional_tag(i) do { \
 	if (have_optional_tags[i]) { \
-		ltfsmsg(LTFS_ERR, "17002E", name); \
+		ltfsmsg(LTFS_ERR, 17002E, name); \
 		return -1; \
 	} \
 	have_optional_tags[i] = true; \
@@ -184,10 +184,10 @@ int xml_format_time(struct ltfs_timespec t, char** out);
 #define assert_not_empty() do { \
 	empty = xmlTextReaderIsEmptyElement(reader); \
 	if (empty < 0) { \
-		ltfsmsg(LTFS_ERR, "17003E"); \
+		ltfsmsg(LTFS_ERR, 17003E); \
 		return -1; \
 	} else if (empty > 0) { \
-		ltfsmsg(LTFS_ERR, "17004E", name); \
+		ltfsmsg(LTFS_ERR, 17004E, name); \
 		return -1; \
 	} \
 } while (0)
@@ -196,7 +196,7 @@ int xml_format_time(struct ltfs_timespec t, char** out);
 #define check_empty() do { \
 	empty = xmlTextReaderIsEmptyElement(reader); \
 	if (empty < 0) { \
-		ltfsmsg(LTFS_ERR, "17003E"); \
+		ltfsmsg(LTFS_ERR, 17003E); \
 		return -1; \
 	} \
 } while (0)
@@ -204,7 +204,7 @@ int xml_format_time(struct ltfs_timespec t, char** out);
 /* consume the end of a tag, failing if there's extra content */
 #define check_tag_end(tagname) do { \
 	if (xml_next_tag(reader, (tagname), &name, &type) < 0 || type != XML_ELEMENT_DECL) { \
-		ltfsmsg(LTFS_ERR, "17005E", (tagname)); \
+		ltfsmsg(LTFS_ERR, 17005E, (tagname)); \
 		return -1; \
 	} \
 } while (0)
@@ -217,7 +217,7 @@ int xml_format_time(struct ltfs_timespec t, char** out);
 	if (xml_scan_text(reader, &value) < 0) \
 		return -1; \
 	if (strlen(value) == 0) { \
-		ltfsmsg(LTFS_ERR, "17004E", name); \
+		ltfsmsg(LTFS_ERR, 17004E, name); \
 		return -1; \
 	} \
 } while (0)
@@ -231,7 +231,7 @@ int xml_format_time(struct ltfs_timespec t, char** out);
 
 /* issue a warning that the tag is unrecognized and will be ignored. */
 #define ignore_unrecognized_tag() do { \
-	ltfsmsg(LTFS_WARN, "17006W", name, parent_tag); \
+	ltfsmsg(LTFS_WARN, 17006W, name, parent_tag); \
 	if (xml_skip_tag(reader) < 0) \
 		return -1; \
 } while (0)

--- a/src/libltfs/xml_reader.c
+++ b/src/libltfs/xml_reader.c
@@ -84,11 +84,11 @@ int xml_scan_text(xmlTextReaderPtr reader, const char **value)
 		 * Since we also actually try to get the text, this does not lead to incorrect parsing. */
 		*value = (const char *)xmlTextReaderConstValue(reader);
 		if (!(*value)) {
-			ltfsmsg(LTFS_ERR, "17035E");
+			ltfsmsg(LTFS_ERR, 17035E);
 			return -1;
 		}
 	} else {
-		ltfsmsg(LTFS_ERR, "17036E", type);
+		ltfsmsg(LTFS_ERR, 17036E, type);
 		return -1;
 	}
 
@@ -130,7 +130,7 @@ int xml_skip_tag(xmlTextReaderPtr reader)
 
 	depth = start_depth = xmlTextReaderDepth(reader);
 	if (start_depth < 0) {
-		ltfsmsg(LTFS_ERR, "17093E");
+		ltfsmsg(LTFS_ERR, 17093E);
 		return -1;
 	}
 
@@ -138,20 +138,20 @@ int xml_skip_tag(xmlTextReaderPtr reader)
 	while (! empty && (type != XML_ELEMENT_DECL || depth > start_depth)) {
 		ret = xmlTextReaderRead(reader);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "17093E");
+			ltfsmsg(LTFS_ERR, 17093E);
 			return -1;
 		} else if (ret == 0) {
-			ltfsmsg(LTFS_ERR, "17038E");
+			ltfsmsg(LTFS_ERR, 17038E);
 			return -1;
 		}
 		type = xmlTextReaderNodeType(reader);
 		if (type < 0) {
-			ltfsmsg(LTFS_ERR, "17093E");
+			ltfsmsg(LTFS_ERR, 17093E);
 			return -1;
 		}
 		depth = xmlTextReaderDepth(reader);
 		if (depth < 0) {
-			ltfsmsg(LTFS_ERR, "17093E");
+			ltfsmsg(LTFS_ERR, 17093E);
 			return -1;
 		}
 	}
@@ -186,30 +186,30 @@ int xml_save_tag(xmlTextReaderPtr reader, size_t *tag_count, unsigned char ***ta
 	 * finished, as this call modifies the behavior of xmlFreeTextReader. */
 	doc = xmlTextReaderCurrentDoc(reader);
 	if (! doc) {
-		ltfsmsg(LTFS_ERR, "17200E", "xmlTextReaderCurrentDoc");
+		ltfsmsg(LTFS_ERR, 17200E, "xmlTextReaderCurrentDoc");
 		return -1;
 	}
 	node = xmlTextReaderExpand(reader);
 	if (! node) {
-		ltfsmsg(LTFS_ERR, "17200E", "xmlTextReaderExpand");
+		ltfsmsg(LTFS_ERR, 17200E, "xmlTextReaderExpand");
 		return -1;
 	}
 	buf = xmlBufferCreate();
 	if (! buf) {
-		ltfsmsg(LTFS_ERR, "17200E", "xmlBufferCreate");
+		ltfsmsg(LTFS_ERR, 17200E, "xmlBufferCreate");
 		return -1;
 	}
 
 	ret = xmlNodeDump(buf, doc, node, 0, 0);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17200E", "xmlNodeDump");
+		ltfsmsg(LTFS_ERR, 17200E, "xmlNodeDump");
 		return -1;
 	}
 	bufsize = xmlBufferLength(buf);
 	tag_value = malloc(bufsize + 1);
 	if (! tag_value) {
 		xmlBufferFree(buf);
-		ltfsmsg(LTFS_ERR, "10001E", "_xml_save_tag: tag value");
+		ltfsmsg(LTFS_ERR, 10001E, "_xml_save_tag: tag value");
 		return -1;
 	}
 	memcpy(tag_value, xmlBufferContent(buf), bufsize);
@@ -219,14 +219,14 @@ int xml_save_tag(xmlTextReaderPtr reader, size_t *tag_count, unsigned char ***ta
 #else
 	tag_value = xmlTextReaderReadOuterXml(reader);
 	if (! tag_value) {
-		ltfsmsg(LTFS_ERR, "17091E");
+		ltfsmsg(LTFS_ERR, 17091E);
 		return -1;
 	}
 #endif /* __APPLE__ */
 
 	t = realloc(*tag_list, c * sizeof(unsigned char *));
 	if (! t) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		free(tag_value);
 		return -1;
 	}
@@ -249,10 +249,10 @@ int xml_reader_read(xmlTextReaderPtr reader)
 {
 	int ret = xmlTextReaderRead(reader);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17037E");
+		ltfsmsg(LTFS_ERR, 17037E);
 		return -1;
 	} else if (ret == 0) {
-		ltfsmsg(LTFS_ERR, "17038E");
+		ltfsmsg(LTFS_ERR, 17038E);
 		return -1;
 	}
 	return 0;
@@ -269,7 +269,7 @@ int xml_parse_uuid(char *out_val, const char *val)
 	CHECK_ARG_NULL(val, -LTFS_NULL_ARG);
 
 	if (strlen(val) != 36) {
-		ltfsmsg(LTFS_ERR, "17029E", val);
+		ltfsmsg(LTFS_ERR, 17029E, val);
 		return -1;
 	}
 	strcpy(out_val, val);
@@ -277,13 +277,13 @@ int xml_parse_uuid(char *out_val, const char *val)
 	for (i=0; i<36; ++i) {
 		if (i == 8 || i == 13 || i == 18 || i == 23) {
 			if (val[i] != '-') {
-				ltfsmsg(LTFS_ERR, "17029E", val);
+				ltfsmsg(LTFS_ERR, 17029E, val);
 				return -1;
 			}
 		} else {
 			if ((val[i] < '0' || val[i] > '9') && (val[i] < 'a' || val[i] > 'f') &&
 				(val[i] < 'A' || val[i] > 'F')) {
-				ltfsmsg(LTFS_ERR, "17029E", val);
+				ltfsmsg(LTFS_ERR, 17029E, val);
 				return -1;
 			}
 		}
@@ -312,10 +312,10 @@ int xml_parse_filename(char **out_val, const char *value)
 
 	ret = pathname_normalize(value, out_val);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17030E", value);
+		ltfsmsg(LTFS_ERR, 17030E, value);
 		return ret;
 	} else if (pathname_validate_file(*out_val) < 0) {
-		ltfsmsg(LTFS_ERR, "17031E", value);
+		ltfsmsg(LTFS_ERR, 17031E, value);
 		free(*out_val);
 		*out_val = NULL;
 		return -1;
@@ -340,10 +340,10 @@ int xml_parse_target(char **out_val, const char *value)
 
 	ret = pathname_normalize(value, out_val);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17030E", value);
+		ltfsmsg(LTFS_ERR, 17030E, value);
 		return ret;
 	} else if (pathname_validate_target(*out_val) < 0) {
-		ltfsmsg(LTFS_ERR, "17031E", value);
+		ltfsmsg(LTFS_ERR, 17031E, value);
 		free(*out_val);
 		*out_val = NULL;
 		return -1;
@@ -439,7 +439,7 @@ int xml_parse_bool(bool *out_val, const char *value)
 	else if (! strcmp(value, "false") || ! strcmp(value, "0"))
 		*out_val = false;
 	else {
-		ltfsmsg(LTFS_ERR, "17032E");
+		ltfsmsg(LTFS_ERR, 17032E);
 		return -1;
 	}
 
@@ -463,7 +463,7 @@ int xml_parse_time(bool msg, const char *fmt_time, struct ltfs_timespec *rawtime
 				 &rawtime->tv_nsec);
 	if( ret != 7 ) {
 		if (msg)
-			ltfsmsg(LTFS_ERR, "17034E", fmt_time, ret);
+			ltfsmsg(LTFS_ERR, 17034E, fmt_time, ret);
 		return -1;
 	}
 
@@ -529,7 +529,7 @@ int xml_input_tape_read_callback(void *context, char *buffer, int len)
 			++ctx->current_pos;
 			if (nread < 0) {
 				/* We know we're not at EOD, so read errors are unexpected. */
-				ltfsmsg(LTFS_ERR, "17039E", (int)nread);
+				ltfsmsg(LTFS_ERR, 17039E, (int)nread);
 				return -1;
 			} else if ((size_t) nread < ctx->buf_size) {
 				/* Caught a small read. If this is a file mark, position before it. If
@@ -538,7 +538,7 @@ int xml_input_tape_read_callback(void *context, char *buffer, int len)
 				if (nread == 0) {
 					ctx->saw_file_mark = true;
 					if (tape_spacefm(ctx->vol->device, -1) < 0) {
-						ltfsmsg(LTFS_ERR, "17040E");
+						ltfsmsg(LTFS_ERR, 17040E);
 						return -1;
 					}
 				} else if (ctx->eod_pos == 0 ||
@@ -546,7 +546,7 @@ int xml_input_tape_read_callback(void *context, char *buffer, int len)
 					/* Look for a trailing file mark. */
 					buf2 = malloc(ctx->vol->label->blocksize);
 					if (! buf2) {
-						ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+						ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 						return -1;
 					}
 					nr2 = tape_read(ctx->vol->device, buf2, ctx->vol->label->blocksize, false,
@@ -554,12 +554,12 @@ int xml_input_tape_read_callback(void *context, char *buffer, int len)
 					free(buf2);
 					errno = 0; /* Clear errno because some OSs set errno in free() */
 					if (nr2 < 0) { /* Still not at EOD, so read errors are cause for alarm. */
-						ltfsmsg(LTFS_ERR, "17041E", (int)nr2);
+						ltfsmsg(LTFS_ERR, 17041E, (int)nr2);
 						return -1;
 					} else if (nr2 == 0) {
 						ctx->saw_file_mark = true;
 						if (tape_spacefm(ctx->vol->device, -1) < 0) {
-							ltfsmsg(LTFS_ERR, "17040E");
+							ltfsmsg(LTFS_ERR, 17040E);
 							return -1;
 						}
 					}

--- a/src/libltfs/xml_reader_libltfs.c
+++ b/src/libltfs/xml_reader_libltfs.c
@@ -147,7 +147,7 @@ static int _xml_parse_nametype(xmlTextReaderPtr reader, struct ltfs_name *n, boo
 
 	encoded_name = strdup(value);
 	if (!encoded_name) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -1;
 	}
 
@@ -184,7 +184,7 @@ static int _xml_parse_partition(const char *val)
 	CHECK_ARG_NULL(val, -LTFS_NULL_ARG);
 
 	if (strlen(val) != 1 || val[0] < 'a' || val[0] > 'z') {
-		ltfsmsg(LTFS_ERR, "17033E", val);
+		ltfsmsg(LTFS_ERR, 17033E, val);
 		return -1;
 	}
 
@@ -244,29 +244,29 @@ static int _xml_parser_init(xmlTextReaderPtr reader, const char *top_name, int *
 	if (xml_next_tag(reader, "", &name, &type) < 0)
 		return -1;
 	if (strcmp(name, top_name)) {
-		ltfsmsg(LTFS_ERR, "17017E", name);
+		ltfsmsg(LTFS_ERR, 17017E, name);
 		return -1;
 	}
 
 	/* reject this XML file if it isn't UTF-8 */
 	encoding = (const char *)xmlTextReaderConstEncoding(reader);
 	if (! encoding || strcmp(encoding, "UTF-8")) {
-		ltfsmsg(LTFS_ERR, "17018E", encoding);
+		ltfsmsg(LTFS_ERR, 17018E, encoding);
 		return -1;
 	}
 
 	/* check the version attribute of the top-level tag */
 	value = (char *)xmlTextReaderGetAttribute(reader, BAD_CAST "version");
 	if (! value) {
-		ltfsmsg(LTFS_ERR, "17019E");
+		ltfsmsg(LTFS_ERR, 17019E);
 		return -1;
 	}
 	if (_xml_parse_version(value, &ver) < 0) {
-		ltfsmsg(LTFS_ERR, "17020E", value);
+		ltfsmsg(LTFS_ERR, 17020E, value);
 		return -LTFS_UNSUPPORTED_INDEX_VERSION;
 	}
 	if (ver < min_version || ver > max_version) {
-		ltfsmsg(LTFS_ERR, "17021E", top_name, value);
+		ltfsmsg(LTFS_ERR, 17021E, top_name, value);
 		free(value);
 		return -LTFS_UNSUPPORTED_INDEX_VERSION;
 	}
@@ -366,7 +366,7 @@ static int _xml_parse_label(xmlTextReaderPtr reader, struct ltfs_label *label)
 				free(label->creator);
 			label->creator = strdup(value);
 			if (! label->creator) {
-				ltfsmsg(LTFS_ERR, "10001E", name);
+				ltfsmsg(LTFS_ERR, 10001E, name);
 				return -1;
 			}
 			check_tag_end("creator");
@@ -378,7 +378,7 @@ static int _xml_parse_label(xmlTextReaderPtr reader, struct ltfs_label *label)
 			if (ret < 0)
 				return -1;
 			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17218W", "formattime", value);
+				ltfsmsg(LTFS_WARN, 17218W, "formattime", value);
 			check_tag_end("formattime");
 
 		} else if (! strcmp(name, "volumeuuid")) {
@@ -404,7 +404,7 @@ static int _xml_parse_label(xmlTextReaderPtr reader, struct ltfs_label *label)
 			check_required_tag(5);
 			get_tag_text();
 			if (xml_parse_ull(&value_int, value) < 0 || value_int == 0) {
-				ltfsmsg(LTFS_ERR, "17022E", value);
+				ltfsmsg(LTFS_ERR, 17022E, value);
 				return -1;
 			}
 			label->blocksize = value_int;
@@ -451,7 +451,7 @@ static int _xml_parse_ip_criteria(xmlTextReaderPtr reader, struct ltfs_index *id
 			check_required_tag(0);
 			get_tag_text();
 			if (xml_parse_ull(&value_int, value) < 0) {
-				ltfsmsg(LTFS_ERR, "17024E", value);
+				ltfsmsg(LTFS_ERR, 17024E, value);
 				return -1;
 			}
 			idx->original_criteria.max_filesize_criteria = value_int;
@@ -482,7 +482,7 @@ static int _xml_parse_ip_criteria(xmlTextReaderPtr reader, struct ltfs_index *id
 	 * later without affecting the criteria stored in future indexes (idx->original_criteria). */
 	if (index_criteria_dup_rules(&idx->index_criteria, &idx->original_criteria) < 0) {
 		/* Could not duplicate index criteria rules */
-		ltfsmsg(LTFS_ERR, "11301E");
+		ltfsmsg(LTFS_ERR, 11301E);
 		return -1;
 	}
 
@@ -528,7 +528,7 @@ static int _xml_parse_one_extent(xmlTextReaderPtr reader, int idx_version, struc
 
 	xt = calloc(1, sizeof(struct extent_info));
 	if (!xt) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -1;
 	}
 
@@ -615,7 +615,7 @@ static int _xml_parse_one_extent(xmlTextReaderPtr reader, int idx_version, struc
 				break;
 			} else if (xt->fileoffset + xt->bytecount > xt_last->fileoffset) {
 				/* Overlap error */
-				ltfsmsg(LTFS_ERR, "17097E");
+				ltfsmsg(LTFS_ERR, 17097E);
 				free(xt);
 				return -1;
 			}
@@ -671,7 +671,7 @@ static int _xml_parse_one_xattr(xmlTextReaderPtr reader, struct dentry *d)
 
 	xattr = calloc(1, sizeof(struct xattr_info));
 	if (! xattr) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -1;
 	}
 
@@ -692,7 +692,7 @@ static int _xml_parse_one_xattr(xmlTextReaderPtr reader, struct dentry *d)
 
 			xattr_type = (char *)xmlTextReaderGetAttribute(reader, BAD_CAST "type");
 			if (xattr_type && strcmp(xattr_type, "text") && strcmp(xattr_type, "base64")) {
-				ltfsmsg(LTFS_ERR, "17027E", xattr_type);
+				ltfsmsg(LTFS_ERR, 17027E, xattr_type);
 				free(xattr);
 				return -1;
 			}
@@ -707,7 +707,7 @@ static int _xml_parse_one_xattr(xmlTextReaderPtr reader, struct dentry *d)
 				if (! xattr_type || ! strcmp(xattr_type, "text")) {
 					xattr->value = strdup(value);
 					if (! xattr->value) {
-						ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+						ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 						free(xattr->key.name);
 						free(xattr);
 						return -1;
@@ -719,7 +719,7 @@ static int _xml_parse_one_xattr(xmlTextReaderPtr reader, struct dentry *d)
 						strlen(value),
 						(unsigned char **)(&xattr->value));
 					if (xattr->size == 0) {
-						ltfsmsg(LTFS_ERR, "17028E");
+						ltfsmsg(LTFS_ERR, 17028E);
 						free(xattr->key.name);
 						free(xattr);
 						return -1;
@@ -826,7 +826,7 @@ static int _xml_save_symlink_conflict( struct ltfs_index *idx, struct dentry *d)
 
 	err_d = realloc( idx->symlink_conflict, c * sizeof(size_t));
 	if (! err_d) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -1;
 	}
 	err_d[c-1] = d;
@@ -852,7 +852,7 @@ static int _xml_parse_file(xmlTextReaderPtr reader, struct ltfs_index *idx, stru
 
 	file = fs_allocate_dentry(dir, NULL, NULL, false, false, false, idx);
 	if (! file) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -1;
 	}
 
@@ -893,7 +893,7 @@ static int _xml_parse_file(xmlTextReaderPtr reader, struct ltfs_index *idx, stru
 			if (ret < 0)
 				return -1;
 			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "modifytime", file->name, file->uid, value);
+				ltfsmsg(LTFS_WARN, 17220W, "modifytime", file->name.name, (unsigned long long)file->uid, value);
 			check_tag_end("modifytime");
 
 		} else if (!strcmp(name, "creationtime")) {
@@ -903,7 +903,7 @@ static int _xml_parse_file(xmlTextReaderPtr reader, struct ltfs_index *idx, stru
 			if (ret < 0)
 				return -1;
 			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "creationtime", file->name, file->uid, value);
+				ltfsmsg(LTFS_WARN, 17220W, "creationtime", file->name.name, (unsigned long long)file->uid, value);
 
 			check_tag_end("creationtime");
 
@@ -914,7 +914,7 @@ static int _xml_parse_file(xmlTextReaderPtr reader, struct ltfs_index *idx, stru
 			if (ret < 0)
 				return -1;
 			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "accesstime", file->name, file->uid, value);
+				ltfsmsg(LTFS_WARN, 17220W, "accesstime", file->name.name, (unsigned long long)file->uid, value);
 			check_tag_end("accesstime");
 
 		} else if (!strcmp(name, "changetime")) {
@@ -924,7 +924,7 @@ static int _xml_parse_file(xmlTextReaderPtr reader, struct ltfs_index *idx, stru
 			if (ret < 0)
 				return -1;
 			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "changetime", file->name, file->uid, value);
+				ltfsmsg(LTFS_WARN, 17220W, "changetime", file->name.name, (unsigned long long)file->uid, value);
 			check_tag_end("changetime");
 
 		} else if (!strcmp(name, "extendedattributes")) {
@@ -957,10 +957,10 @@ static int _xml_parse_file(xmlTextReaderPtr reader, struct ltfs_index *idx, stru
 			check_optional_tag(3);
 			get_tag_text();
 			if (xml_parse_bool(&openforwrite, value) < 0) {
-				ltfsmsg(LTFS_WARN, "17252W", value, "openforwrite", file->uid);
+				ltfsmsg(LTFS_WARN, 17252W, value, "openforwrite", (unsigned long long)file->uid);
 			} else {
 				if (openforwrite)
-					ltfsmsg(LTFS_INFO, "17251I", file->name, file->uid);
+					ltfsmsg(LTFS_INFO, 17251I, file->name.name, (unsigned long long)file->uid);
 			}
 			check_tag_end("openforwrite");
 
@@ -984,7 +984,7 @@ static int _xml_parse_file(xmlTextReaderPtr reader, struct ltfs_index *idx, stru
 			if (ret < 0)
 				return -1;
 			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "backuptime", file->name, file->uid, value);
+				ltfsmsg(LTFS_WARN, 17220W, "backuptime", file->name.name, (unsigned long long)file->uid, value);
 
 			check_tag_end(BACKUPTIME_TAGNAME);
 		} else if (! strcmp(name, BACKUPTIME_TAGNAME)) {
@@ -1015,19 +1015,19 @@ static int _xml_parse_file(xmlTextReaderPtr reader, struct ltfs_index *idx, stru
 	if (! TAILQ_EMPTY(&file->extentlist)) {
 		xt_last = TAILQ_LAST(&file->extentlist, extent_struct);
 		if (xt_last->fileoffset + xt_last->bytecount > file->size) {
-			ltfsmsg(LTFS_ERR, "17026E");
+			ltfsmsg(LTFS_ERR, 17026E);
 			return -1;
 		}
 	}
 
 	/* Validate UID: must be nonzero (UID 0 is reserved for the root directory) */
 	if (file->uid == 0) {
-		ltfsmsg(LTFS_ERR, "17101E");
+		ltfsmsg(LTFS_ERR, 17101E);
 		return -1;
 	}
 
 	if ( symlink_flag && extent_flag ) {
-		ltfsmsg(LTFS_ERR, "17180E", file->name);
+		ltfsmsg(LTFS_ERR, 17180E, file->name.name);
 		if ( _xml_save_symlink_conflict( idx, file ) ) return -1;
 	}
 
@@ -1058,7 +1058,7 @@ static int _xml_parse_dir_contents(xmlTextReaderPtr reader, struct dentry *dir, 
 			assert_not_empty();
 			entry_name = (struct name_list *)malloc(sizeof(struct name_list));
 			if (!entry_name) {
-				ltfsmsg(LTFS_ERR, "10001E", "_xml_parse_dir_contents: file");
+				ltfsmsg(LTFS_ERR, 10001E, "_xml_parse_dir_contents: file");
 				return -LTFS_NO_MEMORY;
 			}
 			if (_xml_parse_file(reader, idx, dir, entry_name) < 0) {
@@ -1070,7 +1070,7 @@ static int _xml_parse_dir_contents(xmlTextReaderPtr reader, struct dentry *dir, 
 			assert_not_empty();
 			entry_name = (struct name_list *)malloc(sizeof(struct name_list));
 			if (!entry_name) {
-				ltfsmsg(LTFS_ERR, "10001E", "_xml_parse_dir_contents: dir");
+				ltfsmsg(LTFS_ERR, 10001E, "_xml_parse_dir_contents: dir");
 				return -LTFS_NO_MEMORY;
 			}
 			if (_xml_parse_dirtree(reader, dir, idx, dir->vol, entry_name) < 0) {
@@ -1093,7 +1093,7 @@ static int _xml_parse_dir_contents(xmlTextReaderPtr reader, struct dentry *dir, 
 					free(list_ptr);
 				}
 
-				ltfsmsg(LTFS_ERR, "10001E", "_xml_parse_dir_contents: add key");
+				ltfsmsg(LTFS_ERR, 10001E, "_xml_parse_dir_contents: add key");
 				free(entry_name);
 
 				return -LTFS_NO_MEMORY;
@@ -1142,7 +1142,7 @@ static int _xml_parse_dirtree(xmlTextReaderPtr reader, struct dentry *parent,
 	} else {
 		dir = fs_allocate_dentry(parent, NULL, NULL, true, false, false, idx);
 		if (! dir) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 		if (! parent) {
@@ -1197,7 +1197,7 @@ static int _xml_parse_dirtree(xmlTextReaderPtr reader, struct dentry *parent,
 			if (ret < 0)
 				return -1;
 			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "updatetime", dir->name, dir->uid, value);
+				ltfsmsg(LTFS_WARN, 17220W, "updatetime", dir->name.name, (unsigned long long)dir->uid, value);
 
 			check_tag_end("modifytime");
 
@@ -1208,7 +1208,7 @@ static int _xml_parse_dirtree(xmlTextReaderPtr reader, struct dentry *parent,
 			if (ret < 0)
 				return -1;
 			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "creationtime", dir->name, dir->uid, value);
+				ltfsmsg(LTFS_WARN, 17220W, "creationtime", dir->name.name, (unsigned long long)dir->uid, value);
 
 			check_tag_end("creationtime");
 
@@ -1219,7 +1219,7 @@ static int _xml_parse_dirtree(xmlTextReaderPtr reader, struct dentry *parent,
 			if (ret < 0)
 				return -1;
 			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "accesstime", dir->name, dir->uid, value);
+				ltfsmsg(LTFS_WARN, 17220W, "accesstime", dir->name.name, (unsigned long long)dir->uid, value);
 
 			check_tag_end("accesstime");
 
@@ -1230,7 +1230,7 @@ static int _xml_parse_dirtree(xmlTextReaderPtr reader, struct dentry *parent,
 			if (ret < 0)
 				return -1;
 			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "changetime", dir->name, dir->uid, value);
+				ltfsmsg(LTFS_WARN, 17220W, "changetime", dir->name.name, (unsigned long long)dir->uid, value);
 
 			check_tag_end("changetime");
 
@@ -1268,7 +1268,7 @@ static int _xml_parse_dirtree(xmlTextReaderPtr reader, struct dentry *parent,
 			if (ret < 0)
 				return -1;
 			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17220W", "backuptime", dir->name, dir->uid, value);
+				ltfsmsg(LTFS_WARN, 17220W, "backuptime", dir->name.name, (unsigned long long)dir->uid, value);
 
 			check_tag_end(BACKUPTIME_TAGNAME);
 		} else if (! strcmp(name, BACKUPTIME_TAGNAME)) {
@@ -1301,13 +1301,13 @@ static int _xml_parse_dirtree(xmlTextReaderPtr reader, struct dentry *parent,
 	/* Validate UID: root directory must have uid==1, other dentries must have nonzero UID */
 	/* TODO: would be nice to verify that there are no UID conflicts */
 	if (parent && dir->uid == 1) {
-		ltfsmsg(LTFS_ERR, "17101E");
+		ltfsmsg(LTFS_ERR, 17101E);
 		return -1;
 	} else if (! parent && dir->uid != 1) {
-		ltfsmsg(LTFS_ERR, "17100E");
+		ltfsmsg(LTFS_ERR, 17100E);
 		return -1;
 	} else if (dir->uid == 0) {
-		ltfsmsg(LTFS_ERR, "17106E");
+		ltfsmsg(LTFS_ERR, 17106E);
 		return -1;
 	}
 
@@ -1336,19 +1336,19 @@ static int _xml_parse_schema(xmlTextReaderPtr reader, struct ltfs_index *idx, st
 		return ret;
 
 	if (idx->version < LTFS_INDEX_VERSION)
-		ltfsmsg(LTFS_WARN, "17095W",
+		ltfsmsg(LTFS_WARN, 17095W,
 				LTFS_INDEX_VERSION_STR,
 				LTFS_FORMAT_MAJOR(idx->version),
 				LTFS_FORMAT_MINOR(idx->version),
 				LTFS_FORMAT_REVISION(idx->version));
 	else if (idx->version / 100 > LTFS_INDEX_VERSION / 100)
-		ltfsmsg(LTFS_WARN, "17096W",
+		ltfsmsg(LTFS_WARN, 17096W,
 				LTFS_INDEX_VERSION_STR,
 				LTFS_FORMAT_MAJOR(idx->version),
 				LTFS_FORMAT_MINOR(idx->version),
 				LTFS_FORMAT_REVISION(idx->version));
 	else if (idx->version > LTFS_INDEX_VERSION)
-		ltfsmsg(LTFS_WARN, "17234W",
+		ltfsmsg(LTFS_WARN, 17234W,
 				LTFS_INDEX_VERSION_STR,
 				LTFS_FORMAT_MAJOR(idx->version),
 				LTFS_FORMAT_MINOR(idx->version),
@@ -1370,7 +1370,7 @@ static int _xml_parse_schema(xmlTextReaderPtr reader, struct ltfs_index *idx, st
 				free(idx->creator);
 			idx->creator = strdup(value);
 			if (! idx->creator) {
-				ltfsmsg(LTFS_ERR, "10001E", name);
+				ltfsmsg(LTFS_ERR, 10001E, name);
 				return -1;
 			}
 			check_tag_end("creator");
@@ -1386,7 +1386,7 @@ static int _xml_parse_schema(xmlTextReaderPtr reader, struct ltfs_index *idx, st
 			check_required_tag(2);
 			get_tag_text();
 			if (xml_parse_ull(&value_int, value) < 0) {
-				ltfsmsg(LTFS_ERR, "17023E", value);
+				ltfsmsg(LTFS_ERR, 17023E, value);
 				return -1;
 			}
 			idx->generation = value_int;
@@ -1399,7 +1399,7 @@ static int _xml_parse_schema(xmlTextReaderPtr reader, struct ltfs_index *idx, st
 			if (ret < 0)
 				return -1;
 			else if (ret == LTFS_TIME_OUT_OF_RANGE)
-				ltfsmsg(LTFS_WARN, "17219W", "updatetime", value);
+				ltfsmsg(LTFS_WARN, 17219W, "updatetime", value);
 
 			check_tag_end("updatetime");
 
@@ -1438,12 +1438,12 @@ static int _xml_parse_schema(xmlTextReaderPtr reader, struct ltfs_index *idx, st
 			check_optional_tag(2);
 			get_tag_text();
 			if (strlen(value) > INDEX_MAX_COMMENT_LEN) {
-				ltfsmsg(LTFS_ERR, "17094E");
+				ltfsmsg(LTFS_ERR, 17094E);
 				return -1;
 			}
 			idx->commit_message = strdup(value);
 			if (! idx->commit_message) {
-				ltfsmsg(LTFS_ERR, "10001E", "_xml_parse_schema: index comment");
+				ltfsmsg(LTFS_ERR, 10001E, "_xml_parse_schema: index comment");
 				return -1;
 			}
 			check_tag_end("comment");
@@ -1521,7 +1521,7 @@ static int _xml_symlinkinfo_from_file(const char *filename, struct dentry *d)
 
 	reader = xmlReaderForFile(filename, NULL, XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
 	if (! reader) {
-		ltfsmsg(LTFS_ERR, "17011E", filename);
+		ltfsmsg(LTFS_ERR, 17011E, filename);
 		return -1;
 	}
 
@@ -1536,7 +1536,7 @@ static int _xml_symlinkinfo_from_file(const char *filename, struct dentry *d)
 			ret = _xml_parse_symlink_target(reader, IDX_VERSION_SPARSE, d);
 			if (ret < 0) {
 				/* XML parser: failed to read extent list from file (%d) */
-				ltfsmsg(LTFS_ERR, "17084E", ret);
+				ltfsmsg(LTFS_ERR, 17084E, ret);
 			}
 		}
 		break;
@@ -1569,7 +1569,7 @@ static int _xml_extentlist_from_file(const char *filename, struct dentry *d)
 
 	reader = xmlReaderForFile(filename, NULL, XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
 	if (! reader) {
-		ltfsmsg(LTFS_ERR, "17011E", filename);
+		ltfsmsg(LTFS_ERR, 17011E, filename);
 		return -1;
 	}
 
@@ -1584,7 +1584,7 @@ static int _xml_extentlist_from_file(const char *filename, struct dentry *d)
 			ret = _xml_parse_extents(reader, IDX_VERSION_SPARSE, d);
 			if (ret < 0) {
 				/* XML parser: failed to read extent list from file (%d) */
-				ltfsmsg(LTFS_ERR, "17084E", ret);
+				ltfsmsg(LTFS_ERR, 17084E, ret);
 			}
 		}
 		break;
@@ -1611,13 +1611,13 @@ int xml_label_from_file(const char *filename, struct ltfs_label *label)
 
 	reader = xmlReaderForFile(filename, NULL, XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
 	if (! reader) {
-		ltfsmsg(LTFS_ERR, "17007E", filename);
+		ltfsmsg(LTFS_ERR, 17007E, filename);
 		return -1;
 	}
 
 	ret = _xml_parse_label(reader, label);
 	if (ret < 0)
-		ltfsmsg(LTFS_ERR, "17008E", filename);
+		ltfsmsg(LTFS_ERR, 17008E, filename);
 	xmlFreeTextReader(reader);
 
 	return ret;
@@ -1633,13 +1633,13 @@ int xml_label_from_mem(const char *buf, int buf_size, struct ltfs_label *label)
 
 	reader = xmlReaderForMemory(buf, buf_size, NULL, NULL, XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
 	if (! reader) {
-		ltfsmsg(LTFS_ERR, "17009E");
+		ltfsmsg(LTFS_ERR, 17009E);
 		return -LTFS_LIBXML2_FAILURE;
 	}
 
 	ret = _xml_parse_label(reader, label);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17010E");
+		ltfsmsg(LTFS_ERR, 17010E);
 		ret = -LTFS_LABEL_INVALID;
 	}
 	xmlFreeTextReader(reader);
@@ -1666,7 +1666,7 @@ int xml_schema_from_file(const char *filename, struct ltfs_index *idx, struct lt
 
 	reader = xmlReaderForFile(filename, NULL, XML_PARSE_NOERROR | XML_PARSE_NOWARNING | XML_PARSE_HUGE);
 	if (! reader) {
-		ltfsmsg(LTFS_ERR, "17011E", filename);
+		ltfsmsg(LTFS_ERR, 17011E, filename);
 		return -1;
 	}
 
@@ -1676,7 +1676,7 @@ int xml_schema_from_file(const char *filename, struct ltfs_index *idx, struct lt
 	doc = xmlTextReaderCurrentDoc(reader);
 	ret = _xml_parse_schema(reader, idx, vol);
 	if (ret < 0)
-		ltfsmsg(LTFS_ERR, "17012E", filename);
+		ltfsmsg(LTFS_ERR, 17012E, filename);
 	if (doc)
 		xmlFreeDoc(doc);
 	xmlFreeTextReader(reader);
@@ -1714,19 +1714,19 @@ int xml_schema_from_tape(uint64_t eod_pos, struct ltfs_volume *vol)
 
 	ret = tape_get_position(vol->device, &current_pos);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17013E", ret);
+		ltfsmsg(LTFS_ERR, 17013E, ret);
 		return ret;
 	}
 
 	/* Create output callback context data structure. */
 	ctx = malloc(sizeof(struct xml_input_tape));
 	if (! ctx) {
-		ltfsmsg(LTFS_ERR, "10001E", "xml_schema_from_tape: ctx");
+		ltfsmsg(LTFS_ERR, 10001E, "xml_schema_from_tape: ctx");
 		return -LTFS_NO_MEMORY;
 	}
 	ctx->buf = malloc(vol->label->blocksize + LTFS_CRC_SIZE);
 	if (! ctx->buf) {
-		ltfsmsg(LTFS_ERR, "10001E", "xml_schema_from_tape: ctx->buf");
+		ltfsmsg(LTFS_ERR, 10001E, "xml_schema_from_tape: ctx->buf");
 		free(ctx);
 		return -LTFS_NO_MEMORY;
 	}
@@ -1744,7 +1744,7 @@ int xml_schema_from_tape(uint64_t eod_pos, struct ltfs_volume *vol)
 											xml_input_tape_close_callback,
 											ctx, XML_CHAR_ENCODING_NONE);
 	if (! read_buf) {
-		ltfsmsg(LTFS_ERR, "17014E");
+		ltfsmsg(LTFS_ERR, 17014E);
 		free(ctx->buf);
 		free(ctx);
 		return -LTFS_LIBXML2_FAILURE;
@@ -1753,7 +1753,7 @@ int xml_schema_from_tape(uint64_t eod_pos, struct ltfs_volume *vol)
 	/* Create XML reader. */
 	reader = xmlNewTextReader(read_buf, NULL);
 	if (! reader) {
-		ltfsmsg(LTFS_ERR, "17015E");
+		ltfsmsg(LTFS_ERR, 17015E);
 		xmlFreeParserInputBuffer(read_buf);
 		return -LTFS_LIBXML2_FAILURE;
 	}
@@ -1762,7 +1762,7 @@ int xml_schema_from_tape(uint64_t eod_pos, struct ltfs_volume *vol)
 	/* Set XML text reader options if it is possible (may be libxml2 2.7 or later) */
 	ret = xmlTextReaderSetup(reader, NULL, NULL, NULL, XML_PARSE_NOERROR | XML_PARSE_NOWARNING | XML_PARSE_HUGE);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17015E");
+		ltfsmsg(LTFS_ERR, 17015E);
 		xmlFreeTextReader(reader);
 		xmlFreeParserInputBuffer(read_buf);
 		return -LTFS_LIBXML2_FAILURE;
@@ -1776,7 +1776,7 @@ int xml_schema_from_tape(uint64_t eod_pos, struct ltfs_volume *vol)
 	/* Generate the Index. */
 	ret = _xml_parse_schema(reader, vol->index, vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17016E");
+		ltfsmsg(LTFS_ERR, 17016E);
 		if ((ret != -LTFS_UNSUPPORTED_INDEX_VERSION)&&( ret != -LTFS_SYMLINK_CONFLICT))
 			ret = -LTFS_INDEX_INVALID;
 	} else if (ret == 0) {

--- a/src/libltfs/xml_writer.c
+++ b/src/libltfs/xml_writer.c
@@ -82,13 +82,13 @@ int xml_format_time(struct ltfs_timespec t, char** out)
 
 	gmt = ltfs_gmtime(&sec, &tm);
 	if (! gmt) {
-		ltfsmsg(LTFS_ERR, "17056E");
+		ltfsmsg(LTFS_ERR, 17056E);
 		return -1;
 	}
 
 	timebuf = calloc(31, sizeof(char));
 	if (!timebuf) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -1;
 	}
 	sprintf(timebuf, "%04d-%02d-%02dT%02d:%02d:%02d.%09ldZ", tm.tm_year+1900, tm.tm_mon+1,
@@ -121,14 +121,14 @@ int xml_output_tape_write_callback(void *context, const char *buffer, int len)
 			memcpy(ctx->buf + ctx->buf_used, buffer + (len - bytes_remaining), copy_count);
 			ret = tape_write(ctx->device, ctx->buf, ctx->buf_size, true, true);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "17060E", (int)ret);
+				ltfsmsg(LTFS_ERR, 17060E, (int)ret);
 				return -1;
 			}
 
 			if (ctx->fd > 0) {
 				ret = write(ctx->fd, ctx->buf, ctx->buf_size);
 				if (ret < 0) {
-					ltfsmsg(LTFS_ERR, "17244E", (int)errno);
+					ltfsmsg(LTFS_ERR, 17244E, (int)errno);
 					return -1;
 				}
 			}
@@ -168,7 +168,7 @@ int xml_output_tape_close_callback(void *context)
 		xml_release_file_lock(ctx->fd);
 		ctx->fd = -1;
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "17206E", "tape write callback (fsync)", errno, ctx->buf_used);
+			ltfsmsg(LTFS_ERR, 17206E, "tape write callback (fsync)", errno, (unsigned long)ctx->buf_used);
 			return -1;
 		}
 	}
@@ -178,9 +178,9 @@ int xml_output_tape_close_callback(void *context)
 	}
 
 	if (ret_t < 0)
-		ltfsmsg(LTFS_ERR, "17061E", (int)ret_t);
+		ltfsmsg(LTFS_ERR, 17061E, (int)ret_t);
 	if (ret_d < 0)
-		ltfsmsg(LTFS_ERR, "17245E", (int)errno);
+		ltfsmsg(LTFS_ERR, 17245E, (int)errno);
 
 	free(ctx->buf);
 	free(ctx);
@@ -198,13 +198,13 @@ int xml_output_fd_write_callback(void *context, const char *buffer, int len)
 	if (len > 0) {
 		ret = write(ctx->fd, buffer, len);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "17206E", "write callback (write)", errno, len);
+			ltfsmsg(LTFS_ERR, 17206E, "write callback (write)", errno, (unsigned long)len);
 			return -1;
 		}
 
 		ret = fsync(ctx->fd);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "17206E", "write callback (fsync)", errno, len);
+			ltfsmsg(LTFS_ERR, 17206E, "write callback (fsync)", errno, (unsigned long)len);
 			return -1;
 		}
 	}
@@ -246,7 +246,7 @@ int xml_acquire_file_lock(const char *file, bool is_write)
 	if (fd < 0) {
 		/* Failed to open the advisory lock '%s' (%d) */
 		errno_save = errno;
-		ltfsmsg(LTFS_WARN, "17241W", file, errno);
+		ltfsmsg(LTFS_WARN, 17241W, file, errno);
 		goto out;
 	}
 
@@ -261,7 +261,7 @@ int xml_acquire_file_lock(const char *file, bool is_write)
 	if (ret < 0) {
 		/* Failed to acquire the advisory lock '%s' (%d) */
 		errno_save = errno;
-		ltfsmsg(LTFS_WARN, "17242W", file, errno);
+		ltfsmsg(LTFS_WARN, 17242W, file, errno);
 		close(fd);
 		fd = -1;
 		goto out;
@@ -270,7 +270,7 @@ int xml_acquire_file_lock(const char *file, bool is_write)
 
 	ret = lseek(fd, 0, SEEK_SET);
 	if (ret < 0){
-		ltfsmsg(LTFS_ERR, "17246E", "seek", errno);
+		ltfsmsg(LTFS_ERR, 17246E, "seek", errno);
 		errno_save = errno;
 		close(fd);
 		fd = -1;
@@ -279,7 +279,7 @@ int xml_acquire_file_lock(const char *file, bool is_write)
 
 	ret = ftruncate(fd, 0);
 	if (ret < 0){
-		ltfsmsg(LTFS_ERR, "17246E", "seek", errno);
+		ltfsmsg(LTFS_ERR, 17246E, "seek", errno);
 		errno_save = errno;
 		close(fd);
 		fd = -1;
@@ -314,7 +314,7 @@ int xml_release_file_lock(int fd)
 	if (ret < 0) {
 		/* Failed to release the advisory lock (%d) */
 		errno_save = errno;
-		ltfsmsg(LTFS_WARN, "17243W", errno);
+		ltfsmsg(LTFS_WARN, 17243W, errno);
 	}
 #endif
 

--- a/src/libltfs/xml_writer_libltfs.c
+++ b/src/libltfs/xml_writer_libltfs.c
@@ -101,7 +101,7 @@ static int encode_entry_name(char **new_name, const char *name)
 
 		U8_NEXT(name, i, len, c);
 		if (c < 0) {
-			ltfsmsg(LTFS_ERR, "11235E");
+			ltfsmsg(LTFS_ERR, 11235E);
 			free(tmp_name);
 			return -LTFS_ICU_ERROR;
 		}
@@ -171,7 +171,7 @@ static int _xml_write_dentry_times(xmlTextWriterPtr writer, const struct dentry 
 	if (!mtime)
 		return -1;
 	else if (ret == LTFS_TIME_OUT_OF_RANGE)
-		ltfsmsg(LTFS_WARN, "17225W", "creationtime", d->creation_time.tv_sec);
+		ltfsmsg(LTFS_WARN, 17225W, "creationtime", (unsigned long long)d->creation_time.tv_sec);
 	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "creationtime", BAD_CAST mtime), -1);
 	free(mtime);
 
@@ -179,7 +179,7 @@ static int _xml_write_dentry_times(xmlTextWriterPtr writer, const struct dentry 
 	if (!mtime)
 		return -1;
 	else if (ret == LTFS_TIME_OUT_OF_RANGE)
-		ltfsmsg(LTFS_WARN, "17225W", "changetime", d->change_time.tv_sec);
+		ltfsmsg(LTFS_WARN, 17225W, "changetime", (unsigned long long)d->change_time.tv_sec);
 	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "changetime", BAD_CAST mtime), -1);
 	free(mtime);
 
@@ -187,7 +187,7 @@ static int _xml_write_dentry_times(xmlTextWriterPtr writer, const struct dentry 
 	if (!mtime)
 		return -1;
 	else if (ret == LTFS_TIME_OUT_OF_RANGE)
-		ltfsmsg(LTFS_WARN, "17225W", "modifytime", d->modify_time.tv_sec);
+		ltfsmsg(LTFS_WARN, 17225W, "modifytime", (unsigned long long)d->modify_time.tv_sec);
 	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "modifytime", BAD_CAST mtime), -1);
 	free(mtime);
 
@@ -195,7 +195,7 @@ static int _xml_write_dentry_times(xmlTextWriterPtr writer, const struct dentry 
 	if (!mtime)
 		return -1;
 	else if (ret == LTFS_TIME_OUT_OF_RANGE)
-		ltfsmsg(LTFS_WARN, "17225W", "accesstime", d->access_time.tv_sec);
+		ltfsmsg(LTFS_WARN, 17225W, "accesstime", (unsigned long long)d->access_time.tv_sec);
 	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "accesstime", BAD_CAST mtime), -1);
 	free(mtime);
 
@@ -203,7 +203,7 @@ static int _xml_write_dentry_times(xmlTextWriterPtr writer, const struct dentry 
 	if (!mtime)
 		return -1;
 	else if (ret == LTFS_TIME_OUT_OF_RANGE)
-		ltfsmsg(LTFS_WARN, "17225W", "backuptime", d->backup_time.tv_sec);
+		ltfsmsg(LTFS_WARN, 17225W, "backuptime", (unsigned long long)d->backup_time.tv_sec);
 	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "backuptime", BAD_CAST mtime), -1);
 	free(mtime);
 
@@ -231,7 +231,7 @@ static int _xml_write_xattr(xmlTextWriterPtr writer, const struct dentry *file)
 			if (xattr->value) {
 				ret = pathname_validate_xattr_value(xattr->value, xattr->size);
 				if (ret < 0) {
-					ltfsmsg(LTFS_ERR, "17059E", ret);
+					ltfsmsg(LTFS_ERR, 17059E, ret);
 					return -1;
 				} else if (ret > 0) {
 					xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "value"), -1);
@@ -269,7 +269,7 @@ static int _xml_write_file(xmlTextWriterPtr writer, struct dentry *file, struct 
 	size_t i;
 
 	if (file->isdir) {
-		ltfsmsg(LTFS_ERR, "17062E");
+		ltfsmsg(LTFS_ERR, 17062E);
 		return -1;
 	}
 
@@ -327,7 +327,7 @@ static int _xml_write_file(xmlTextWriterPtr writer, struct dentry *file, struct 
 	if (file->tag_count > 0) {
 		for (i=0; i<file->tag_count; ++i) {
 			if (xmlTextWriterWriteRaw(writer, file->preserved_tags[i]) < 0) {
-				ltfsmsg(LTFS_ERR, "17092E", __FUNCTION__);
+				ltfsmsg(LTFS_ERR, 17092E, __FUNCTION__);
 				return -1;
 			}
 		}
@@ -401,18 +401,18 @@ static int _xml_write_dirtree(xmlTextWriterPtr writer, struct dentry *dir,
 					offset->fp = fopen(offset_name, "w");
 					free(offset_name);
 					if (!offset->fp)
-						ltfsmsg(LTFS_WARN, "17248W", "offset cache", list_ptr->d->vol->index_cache_path);
+						ltfsmsg(LTFS_WARN, 17248W, "offset cache", list_ptr->d->vol->index_cache_path);
 				} else
-					ltfsmsg(LTFS_WARN, "17247W", "offset cache", list_ptr->d->vol->index_cache_path);
+					ltfsmsg(LTFS_WARN, 17247W, "offset cache", list_ptr->d->vol->index_cache_path);
 
 				ret = asprintf(&sync_name, "%s.%s", list_ptr->d->vol->index_cache_path, "synclist");
 				if (ret > 0) {
 					sync->fp = fopen(sync_name, "w");
 					free(sync_name);
 					if (!sync->fp)
-						ltfsmsg(LTFS_WARN, "17248W", "sync list", list_ptr->d->vol->index_cache_path);
+						ltfsmsg(LTFS_WARN, 17248W, "sync list", list_ptr->d->vol->index_cache_path);
 				} else
-					ltfsmsg(LTFS_WARN, "17247W", "sync list", list_ptr->d->vol->index_cache_path);
+					ltfsmsg(LTFS_WARN, 17247W, "sync list", list_ptr->d->vol->index_cache_path);
 			}
 
 			xml_mktag(_xml_write_dirtree(writer, list_ptr->d, idx, offset, sync), -1);
@@ -440,7 +440,7 @@ static int _xml_write_dirtree(xmlTextWriterPtr writer, struct dentry *dir,
 	if (dir->tag_count > 0) {
 		for (i=0; i<dir->tag_count; ++i) {
 			if (xmlTextWriterWriteRaw(writer, dir->preserved_tags[i]) < 0) {
-				ltfsmsg(LTFS_ERR, "17092E", __FUNCTION__);
+				ltfsmsg(LTFS_ERR, 17092E, __FUNCTION__);
 				return -1;
 			}
 		}
@@ -475,11 +475,11 @@ static int _xml_write_schema(xmlTextWriterPtr writer, const char *creator,
 	if (!update_time)
 		return -1;
 	else if (ret == LTFS_TIME_OUT_OF_RANGE)
-		ltfsmsg(LTFS_WARN, "17224W", "modifytime", idx->mod_time.tv_sec);
+		ltfsmsg(LTFS_WARN, 17224W, "modifytime", (unsigned long long)idx->mod_time.tv_sec);
 
 	ret = xmlTextWriterStartDocument(writer, NULL, "UTF-8", NULL);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17057E", ret);
+		ltfsmsg(LTFS_ERR, 17057E, ret);
 		return -1;
 	}
 
@@ -575,15 +575,15 @@ static int _xml_write_schema(xmlTextWriterPtr writer, const char *creator,
 
 	xml_mktag(_xml_write_dirtree(writer, idx->root, idx, &offset, &list), -1);
 	if (offset.count)
-		ltfsmsg(LTFS_INFO, "17249I", offset.count);
+		ltfsmsg(LTFS_INFO, 17249I, (unsigned long long)offset.count);
 	if (list.count)
-		ltfsmsg(LTFS_INFO, "17250I", list.count);
+		ltfsmsg(LTFS_INFO, 17250I, (unsigned long long)list.count);
 
 	/* Save unrecognized tags */
 	if (idx->tag_count > 0) {
 		for (i=0; i<idx->tag_count; ++i) {
 			if (xmlTextWriterWriteRaw(writer, idx->preserved_tags[i]) < 0) {
-				ltfsmsg(LTFS_ERR, "17092E", __FUNCTION__);
+				ltfsmsg(LTFS_ERR, 17092E, __FUNCTION__);
 				return -1;
 			}
 		}
@@ -592,7 +592,7 @@ static int _xml_write_schema(xmlTextWriterPtr writer, const char *creator,
 	xml_mktag(xmlTextWriterEndElement(writer), -1);
 	ret = xmlTextWriterEndDocument(writer);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17058E", ret);
+		ltfsmsg(LTFS_ERR, 17058E, ret);
 		return -1;
 	}
 
@@ -623,19 +623,19 @@ xmlBufferPtr xml_make_label(const char *creator, tape_partition_t partition,
 
 	buf = xmlBufferCreate();
 	if (!buf) {
-		ltfsmsg(LTFS_ERR, "17047E");
+		ltfsmsg(LTFS_ERR, 17047E);
 		return NULL;
 	}
 
 	writer = xmlNewTextWriterMemory(buf, 0);
 	if (!writer) {
-		ltfsmsg(LTFS_ERR, "17043E");
+		ltfsmsg(LTFS_ERR, 17043E);
 		return NULL;
 	}
 
 	ret = xmlTextWriterStartDocument(writer, NULL, "UTF-8", NULL);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17044E", ret);
+		ltfsmsg(LTFS_ERR, 17044E, ret);
 		return NULL;
 	}
 
@@ -650,10 +650,10 @@ xmlBufferPtr xml_make_label(const char *creator, tape_partition_t partition,
 
 	ret = xml_format_time(label->format_time, &fmt_time);
 	if (!fmt_time) {
-		ltfsmsg(LTFS_ERR, "17045E");
+		ltfsmsg(LTFS_ERR, 17045E);
 		return NULL;
 	} else if (ret == LTFS_TIME_OUT_OF_RANGE)
-		ltfsmsg(LTFS_WARN, "17223W", "formattime", label->format_time.tv_sec);
+		ltfsmsg(LTFS_WARN, 17223W, "formattime", (unsigned long long)label->format_time.tv_sec);
 
 	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "formattime", BAD_CAST fmt_time), NULL);
 	free(fmt_time);
@@ -678,7 +678,7 @@ xmlBufferPtr xml_make_label(const char *creator, tape_partition_t partition,
 
 	ret = xmlTextWriterEndDocument(writer);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "17046E", ret);
+		ltfsmsg(LTFS_ERR, 17046E, ret);
 		return NULL;
 	}
 
@@ -701,18 +701,18 @@ xmlBufferPtr xml_make_schema(const char *creator, const struct ltfs_index *idx)
 
 	buf = xmlBufferCreate();
 	if (!buf) {
-		ltfsmsg(LTFS_ERR, "17048E");
+		ltfsmsg(LTFS_ERR, 17048E);
 		return NULL;
 	}
 
 	writer = xmlNewTextWriterMemory(buf, 0);
 	if (!writer) {
-		ltfsmsg(LTFS_ERR, "17049E");
+		ltfsmsg(LTFS_ERR, 17049E);
 		return NULL;
 	}
 
 	if (_xml_write_schema(writer, creator, idx) < 0) {
-		ltfsmsg(LTFS_ERR, "17050E");
+		ltfsmsg(LTFS_ERR, 17050E);
 		xmlBufferFree(buf);
 		buf = NULL;
 	}
@@ -739,7 +739,7 @@ int xml_schema_to_file(const char *filename, const char *creator
 
 	writer = xmlNewTextWriterFilename(filename, 0);
 	if (! writer) {
-		ltfsmsg(LTFS_ERR, "17051E", filename);
+		ltfsmsg(LTFS_ERR, 17051E, filename);
 		return -1;
 	}
 
@@ -751,11 +751,11 @@ int xml_schema_to_file(const char *filename, const char *creator
 	if (alt_creator) {
 		ret = _xml_write_schema(writer, alt_creator, idx);
 		if (ret < 0)
-			ltfsmsg(LTFS_ERR, "17052E", ret, filename);
+			ltfsmsg(LTFS_ERR, 17052E, ret, filename);
 		xmlFreeTextWriter(writer);
 		free(alt_creator);
 	} else {
-		ltfsmsg(LTFS_ERR, "10001E", "xml_schema_to_file: alt creator string");
+		ltfsmsg(LTFS_ERR, 10001E, "xml_schema_to_file: alt creator string");
 		return -1;
 	}
 
@@ -782,12 +782,12 @@ int xml_schema_to_tape(char *reason, struct ltfs_volume *vol)
 	/* Create output callback context data structure. */
 	out_ctx = calloc(1, sizeof(struct xml_output_tape));
 	if (! out_ctx) {
-		ltfsmsg(LTFS_ERR, "10001E", "xml_schema_to_tape: output context");
+		ltfsmsg(LTFS_ERR, 10001E, "xml_schema_to_tape: output context");
 		return -LTFS_NO_MEMORY;
 	}
 	out_ctx->buf = malloc(vol->label->blocksize + LTFS_CRC_SIZE);
 	if (! out_ctx->buf) {
-		ltfsmsg(LTFS_ERR, "10001E", "xml_schema_to_tape: output buffer");
+		ltfsmsg(LTFS_ERR, 10001E, "xml_schema_to_tape: output buffer");
 		free(out_ctx);
 		return -LTFS_NO_MEMORY;
 	}
@@ -806,7 +806,7 @@ int xml_schema_to_tape(char *reason, struct ltfs_volume *vol)
 										xml_output_tape_close_callback,
 										out_ctx, NULL);
 	if (! write_buf) {
-		ltfsmsg(LTFS_ERR, "17053E");
+		ltfsmsg(LTFS_ERR, 17053E);
 		if (out_ctx->fd >= 0)
 			xml_release_file_lock(out_ctx->fd);
 		free(out_ctx->buf);
@@ -817,7 +817,7 @@ int xml_schema_to_tape(char *reason, struct ltfs_volume *vol)
 	/* Create XML writer. */
 	writer = xmlNewTextWriter(write_buf);
 	if (! writer) {
-		ltfsmsg(LTFS_ERR, "17054E");
+		ltfsmsg(LTFS_ERR, 17054E);
 		if (out_ctx->fd >= 0)
 			xml_release_file_lock(out_ctx->fd);
 		xmlOutputBufferClose(write_buf);
@@ -829,7 +829,7 @@ int xml_schema_to_tape(char *reason, struct ltfs_volume *vol)
 	if (creator) {
 		ret = _xml_write_schema(writer, creator, vol->index);
 		if (ret < 0)
-			ltfsmsg(LTFS_ERR, "17055E", ret);
+			ltfsmsg(LTFS_ERR, 17055E, ret);
 
 		xmlFreeTextWriter(writer);
 		free(creator);
@@ -840,12 +840,12 @@ int xml_schema_to_tape(char *reason, struct ltfs_volume *vol)
 				free(vol->index->creator);
 			vol->index->creator = strdup(vol->creator);
 			if (! vol->index->creator) {
-				ltfsmsg(LTFS_ERR, "10001E", "xml_schema_to_tape: new creator string");
+				ltfsmsg(LTFS_ERR, 10001E, "xml_schema_to_tape: new creator string");
 				ret = -1;
 			}
 		}
 	} else {
-		ltfsmsg(LTFS_ERR, "10001E", "xml_schema_to_tape: creator string");
+		ltfsmsg(LTFS_ERR, 10001E, "xml_schema_to_tape: creator string");
 		xmlFreeTextWriter(writer);
 		ret = -1;
 	}

--- a/src/ltfs_fuse.c
+++ b/src/ltfs_fuse.c
@@ -89,12 +89,12 @@ struct ltfs_file_handle *_new_ltfs_file_handle(struct file_info *fi)
 	int ret;
 	struct ltfs_file_handle *file = calloc(1, sizeof(struct ltfs_file_handle));
 	if (! file) {
-		ltfsmsg(LTFS_ERR, "10001E", "file structure");
+		ltfsmsg(LTFS_ERR, 10001E, "file structure");
 		return NULL;
 	}
 	ret = ltfs_mutex_init(&file->lock);
 	if (ret) {
-		ltfsmsg(LTFS_ERR, "10002E", ret);
+		ltfsmsg(LTFS_ERR, 10002E, ret);
 		free(file);
 		return NULL;
 	}
@@ -116,19 +116,19 @@ static struct file_info *_new_file_info(const char *path)
 	int ret;
 	struct file_info *fi = calloc(1, sizeof(struct file_info));
 	if (! fi) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return NULL;
 	}
 	ret = ltfs_mutex_init(&fi->lock);
 	if (ret) {
-		ltfsmsg(LTFS_ERR, "10002E", ret);
+		ltfsmsg(LTFS_ERR, 10002E, ret);
 		free(fi);
 		return NULL;
 	}
 	if (path) {
 		fi->path = strdup(path);
 		if (! fi->path) {
-			ltfsmsg(LTFS_ERR, "10001E", "_new_file_info: path");
+			ltfsmsg(LTFS_ERR, 10001E, "_new_file_info: path");
 			ltfs_mutex_destroy(&fi->lock);
 			free(fi);
 			return NULL;
@@ -265,7 +265,7 @@ int ltfs_fuse_fgetattr(const char *path, struct stat *stbuf, struct fuse_file_in
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_FGETATTR), (uint64_t)fi, 0);
 
-	ltfsmsg(LTFS_DEBUG3, "14030D", _dentry_name(path, file->file_info));
+	ltfsmsg(LTFS_DEBUG3, 14030D, _dentry_name(path, file->file_info));
 
 	ret = ltfs_fsops_getattr(file->file_info->dentry_handle, &attr, priv->data);
 
@@ -287,7 +287,7 @@ int ltfs_fuse_getattr(const char *path, struct stat *stbuf)
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_GETATTR), 0, 0);
 
-	ltfsmsg(LTFS_DEBUG3, "14031D", path);
+	ltfsmsg(LTFS_DEBUG3, 14031D, path);
 
 	ret = ltfs_fsops_getattr_path(path, &attr, &id, priv->data);
 
@@ -361,11 +361,11 @@ int ltfs_fuse_open(const char *path, struct fuse_file_info *fi)
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_OPEN), (uint64_t)fi->flags, 0);
 
 	if ((fi->flags & O_WRONLY) == O_WRONLY)
-		ltfsmsg(LTFS_DEBUG, "14032D", path, "write-only");
+		ltfsmsg(LTFS_DEBUG, 14032D, path, "write-only");
 	else if ((fi->flags & O_RDWR) == O_RDWR)
-		ltfsmsg(LTFS_DEBUG, "14032D", path, "read-write");
+		ltfsmsg(LTFS_DEBUG, 14032D, path, "read-write");
 	else /* read-only */
-		ltfsmsg(LTFS_DEBUG, "14032D", path, "read-only");
+		ltfsmsg(LTFS_DEBUG, 14032D, path, "read-only");
 	open_write = (((fi->flags & O_WRONLY) == O_WRONLY) || ((fi->flags & O_RDWR) == O_RDWR));
 
 	/* Open the file */
@@ -427,7 +427,7 @@ int ltfs_fuse_release(const char *path, struct fuse_file_info *fi)
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_RELEASE), 0, 0);
 
-	ltfsmsg(LTFS_DEBUG, "14035D", _dentry_name(path, file->file_info));
+	ltfsmsg(LTFS_DEBUG, 14035D, _dentry_name(path, file->file_info));
 
 	uid = ((struct dentry *)(file->file_info->dentry_handle))->uid;
 
@@ -465,7 +465,7 @@ int ltfs_fuse_opendir(const char *path, struct fuse_file_info *fi)
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_OPENDIR), (uint64_t)fi->flags, 0);
 
-	ltfsmsg(LTFS_DEBUG, "14033D", path);
+	ltfsmsg(LTFS_DEBUG, 14033D, path);
 
 	open_write = (((fi->flags & O_WRONLY) == O_WRONLY) || ((fi->flags & O_RDWR) == O_RDWR));
 
@@ -506,7 +506,7 @@ int ltfs_fuse_releasedir(const char *path, struct fuse_file_info *fi)
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_RELEASEDIR), 0, 0);
 
-	ltfsmsg(LTFS_DEBUG, "14034D", _dentry_name(path, file->file_info));
+	ltfsmsg(LTFS_DEBUG, 14034D, _dentry_name(path, file->file_info));
 
 	uid = ((struct dentry *)(file->file_info->dentry_handle))->uid;
 
@@ -540,7 +540,7 @@ static int _ltfs_fuse_do_flush(struct ltfs_file_handle *file, struct ltfs_fuse_d
 	if (dirty) {
 		ret = ltfs_fsops_flush(file->file_info->dentry_handle, false, priv->data);
 		if (ret < 0)
-			ltfsmsg(LTFS_ERR, "14022E", caller);
+			ltfsmsg(LTFS_ERR, 14022E, caller);
 		else {
 			ltfs_mutex_lock(&file->lock);
 			file->dirty = false;
@@ -560,7 +560,7 @@ int ltfs_fuse_fsync(const char *path, int isdatasync, struct fuse_file_info *fi)
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_FSYNC), (uint64_t)isdatasync, 0);
 
-	ltfsmsg(LTFS_DEBUG, "14036D", _dentry_name(path, file->file_info));
+	ltfsmsg(LTFS_DEBUG, 14036D, _dentry_name(path, file->file_info));
 	uid = ((struct dentry *)(file->file_info->dentry_handle))->uid;
 	ret = _ltfs_fuse_do_flush(file, priv, __FUNCTION__);
 
@@ -578,7 +578,7 @@ int ltfs_fuse_flush(const char *path, struct fuse_file_info *fi)
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_FLUSH), 0, 0);
 
-	ltfsmsg(LTFS_DEBUG, "14037D", _dentry_name(path, file->file_info));
+	ltfsmsg(LTFS_DEBUG, 14037D, _dentry_name(path, file->file_info));
 	uid = ((struct dentry *)(file->file_info->dentry_handle))->uid;
 	ret = _ltfs_fuse_do_flush(file, priv, __FUNCTION__);
 
@@ -599,13 +599,13 @@ int ltfs_fuse_utimens(const char *path, const struct timespec ts[2])
 	tsTmp[0] = ltfs_timespec_from_timespec(&ts[0]);
 	tsTmp[1] = ltfs_timespec_from_timespec(&ts[1]);
 
-	ltfsmsg(LTFS_DEBUG, "14038D", path);
+	ltfsmsg(LTFS_DEBUG, 14038D, path);
 	ret = ltfs_fsops_utimens_path(path, tsTmp, &id, priv->data);
 
 	ltfs_request_trace(FUSE_REQ_EXIT(REQ_UTIMENS), ret, id.uid);
 
 	if (ret)
-		ltfsmsg(LTFS_ERR, "10020E", "utimens", path, 0, 0);
+		ltfsmsg(LTFS_ERR, 10020E, "utimens", path, 0, 0);
 
 	return errormap_fuse_error(ret);
 }
@@ -623,13 +623,13 @@ int ltfs_fuse_chmod(const char *path, mode_t mode)
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_CHMOD), (uint64_t)mode, 0);
 
-	ltfsmsg(LTFS_DEBUG, "14039D", path);
+	ltfsmsg(LTFS_DEBUG, 14039D, path);
 	ret = ltfs_fsops_set_readonly_path(path, new_readonly, &id, priv->data);
 
 	ltfs_request_trace(FUSE_REQ_EXIT(REQ_CHMOD), ret, id.uid);
 
 	if (ret)
-		ltfsmsg(LTFS_ERR, "10020E", "chmod", path, mode, 0);
+		ltfsmsg(LTFS_ERR, 10020E, "chmod", path, mode, 0);
 
 	return errormap_fuse_error(ret);
 }
@@ -657,7 +657,7 @@ int ltfs_fuse_create(const char *path, mode_t mode, struct fuse_file_info *fi)
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_CREATE), (uint64_t)fi->flags, 0);
 
-	ltfsmsg(LTFS_DEBUG, "14040D", path);
+	ltfsmsg(LTFS_DEBUG, 14040D, path);
 
 	readonly = ! (mode & priv->file_mode & 0222);
 
@@ -729,7 +729,7 @@ int ltfs_fuse_mkdir(const char *path, mode_t mode)
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_MKDIR), (uint64_t)mode, 0);
 
-	ltfsmsg(LTFS_DEBUG, "14041D", path);
+	ltfsmsg(LTFS_DEBUG, 14041D, path);
 
 	ret = ltfs_fsops_create(path, true, false, false, (struct dentry **)&dentry_handle, priv->data);
 	if (ret == 0) {
@@ -750,7 +750,7 @@ int ltfs_fuse_truncate(const char *path, off_t length)
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_TRUNCATE), (uint64_t)length, 0);
 
-	ltfsmsg(LTFS_DEBUG, "14042D", path, (long long)length);
+	ltfsmsg(LTFS_DEBUG, 14042D, path, (long long)length);
 
 	ret = ltfs_fsops_truncate_path(path, length, &id, priv->data);
 
@@ -767,7 +767,7 @@ int ltfs_fuse_ftruncate(const char *path, off_t length, struct fuse_file_info *f
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_FTRUNCATE), (uint64_t)length, 0);
 
-	ltfsmsg(LTFS_DEBUG, "14043D", _dentry_name(path, file->file_info), (long long) length);
+	ltfsmsg(LTFS_DEBUG, 14043D, _dentry_name(path, file->file_info), (long long) length);
 
 	ret = ltfs_fsops_truncate(file->file_info->dentry_handle, length, priv->data);
 
@@ -785,7 +785,7 @@ int ltfs_fuse_unlink(const char *path)
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_UNLINK), 0, 0);
 
-	ltfsmsg(LTFS_DEBUG, "14044D", path);
+	ltfsmsg(LTFS_DEBUG, 14044D, path);
 
 	ret = ltfs_fsops_unlink(path, &id, priv->data);
 
@@ -802,7 +802,7 @@ int ltfs_fuse_rmdir(const char *path)
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_RMDIR), 0, 0);
 
-	ltfsmsg(LTFS_DEBUG, "14045D", path);
+	ltfsmsg(LTFS_DEBUG, 14045D, path);
 
 	ret = ltfs_fsops_unlink(path, &id, priv->data);
 
@@ -819,7 +819,7 @@ int ltfs_fuse_rename(const char *from, const char *to)
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_RENAME), 0, 0);
 
-	ltfsmsg(LTFS_DEBUG, "14046D", from, to);
+	ltfsmsg(LTFS_DEBUG, 14046D, from, to);
 
 	ret = ltfs_fsops_rename(from, to, &id, priv->data);
 
@@ -836,7 +836,7 @@ int _ltfs_fuse_filldir(void *buf, const char *name, void *priv)
 
 	ret = pathname_unformat(name, &new_name);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "14027E", "unformat", ret);
+		ltfsmsg(LTFS_ERR, 14027E, "unformat", ret);
 		return ret;
 	}
 
@@ -845,7 +845,7 @@ int _ltfs_fuse_filldir(void *buf, const char *name, void *priv)
 
 	ret = pathname_nfd_normaize(name, &new_name);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "14027E", "nfd", ret);
+		ltfsmsg(LTFS_ERR, 14027E, "nfd", ret);
 		return ret;
 	}
 
@@ -869,16 +869,16 @@ int ltfs_fuse_readdir(const char *path, void *buf, fuse_fill_dir_t filler,
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_READDIR), (uint64_t)offset, 0);
 
-	ltfsmsg(LTFS_DEBUG, "14047D", _dentry_name(path, file->file_info));
+	ltfsmsg(LTFS_DEBUG, 14047D, _dentry_name(path, file->file_info));
 
 	if (filler(buf, ".",  NULL, 0)) {
 		/* No buffer space */
-		ltfsmsg(LTFS_DEBUG, "14026D");
+		ltfsmsg(LTFS_DEBUG, 14026D);
 		return -ENOBUFS;
 	}
 	if (filler(buf, "..", NULL, 0)) {
 		/* No buffer space */
-		ltfsmsg(LTFS_DEBUG, "14026D");
+		ltfsmsg(LTFS_DEBUG, 14026D);
 		return -ENOBUFS;
 	}
 
@@ -899,7 +899,7 @@ int ltfs_fuse_write(const char *path, const char *buf, size_t size, off_t offset
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_WRITE), (uint64_t)offset, (uint64_t)size);
 
-	ltfsmsg(LTFS_DEBUG3, "14048D", _dentry_name(path, file->file_info), (long long)offset, size);
+	ltfsmsg(LTFS_DEBUG3, 14048D, _dentry_name(path, file->file_info), (long long)offset, size);
 
 	ret = ltfs_fsops_write(file->file_info->dentry_handle, buf, size, offset, true, priv->data);
 
@@ -931,7 +931,7 @@ int ltfs_fuse_read(const char *path, char *buf, size_t size, off_t offset, struc
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_READ), (uint64_t)offset, (uint64_t)size);
 
-	ltfsmsg(LTFS_DEBUG3, "14049D", _dentry_name(path, file->file_info), (long long)offset, size);
+	ltfsmsg(LTFS_DEBUG3, 14049D, _dentry_name(path, file->file_info), (long long)offset, size);
 
 	ret = ltfs_fsops_read(file->file_info->dentry_handle, buf, size, offset, priv->data);
 
@@ -955,7 +955,7 @@ int ltfs_fuse_setxattr(const char *path, const char *name, const char *value, si
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_SETXATTR), (uint64_t)size, 0);
 
-	ltfsmsg(LTFS_DEBUG3, "14050D", path, name, size);
+	ltfsmsg(LTFS_DEBUG3, 14050D, path, name, size);
 
 	/* position argument is only supported for resource forks
 	 * on OS X, and we have no resource forks
@@ -964,7 +964,7 @@ int ltfs_fuse_setxattr(const char *path, const char *name, const char *value, si
 #ifdef __APPLE__
 	if (position) {
 		/* Position argument must be zero */
-		ltfsmsg(LTFS_ERR, "14023E");
+		ltfsmsg(LTFS_ERR, 14023E);
 		ltfs_request_trace(FUSE_REQ_EXIT(REQ_SETXATTR), -EINVAL, 0);
 		return -EINVAL;
 	}
@@ -990,7 +990,7 @@ int ltfs_fuse_getxattr(const char *path, const char *name, char *value, size_t s
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_GETXATTR), (uint64_t)size, 0);
 
-	ltfsmsg(LTFS_DEBUG3, "14051D", path, name);
+	ltfsmsg(LTFS_DEBUG3, 14051D, path, name);
 
 	/* position argument is only supported for resource forks
 	 * on OS X, and we have no resource forks
@@ -999,7 +999,7 @@ int ltfs_fuse_getxattr(const char *path, const char *name, char *value, size_t s
 #ifdef __APPLE__
 	if (position) {
 		/* Position argument must be zero */
-		ltfsmsg(LTFS_ERR, "14024E");
+		ltfsmsg(LTFS_ERR, 14024E);
 		ltfs_request_trace(FUSE_REQ_EXIT(REQ_GETXATTR), -EINVAL, 0);
 		return -EINVAL;
 	}
@@ -1027,7 +1027,7 @@ int ltfs_fuse_listxattr(const char *path, char *list, size_t size)
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_LISTXATTR), (uint64_t)size, 0);
 
-	ltfsmsg(LTFS_DEBUG, "14052D", path);
+	ltfsmsg(LTFS_DEBUG, 14052D, path);
 
 	ret = ltfs_fsops_listxattr(path, list, size, &id, priv->data);
 
@@ -1044,7 +1044,7 @@ int ltfs_fuse_removexattr(const char *path, const char *name)
 
 	ltfs_request_trace(FUSE_REQ_ENTER(REQ_REMOVEXATTR), 0, 0);
 
-	ltfsmsg(LTFS_DEBUG, "14053D", path, name);
+	ltfsmsg(LTFS_DEBUG, 14053D, path, name);
 
 	ret = ltfs_fsops_removexattr(path, name, &id, priv->data);
 
@@ -1083,7 +1083,7 @@ void * ltfs_fuse_mount(struct fuse_conn_info *conn)
 	 */
 	if (iosched_init(&priv->iosched_plugin, priv->data) < 0) {
 		/* I/O scheduler disabled. Performance down, memory usage up. */
-		ltfsmsg(LTFS_WARN, "14028W");
+		ltfsmsg(LTFS_WARN, 14028W);
 	}
 
 	/* fill in fixed filesystem stats */
@@ -1123,7 +1123,7 @@ void * ltfs_fuse_mount(struct fuse_conn_info *conn)
 	stats->f_fsid = LTFS_SUPER_MAGIC;                  /* Ignored by FUSE */
 	stats->f_namemax = LTFS_FILENAME_MAX;
 
-	ltfsmsg(LTFS_INFO, "14029I");
+	ltfsmsg(LTFS_INFO, 14029I);
 #endif /* mingw_PLATFORM */
 
 	/* Kick timer thread for sync by time */

--- a/src/main.c
+++ b/src/main.c
@@ -146,38 +146,38 @@ static struct fuse_opt ltfs_options[] = {
 
 void single_drive_advanced_usage(const char *default_driver, struct ltfs_fuse_data *priv)
 {
-	ltfsresult("14401I");                        /* LTFS options: */
-	ltfsresult("14413I", LTFS_CONFIG_FILE);      /* -o config_file=<file> */
-	ltfsresult("14404I", LTFS_DEFAULT_WORK_DIR); /* -o work_directory=<dir> */
-	ltfsresult("14414I");                        /* -o atime */
-	ltfsresult("14440I");                        /* -o noatime */
-	ltfsresult("14415I", default_driver);        /* -o tape_backend=<name> */
-	ltfsresult("14416I", config_file_get_default_plugin("iosched", priv->config)); /* -o iosched_backend=<name> */
-	ltfsresult("14455I", config_file_get_default_plugin("kmi", priv->config)); /* -o kmi_backend=<name> */
-	ltfsresult("14417I");                        /* -o umask=<mode> */
-	ltfsresult("14418I");                        /* -o fmask=<mode> */
-	ltfsresult("14419I");                        /* -o dmask=<mode> */
-	ltfsresult("14420I", LTFS_MIN_CACHE_SIZE_DEFAULT); /* -o min_pool_size=<num> */
-	ltfsresult("14421I", LTFS_MAX_CACHE_SIZE_DEFAULT); /* -o max_pool_size=<num> */
-	ltfsresult("14422I"); /* -o rules=<rule[,rule]> */
-	ltfsresult("14423I"); /* -o quiet */
-	ltfsresult("14405I"); /* -o trace */
-	ltfsresult("14467I"); /* -o syslogtrace */
-	ltfsresult("14424I"); /* -o fulltrace */
-	ltfsresult("14441I", LTFS_INFO); /* -o verbose=<num> */
-	ltfsresult("14425I"); /* -o eject */
-	ltfsresult("14439I"); /* -o noeject */
-	ltfsresult("14427I"); /* -o sync_type=type */
-	ltfsresult("14443I"); /* -o force_mount_no_eod */
-	ltfsresult("14436I"); /* -o device_list */
-	ltfsresult("14437I"); /* -o rollback_mount */
-	ltfsresult("14448I"); /* -o release_device */
-	ltfsresult("14456I"); /* -o capture_index */
-	ltfsresult("14463I"); /* -o scsi_append_only_mode=<on|off> */
-	ltfsresult("14406I"); /* -a */
+	ltfsresult(14401I);                        /* LTFS options: */
+	ltfsresult(14413I, LTFS_CONFIG_FILE);      /* -o config_file=<file> */
+	ltfsresult(14404I, LTFS_DEFAULT_WORK_DIR); /* -o work_directory=<dir> */
+	ltfsresult(14414I);                        /* -o atime */
+	ltfsresult(14440I);                        /* -o noatime */
+	ltfsresult(14415I, default_driver);        /* -o tape_backend=<name> */
+	ltfsresult(14416I, config_file_get_default_plugin("iosched", priv->config)); /* -o iosched_backend=<name> */
+	ltfsresult(14455I, config_file_get_default_plugin("kmi", priv->config)); /* -o kmi_backend=<name> */
+	ltfsresult(14417I);                        /* -o umask=<mode> */
+	ltfsresult(14418I);                        /* -o fmask=<mode> */
+	ltfsresult(14419I);                        /* -o dmask=<mode> */
+	ltfsresult(14420I, LTFS_MIN_CACHE_SIZE_DEFAULT); /* -o min_pool_size=<num> */
+	ltfsresult(14421I, LTFS_MAX_CACHE_SIZE_DEFAULT); /* -o max_pool_size=<num> */
+	ltfsresult(14422I); /* -o rules=<rule[,rule]> */
+	ltfsresult(14423I); /* -o quiet */
+	ltfsresult(14405I); /* -o trace */
+	ltfsresult(14467I); /* -o syslogtrace */
+	ltfsresult(14424I); /* -o fulltrace */
+	ltfsresult(14441I, LTFS_INFO); /* -o verbose=<num> */
+	ltfsresult(14425I); /* -o eject */
+	ltfsresult(14439I); /* -o noeject */
+	ltfsresult(14427I, LONG_MAX / 60); /* -o sync_type=type */
+	ltfsresult(14443I); /* -o force_mount_no_eod */
+	ltfsresult(14436I); /* -o device_list */
+	ltfsresult(14437I); /* -o rollback_mount */
+	ltfsresult(14448I); /* -o release_device */
+	ltfsresult(14456I); /* -o capture_index */
+	ltfsresult(14463I); /* -o scsi_append_only_mode=<on|off> */
+	ltfsresult(14406I); /* -a */
 	/* TODO: future use for WORM */
 	/* set worm rollback flag and rollback_str by this option */
-	/* ltfsresult("14468I"); */ /* -o rollback_mount_no_eod */
+	/* ltfsresult(14468I); */ /* -o rollback_mount_no_eod */
 }
 
 void usage(char *progname, struct ltfs_fuse_data *priv)
@@ -194,30 +194,30 @@ void usage(char *progname, struct ltfs_fuse_data *priv)
 		if (ret == 0)
 			default_device = ltfs_default_device_name(priv->tape_plugin.ops);
 
-		ltfsresult("14400I", progname);                   /* usage: %s mountpoint [options] */
+		ltfsresult(14400I, progname);                   /* usage: %s mountpoint [options] */
 		fprintf(stderr, "\n");
-		ltfsresult("14401I");                             /* LTFS options: */
+		ltfsresult(14401I);                             /* LTFS options: */
 		if (default_device)
-			ltfsresult("14402I", default_device);         /* -o devname=<dev> */
+			ltfsresult(14402I, default_device);         /* -o devname=<dev> */
 		else
-			ltfsresult("14403I");                         /* -o devname=<dev> */
-		ltfsresult("14404I", LTFS_DEFAULT_WORK_DIR);      /* -o work_directory=<dir> */
-		ltfsresult("14405I");                             /* -o trace */
-		ltfsresult("14425I");                             /* -o eject */
-		ltfsresult("14427I", LONG_MAX / 60);              /* -o sync_type=type */
-		ltfsresult("14443I");                             /* -o force_mount_no_eod */
-		ltfsresult("14436I");                             /* -o device_list */
-		ltfsresult("14437I");                             /* -o rollback_mount */
-		ltfsresult("14448I");                             /* -o release_device */
-		ltfsresult("14461I");                             /* -o symlink_type=type */
-		ltfsresult("14406I");                             /* -a */
-		ltfsresult("14407I");                             /* -V, --version */
-		ltfsresult("14408I");                             /* -h, --help */
+			ltfsresult(14403I);                         /* -o devname=<dev> */
+		ltfsresult(14404I, LTFS_DEFAULT_WORK_DIR);      /* -o work_directory=<dir> */
+		ltfsresult(14405I);                             /* -o trace */
+		ltfsresult(14425I);                             /* -o eject */
+		ltfsresult(14427I, LONG_MAX / 60);              /* -o sync_type=type */
+		ltfsresult(14443I);                             /* -o force_mount_no_eod */
+		ltfsresult(14436I);                             /* -o device_list */
+		ltfsresult(14437I);                             /* -o rollback_mount */
+		ltfsresult(14448I);                             /* -o release_device */
+		ltfsresult(14461I);                             /* -o symlink_type=type */
+		ltfsresult(14406I);                             /* -a */
+		ltfsresult(14407I);                             /* -V, --version */
+		ltfsresult(14408I);                             /* -h, --help */
 		fprintf(stderr, "\n");
-		ltfsresult("14409I");                             /* FUSE options: */
-		ltfsresult("14410I");                             /* -o umask=M */
-		ltfsresult("14411I");                             /* -o uid=N */
-		ltfsresult("14412I");                             /* -o gid=N */
+		ltfsresult(14409I);                             /* FUSE options: */
+		ltfsresult(14410I);                             /* -o umask=M */
+		ltfsresult(14411I);                             /* -o uid=N */
+		ltfsresult(14412I);                             /* -o gid=N */
 		fprintf(stderr, "\n");
 		fprintf(stderr, "\n");
 
@@ -303,7 +303,7 @@ int permissions_setup(struct ltfs_fuse_data *priv)
 		priv->mount_uid = parse_uid(priv->force_uid);
 		if (priv->mount_uid == (uid_t)-1) {
 			/* Invalid UID */
-			ltfsmsg(LTFS_ERR, "14079E", priv->force_uid);
+			ltfsmsg(LTFS_ERR, 14079E, priv->force_uid);
 			return -1;
 		}
 		free(priv->force_uid);
@@ -315,7 +315,7 @@ int permissions_setup(struct ltfs_fuse_data *priv)
 		priv->mount_gid = parse_gid(priv->force_gid);
 		if (priv->mount_gid == (gid_t)-1) {
 			/* Invalid GID */
-			ltfsmsg(LTFS_ERR, "14080E", priv->force_gid);
+			ltfsmsg(LTFS_ERR, 14080E, priv->force_gid);
 			return -1;
 		}
 		free(priv->force_gid);
@@ -327,7 +327,7 @@ int permissions_setup(struct ltfs_fuse_data *priv)
 		mode = parse_mode(priv->force_umask);
 		if (mode == (mode_t)-1) {
 			/* Invalid umask */
-			ltfsmsg(LTFS_ERR, "14006E", priv->force_umask);
+			ltfsmsg(LTFS_ERR, 14006E, priv->force_umask);
 			return -1;
 		}
 		priv->file_mode = (S_IFREG | 0777) & ~mode;
@@ -341,7 +341,7 @@ int permissions_setup(struct ltfs_fuse_data *priv)
 		mode = parse_mode(priv->force_fmask);
 		if (mode == (mode_t)-1) {
 			/* Invalid fmask */
-			ltfsmsg(LTFS_ERR, "14007E", priv->force_fmask);
+			ltfsmsg(LTFS_ERR, 14007E, priv->force_fmask);
 			return -1;
 		}
 		priv->file_mode = (S_IFREG | 0777) & ~mode;
@@ -354,7 +354,7 @@ int permissions_setup(struct ltfs_fuse_data *priv)
 		mode = parse_mode(priv->force_dmask);
 		if (mode == (mode_t)-1) {
 			/* Invalid dmask */
-			ltfsmsg(LTFS_ERR, "14008E", priv->force_dmask);
+			ltfsmsg(LTFS_ERR, 14008E, priv->force_dmask);
 			return -1;
 		}
 		priv->dir_mode = (S_IFDIR | 0777) & ~mode;
@@ -382,8 +382,8 @@ int ltfs_parse_options(void *priv_data, const char *arg, int key, struct fuse_ar
 
 	switch(key) {
 		case KEY_VERSION:
-			ltfsresult("14058I", PACKAGE_NAME, PACKAGE_VERSION);
-			ltfsresult("14058I", "LTFS Format Specification", LTFS_INDEX_VERSION_STR);
+			ltfsresult(14058I, PACKAGE_NAME, PACKAGE_VERSION);
+			ltfsresult(14058I, "LTFS Format Specification", LTFS_INDEX_VERSION_STR);
 			exit(0);
 		case KEY_ADVANCED_HELP:
 			priv->advanced_help = true;
@@ -400,7 +400,7 @@ int ltfs_parse_options(void *priv_data, const char *arg, int key, struct fuse_ar
 			if (! priv->advanced_help) {
 				if (! valid_fuse_option && key == FUSE_OPT_KEY_OPT && arg && arg[0] == '-') {
 					/* invalid option */
-					ltfsmsg(LTFS_ERR, "9010E", arg);
+					ltfsmsg(LTFS_ERR, 9010E, arg);
 				} else
 					break;
 			}
@@ -437,7 +437,7 @@ int mkdir_p(const char *path, mode_t mode)
 		if (*ptr == '\0' || last) {
 			ret = mkdir(buf, mode);
 			if (ret && errno != EEXIST) {
-				ltfsmsg(LTFS_ERR, "9014E", path, strerror(errno));
+				ltfsmsg(LTFS_ERR, 9014E, path, strerror(errno));
 				return 1;
 			}
 			if (! last)
@@ -457,12 +457,12 @@ static int create_workdir(struct ltfs_fuse_data *priv)
 		ret = mkdir_p(priv->work_directory, S_IRWXU | S_IRWXG | S_IRWXO);
 		if (ret < 0) {
 			/* Failed to create work directory */
-			ltfsmsg(LTFS_ERR, "14004E", ret);
+			ltfsmsg(LTFS_ERR, 14004E, ret);
 			return ret;
 		}
 	} else if (! S_ISDIR(statbuf.st_mode)) {
 		/* Path exists but is not a directory */
-		ltfsmsg(LTFS_ERR, "14005E", priv->work_directory);
+		ltfsmsg(LTFS_ERR, 14005E, priv->work_directory);
 		return -ENOTDIR;
 	}
 
@@ -495,7 +495,7 @@ int validate_sync_option(struct ltfs_fuse_data *priv)
 	else if (strcasecmp(priv->sync_type_str, "unmount") == 0)
 		priv->sync_type = LTFS_SYNC_UNMOUNT;
 	else {
-		ltfsmsg(LTFS_ERR, "14061E", priv->sync_type_str);
+		ltfsmsg(LTFS_ERR, 14061E, priv->sync_type_str);
 		return 1;
 	}
 
@@ -505,19 +505,19 @@ int validate_sync_option(struct ltfs_fuse_data *priv)
 			errno = 0;
 			priv->sync_time = strtol(sync_time_str, &end_time_str, 10);
 			if (sync_time_str == end_time_str) {
-				ltfsmsg(LTFS_ERR, "14060E", sync_time_str);
+				ltfsmsg(LTFS_ERR, 14060E, sync_time_str);
 				return 1;
 			}
 			if ((priv->sync_time == LONG_MAX || priv->sync_time == LONG_MIN) && errno != 0) {
-				ltfsmsg(LTFS_ERR, "14067E", sync_time_str);
+				ltfsmsg(LTFS_ERR, 14067E, sync_time_str);
 				return 1;
 			}
 			if (priv->sync_time < 0) {
-				ltfsmsg(LTFS_ERR, "14066E");
+				ltfsmsg(LTFS_ERR, 14066E);
 				return 1;
 			}
 			if (priv->sync_time > (LONG_MAX / 60) || priv->sync_time < (LONG_MIN / 60)) {
-				ltfsmsg(LTFS_ERR, "14068E", priv->sync_time);
+				ltfsmsg(LTFS_ERR, 14068E, priv->sync_time);
 				return 1;
 			}
 			priv->sync_time *= 60; /* Convert minutes to seconds*/
@@ -527,7 +527,7 @@ int validate_sync_option(struct ltfs_fuse_data *priv)
 		priv->sync_time = LTFS_SYNC_PERIOD_DEFAULT;
 
 	if (priv->sync_type == LTFS_SYNC_TIME && priv->sync_time == 0) {
-		ltfsmsg(LTFS_INFO, "14062I");
+		ltfsmsg(LTFS_INFO, 14062I);
 		priv->sync_type = LTFS_SYNC_UNMOUNT;
 	}
 
@@ -549,7 +549,7 @@ static int show_device_list(struct ltfs_fuse_data *priv)
 		priv->tape_backend_name = config_file_get_default_plugin("tape", priv->config);
 	ret = plugin_load(&priv->tape_plugin, "tape", priv->tape_backend_name, priv->config);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "14054E", ret);
+		ltfsmsg(LTFS_ERR, 14054E, ret);
 		return 1;
 	}
 
@@ -591,18 +591,18 @@ int main(int argc, char **argv)
 	ret = ltfs_init(LTFS_INFO, true, true);
 	if (ret < 0) {
 		/* Failed to initialize libltfs */
-		ltfsmsg(LTFS_ERR, "10000E", ret);
+		ltfsmsg(LTFS_ERR, 10000E, ret);
 	}
 
 	/* Register messages with libltfs */
 	ret = ltfsprintf_load_plugin("bin_ltfs", bin_ltfs_dat, &message_handle);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10012E", ret);
+		ltfsmsg(LTFS_ERR, 10012E, ret);
 		return 1;
 	}
 
 	if (! priv) {
-		ltfsmsg(LTFS_ERR, "10001E", "main: private data");
+		ltfsmsg(LTFS_ERR, 10001E, "main: private data");
 		return 1;
 	}
 
@@ -610,14 +610,14 @@ int main(int argc, char **argv)
 	priv->first_parsing_pass = true;
 	ret = fuse_opt_parse(&args, priv, ltfs_options_pass1, ltfs_parse_options);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "9001E");
+		ltfsmsg(LTFS_ERR, 9001E);
 		return 1;
 	}
 
 	/* Load the configuration file */
 	ret = config_file_load(priv->config_file, &priv->config);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10008E", ret);
+		ltfsmsg(LTFS_ERR, 10008E, ret);
 		return 1;
 	}
 
@@ -631,7 +631,7 @@ int main(int argc, char **argv)
 			else if (! strncmp(snmp_options[i], "deffile ", 8)) {
 				ret = asprintf(&priv->snmp_deffile, "%s", snmp_options[i]+8);
 				if (ret < 0) {
-					ltfsmsg(LTFS_ERR, "10001E", "library_main: snmp_deffile");
+					ltfsmsg(LTFS_ERR, 10001E, "library_main: snmp_deffile");
 					priv->snmp_enabled = false;
 					break;
 				}
@@ -651,7 +651,7 @@ int main(int argc, char **argv)
 		ret = fuse_opt_insert_arg(&args, i+1, mount_options[i]);
 		if (ret < 0) {
 			/* Could not enable FUSE option */
-			ltfsmsg(LTFS_ERR, "14001E", mount_options[i], ret);
+			ltfsmsg(LTFS_ERR, 14001E, mount_options[i], ret);
 			return 1;
 		}
 		free(mount_options[i]);
@@ -662,7 +662,7 @@ int main(int argc, char **argv)
 	priv->first_parsing_pass = false;
 	ret = fuse_opt_parse(&args, priv, ltfs_options, ltfs_parse_options);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "9001E");
+		ltfsmsg(LTFS_ERR, 9001E);
 		return 1;
 	}
 
@@ -672,8 +672,8 @@ int main(int argc, char **argv)
 	ltfs_set_log_level(priv->verbose % 100);
 
 	/* LTFS starting */
-	ltfsmsg(LTFS_INFO, "14000I", PACKAGE_NAME, PACKAGE_VERSION, priv->verbose);
-	ltfsmsg(LTFS_INFO, "14058I", "LTFS Format Specification", LTFS_INDEX_VERSION_STR);
+	ltfsmsg(LTFS_INFO, 14000I, PACKAGE_NAME, PACKAGE_VERSION, priv->verbose);
+	ltfsmsg(LTFS_INFO, 14058I, "LTFS Format Specification", LTFS_INDEX_VERSION_STR);
 
 	/* Show command line arguments */
 	for (i = 0, cmd_args_len = 0 ; i < argc; i++) {
@@ -682,7 +682,7 @@ int main(int argc, char **argv)
 	cmd_args = calloc(1, cmd_args_len + 1);
 	if (!cmd_args) {
 		/* Memory allocation failed */
-		ltfsmsg(LTFS_ERR, "10001E", "ltfs (arguments)");
+		ltfsmsg(LTFS_ERR, 10001E, "ltfs (arguments)");
 		return -ENOMEM;
 	}
 	strcat(cmd_args, argv[0]);
@@ -690,12 +690,12 @@ int main(int argc, char **argv)
 		strcat(cmd_args, " ");
 		strcat(cmd_args, argv[i]);
 	}
-	ltfsmsg(LTFS_INFO, "14104I", cmd_args);
+	ltfsmsg(LTFS_INFO, 14104I, cmd_args);
 	free(cmd_args);
 
 	/* Show build time information */
-	ltfsmsg(LTFS_INFO, "14105I", BUILD_SYS_FOR);
-	ltfsmsg(LTFS_INFO, "14106I", BUILD_SYS_GCC);
+	ltfsmsg(LTFS_INFO, 14105I, BUILD_SYS_FOR);
+	ltfsmsg(LTFS_INFO, 14106I, BUILD_SYS_GCC);
 
 	/* Show run time information */
 	show_runtime_system_info();
@@ -715,16 +715,16 @@ int main(int argc, char **argv)
 	/* Print the active sync mode */
 	switch(priv->sync_type) {
 		case LTFS_SYNC_TIME:
-			ltfsmsg(LTFS_INFO, "14063I", "time", priv->sync_time);
+			ltfsmsg(LTFS_INFO, 14063I, "time", priv->sync_time);
 			break;
 		case LTFS_SYNC_CLOSE:
-			ltfsmsg(LTFS_INFO, "14064I", "close");
+			ltfsmsg(LTFS_INFO, 14064I, "close");
 			break;
 		case LTFS_SYNC_UNMOUNT:
-			ltfsmsg(LTFS_INFO, "14064I", "unmount");
+			ltfsmsg(LTFS_INFO, 14064I, "unmount");
 			break;
 		default:
-			ltfsmsg(LTFS_ERR, "14065E", priv->sync_type);
+			ltfsmsg(LTFS_ERR, 14065E, priv->sync_type);
 			return 1;
 	}
 
@@ -732,7 +732,7 @@ int main(int argc, char **argv)
 	ret = fuse_opt_add_arg(&args, "-odefault_permissions");
 	if (ret < 0) {
 		/* Could not enable FUSE option */
-		ltfsmsg(LTFS_ERR, "14001E", "default_permissions", ret);
+		ltfsmsg(LTFS_ERR, 14001E, "default_permissions", ret);
 		return 1;
 	}
 
@@ -741,7 +741,7 @@ int main(int argc, char **argv)
 		ret = fuse_opt_add_arg(&args, "-oallow_other");
 		if (ret < 0) {
 			/* Could not enable FUSE option */
-			ltfsmsg(LTFS_ERR, "14001E", "allow_other", ret);
+			ltfsmsg(LTFS_ERR, 14001E, "allow_other", ret);
 			return 1;
 		}
 	}
@@ -750,7 +750,7 @@ int main(int argc, char **argv)
 	ret = fuse_opt_add_arg(&args, "-ohard_remove");
 	if (ret < 0) {
 		/* Could not enable FUSE option */
-		ltfsmsg(LTFS_ERR, "14001E", "hard_remove", ret);
+		ltfsmsg(LTFS_ERR, 14001E, "hard_remove", ret);
 		return 1;
 	}
 
@@ -758,7 +758,7 @@ int main(int argc, char **argv)
 	ret = fuse_opt_add_arg(&args, "-osync_read");
 	if (ret < 0) {
 		/* Could not enable FUSE option */
-		ltfsmsg(LTFS_ERR, "14001E", "sync_read", ret);
+		ltfsmsg(LTFS_ERR, 14001E, "sync_read", ret);
 		return 1;
 	}
 
@@ -771,7 +771,7 @@ int main(int argc, char **argv)
 	fuse_opt_add_arg(&args, "-odaemon_timeout=3100");
 	if (ret < 0) {
 		/* Could not enable FUSE option */
-		ltfsmsg(LTFS_ERR, "14001E", "daemon_timeout", ret);
+		ltfsmsg(LTFS_ERR, 14001E, "daemon_timeout", ret);
 		return 1;
 	}
 	/*
@@ -782,7 +782,7 @@ int main(int argc, char **argv)
 	fuse_opt_add_arg(&args, "-onovncache");
 	if (ret < 0) {
 		/* Could not enable FUSE option */
-		ltfsmsg(LTFS_ERR, "14001E", "novncache", ret);
+		ltfsmsg(LTFS_ERR, 14001E, "novncache", ret);
 		return 1;
 	}
 #endif
@@ -792,7 +792,7 @@ int main(int argc, char **argv)
 	ret = fuse_opt_add_arg(&args, "-obig_writes");
 	if (ret < 0) {
 		/* Could not enable FUSE option */
-		ltfsmsg(LTFS_ERR, "14001E", "big_writes", ret);
+		ltfsmsg(LTFS_ERR, 14001E, "big_writes", ret);
 		return 1;
 	}
 #endif
@@ -801,7 +801,7 @@ int main(int argc, char **argv)
 	ret = permissions_setup(priv);
 	if (ret < 0) {
 		/* Failed to set up permissions */
-		ltfsmsg(LTFS_ERR, "14002E", ret);
+		ltfsmsg(LTFS_ERR, 14002E, ret);
 		usage(argv[0], priv);
 		return 1;
 	}
@@ -811,7 +811,7 @@ int main(int argc, char **argv)
 		priv->tape_backend_name = config_file_get_default_plugin("tape", priv->config);
 		if (priv->tape_backend_name == NULL) {
 			/* No driver plugin configured and no default found */
-			ltfsmsg(LTFS_ERR, "14056E");
+			ltfsmsg(LTFS_ERR, 14056E);
 			return 1;
 		}
 	}
@@ -828,7 +828,7 @@ int main(int argc, char **argv)
 	if (priv->force_min_pool) {
 		priv->min_pool_size = parse_size_t(priv->force_min_pool);
 		if (priv->min_pool_size == 0) {
-			ltfsmsg(LTFS_ERR, "14109E");
+			ltfsmsg(LTFS_ERR, 14109E);
 			return 1;
 		}
 	} else
@@ -836,14 +836,14 @@ int main(int argc, char **argv)
 	if (priv->force_max_pool) {
 		priv->max_pool_size = parse_size_t(priv->force_max_pool);
 		if (priv->max_pool_size == 0) {
-			ltfsmsg(LTFS_ERR, "14110E");
+			ltfsmsg(LTFS_ERR, 14110E);
 			return 1;
 		}
 	} else
 		priv->max_pool_size = LTFS_MAX_CACHE_SIZE_DEFAULT;
 	if (priv->min_pool_size > priv->max_pool_size) {
 		/* Min pool size cannot be greater than max pool size */
-		ltfsmsg(LTFS_ERR, "14003E", priv->min_pool_size, priv->max_pool_size);
+		ltfsmsg(LTFS_ERR, 14003E, (int)priv->min_pool_size, (int)priv->max_pool_size);
 		return 1;
 	}
 
@@ -855,14 +855,14 @@ int main(int argc, char **argv)
 	/* Load plugins */
 	ret = plugin_load(&priv->tape_plugin, "tape", priv->tape_backend_name, priv->config);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "14054E", ret);
+		ltfsmsg(LTFS_ERR, 14054E, ret);
 		return 1;
 	}
 	if (priv->iosched_backend_name) {
 		ret = plugin_load(&priv->iosched_plugin, "iosched", priv->iosched_backend_name,
 			priv->config);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "14055E", ret);
+			ltfsmsg(LTFS_ERR, 14055E, ret);
 			return 1;
 		}
 	}
@@ -870,7 +870,7 @@ int main(int argc, char **argv)
 		ret = plugin_load(&priv->kmi_plugin, "kmi", priv->kmi_backend_name,
 			priv->config);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "14057E", ret);
+			ltfsmsg(LTFS_ERR, 14057E, ret);
 			return 1;
 		}
 	}
@@ -880,7 +880,7 @@ int main(int argc, char **argv)
 		priv->devname = ltfs_default_device_name(priv->tape_plugin.ops);
 		if (! priv->devname) {
 			/* The backend \'%s\' does not have a default device */
-			ltfsmsg(LTFS_ERR, "14009E", priv->tape_backend_name);
+			ltfsmsg(LTFS_ERR, 14009E, priv->tape_backend_name);
 			return 1;
 		}
 	}
@@ -894,7 +894,7 @@ int main(int argc, char **argv)
 	ret = ltfs_mutex_init(&priv->file_table_lock);
 	if (ret) {
 		/*  Cannot initialize open file table */
-		ltfsmsg(LTFS_ERR, "14114E");
+		ltfsmsg(LTFS_ERR, 14114E);
 		return 1;
 	}
 	ret = single_drive_main(&args, priv);
@@ -937,7 +937,7 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 	/*  Setup signal handler to terminate cleanly */
 	ret = ltfs_set_signal_handlers();
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10013E");
+		ltfsmsg(LTFS_ERR, 10013E);
 		return 1;
 	}
 
@@ -946,7 +946,7 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 		errno = 0;
 		priv->rollback_gen = strtoul(priv->rollback_str, &invalid_start, 0);
 		if( (*invalid_start != '\0') || priv->rollback_gen == 0 ) {
-			ltfsmsg(LTFS_ERR, "14091E", priv->rollback_str);
+			ltfsmsg(LTFS_ERR, 14091E, priv->rollback_str);
 			return 1;
 		}
 	}
@@ -958,7 +958,7 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 		else if (strcasecmp(priv->str_append_only_mode, "off") == 0)
 			priv->append_only_mode = 0;
 		else {
-			ltfsmsg(LTFS_ERR, "14115E", priv->str_append_only_mode);
+			ltfsmsg(LTFS_ERR, 14115E, priv->str_append_only_mode);
 			return 1;
 		}
 	} else
@@ -968,7 +968,7 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 		/* Append only mode need to eject a cartridge at unmount to clear the mode on drive setting */
 		/* To avoid cartridge ejection at unmount, disable append only mode at the moount with noeject option */
 		priv->append_only_mode = 0;
-		ltfsmsg(LTFS_INFO, "14095I");
+		ltfsmsg(LTFS_INFO, 14095I);
 	}
 
 	/* If the local inode space is big enough, have FUSE pass through our UIDs as inode
@@ -977,7 +977,7 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 		ret = fuse_opt_add_arg(args, "-ouse_ino");
 		if (ret < 0) {
 			/* Could not enable FUSE option */
-			ltfsmsg(LTFS_ERR, "14001E", "use_ino", ret);
+			ltfsmsg(LTFS_ERR, 14001E, "use_ino", ret);
 			return 1;
 		}
 	}
@@ -987,14 +987,14 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 	ret = fuse_opt_add_arg(args, fsname);
 	if (ret < 0) {
 		/* Could not enable FUSE option */
-		ltfsmsg(LTFS_ERR, "14001E", "fsname", ret);
+		ltfsmsg(LTFS_ERR, 14001E, "fsname", ret);
 		return 1;
 	}
 
 	/* Allocate the LTFS volume structure */
 	if (ltfs_volume_alloc("ltfs", &priv->data) < 0) {
 		/* Could not allocate LTFS volume structure */
-		ltfsmsg(LTFS_ERR, "14011E");
+		ltfsmsg(LTFS_ERR, 14011E);
 		return 1;
 	}
 	ltfs_use_atime(priv->atime, priv->data);
@@ -1002,7 +1002,7 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 
 	if (ltfs_device_open(priv->devname, priv->tape_plugin.ops, priv->data) < 0) {
 		/* Could not open device */
-		ltfsmsg(LTFS_ERR, "10004E", priv->devname);
+		ltfsmsg(LTFS_ERR, 10004E, priv->devname);
 		ltfs_volume_free(&priv->data);
 		return 1;
 	}
@@ -1017,7 +1017,7 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 	/* Parse backend options */
 	if (ltfs_parse_tape_backend_opts(args, priv->data)) {
 		/* Backend option parsing failed */
-		ltfsmsg(LTFS_ERR, "14012E");
+		ltfsmsg(LTFS_ERR, 14012E);
 		ltfs_volume_free(&priv->data);
 		return 1;
 	}
@@ -1025,14 +1025,14 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 	if (priv->kmi_backend_name) {
 		if (kmi_init(&priv->kmi_plugin, priv->data) < 0) {
 			/* Encryption function disabled. */
-			ltfsmsg(LTFS_ERR, "14089E");
+			ltfsmsg(LTFS_ERR, 14089E);
 			ltfs_volume_free(&priv->data);
 			return 1;
 		}
 
 		if (ltfs_parse_kmi_backend_opts(args, priv->data)) {
 			/* Backend option parsing failed */
-			ltfsmsg(LTFS_ERR, "14090E");
+			ltfsmsg(LTFS_ERR, 14090E);
 			ltfs_volume_free(&priv->data);
 			return 1;
 		}
@@ -1045,22 +1045,22 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 	ltfs_load_tape(priv->data);
 	ret = ltfs_wait_device_ready(priv->data);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "14075E");
+		ltfsmsg(LTFS_ERR, 14075E);
 		ltfs_volume_free(&priv->data);
 		return 1;
 	}
 
 	priv->data->append_only_mode = (bool)priv->append_only_mode;
 	if (ltfs_setup_device(priv->data)) {
-		ltfsmsg(LTFS_ERR, "14075E");
+		ltfsmsg(LTFS_ERR, 14075E);
 		ltfs_volume_free(&priv->data);
 		return 1;
 	}
 
 	/* Check EOD validation is skipped or not */
 	if (priv->skip_eod_check) {
-		ltfsmsg(LTFS_INFO, "14076I");
-		ltfsmsg(LTFS_INFO, "14077I");
+		ltfsmsg(LTFS_INFO, 14076I);
+		ltfsmsg(LTFS_INFO, 14077I);
 		ltfs_set_eod_check(! priv->skip_eod_check, priv->data);
 	}
 
@@ -1072,23 +1072,23 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 		else if (strcasecmp(priv->symlink_str, "posix") == 0)
 			priv->data->livelink = false;
 		else {
-			ltfsmsg(LTFS_ERR, "14093E", priv->symlink_str);
+			ltfsmsg(LTFS_ERR, 14093E, priv->symlink_str);
 			return 1;
 		}
-		ltfsmsg(LTFS_INFO, "14092I", priv->symlink_str);
+		ltfsmsg(LTFS_INFO, 14092I, priv->symlink_str);
 	}
 
 	/* Mount the volume */
 	ltfs_set_traverse_mode(TRAVERSE_BACKWARD, priv->data);
 	if (ltfs_mount(false, false, false, false, priv->rollback_gen, priv->data) < 0) {
-		ltfsmsg(LTFS_ERR, "14013E");
+		ltfsmsg(LTFS_ERR, 14013E);
 		ltfs_volume_free(&priv->data);
 		return 1;
 	}
 
 	ret = tape_get_worm_status(priv->data->device, &is_worm);
 	if (ret != 0 || is_worm) {
-		ltfsmsg(LTFS_ERR, "14116E", ret);
+		ltfsmsg(LTFS_ERR, 14116E, ret);
 		ltfs_volume_free(&priv->data);
 		return 1;
 	}
@@ -1098,7 +1098,7 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 		ret = pathname_format(priv->index_rules, &index_rules_utf8, false, false);
 		if (ret < 0) {
 			/* Could not format data placement rules. */
-			ltfsmsg(LTFS_ERR, "14016E", ret);
+			ltfsmsg(LTFS_ERR, 14016E, ret);
 			ltfs_volume_free(&priv->data);
 			return 1;
 		}
@@ -1106,10 +1106,10 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 		free(index_rules_utf8);
 		if (ret == -LTFS_POLICY_IMMUTABLE) {
 			/* Volume doesn't allow override. Ignoring user-specified criteria. */
-			ltfsmsg(LTFS_WARN, "14015W");
+			ltfsmsg(LTFS_WARN, 14015W);
 		} else if (ret < 0) {
 			/* Could not parse data placement rules */
-			ltfsmsg(LTFS_ERR, "14017E", ret);
+			ltfsmsg(LTFS_ERR, 14017E, ret);
 			ltfs_volume_free(&priv->data);
 			return 1;
 		}
@@ -1123,7 +1123,7 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 	if (ret < 0 && ret != -LTFS_WRITE_PROTECT && ret != -LTFS_WRITE_ERROR && ret != -LTFS_NO_SPACE &&
 		ret != -LTFS_LESS_SPACE) { /* No other errors are expected. */
 		/* Could not get read-only status of medium */
-		ltfsmsg(LTFS_ERR, "14018E");
+		ltfsmsg(LTFS_ERR, 14018E);
 		ltfs_volume_free(&priv->data);
 		return 1;
 	} else if (ret == -LTFS_WRITE_PROTECT || ret == -LTFS_WRITE_ERROR || ret == -LTFS_NO_SPACE || ret == -LTFS_LESS_SPACE || priv->rollback_gen != 0) {
@@ -1131,23 +1131,23 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 			ret = ltfs_get_partition_readonly(ltfs_ip_id(priv->data), priv->data);
 			if (ret == -LTFS_WRITE_PROTECT || ret == -LTFS_WRITE_ERROR) {
 				/* The tape is really write protected */
-				ltfsmsg(LTFS_INFO, "14019I");
+				ltfsmsg(LTFS_INFO, 14019I);
 			} else if (ret == -LTFS_NO_SPACE) {
 				/* The index partition is in early warning zone. To be mounted read-only */
-				ltfsmsg(LTFS_INFO, "14073I");
+				ltfsmsg(LTFS_INFO, 14073I);
 			} else { /* 0 or -LTFS_LESS_SPACE */
 				/* The data partition may be in early warning zone. To be mounted read-only */
-				ltfsmsg(LTFS_INFO, "14074I");
+				ltfsmsg(LTFS_INFO, 14074I);
 			}
 		} else if (ret == -LTFS_LESS_SPACE)
-			ltfsmsg(LTFS_INFO, "14071I");
+			ltfsmsg(LTFS_INFO, 14071I);
 		else
-			ltfsmsg(LTFS_INFO, "14072I", priv->rollback_gen);
+			ltfsmsg(LTFS_INFO, 14072I, priv->rollback_gen);
 
 		ret = fuse_opt_add_arg(args, "-oro");
 		if (ret < 0) {
 			/* Could not set FUSE option */
-			ltfsmsg(LTFS_ERR, "14001E", "ro", ret);
+			ltfsmsg(LTFS_ERR, 14001E, "ro", ret);
 			ltfs_volume_free(&priv->data);
 			return 1;
 		}
@@ -1156,7 +1156,7 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 	/*  Cleanup signal handler */
 	ret = ltfs_unset_signal_handlers();
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10014E");
+		ltfsmsg(LTFS_ERR, 10014E);
 		return 1;
 	}
 
@@ -1168,7 +1168,7 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 		ret = asprintf(&opt_volname, "-ovolname=%s(%s)", priv->data->index->volume_name.name, "ltfs");
 		if (ret < 0) {
 			/* Memory allocation failed */
-			ltfsmsg(LTFS_ERR, "10001E", "option string for volume name");
+			ltfsmsg(LTFS_ERR, 10001E, "option string for volume name");
 			ltfs_volume_free(&priv->data);
 			return 1;
 		}
@@ -1176,7 +1176,7 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 		ret = fuse_opt_add_arg(args, opt_volname);
 		if (ret < 0) {
 			/* Could not set FUSE option */
-			ltfsmsg(LTFS_ERR, "14001E", "volname", ret);
+			ltfsmsg(LTFS_ERR, 14001E, "volname", ret);
 			ltfs_volume_free(&priv->data);
 			free(opt_volname);
 			return 1;
@@ -1191,7 +1191,7 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 	ret = fuse_parse_cmdline( &tmpa, &mountpoint, NULL, NULL);
 	fuse_opt_free_args(&tmpa);
 	if (ret < 0 || mountpoint == NULL) {
-		ltfsmsg(LTFS_ERR, "14094E", ret);
+		ltfsmsg(LTFS_ERR, 14094E, ret);
 		ltfs_volume_free(&priv->data);
 		return 1;
 	}
@@ -1203,15 +1203,15 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 		send_ltfsStartTrap();
 
 	/* now we can safely call FUSE */
-	ltfsmsg(LTFS_INFO, "14111I");
-	ltfsmsg(LTFS_INFO, "14112I");
-	ltfsmsg(LTFS_INFO, "14113I");
+	ltfsmsg(LTFS_INFO, 14111I);
+	ltfsmsg(LTFS_INFO, 14112I);
+	ltfsmsg(LTFS_INFO, 14113I);
 	ret = fuse_main(args->argc, args->argv, &ltfs_ops, priv);
 
 	/*  Setup signal handler again to terminate cleanly */
 	ret = ltfs_set_signal_handlers();
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10013E");
+		ltfsmsg(LTFS_ERR, 10013E);
 		return 1;
 	}
 

--- a/src/tape_drivers/crc32c_crc.c
+++ b/src/tape_drivers/crc32c_crc.c
@@ -272,7 +272,7 @@ void *memcpy_crc32c_enc(void *dest, const void *src, size_t n)
 	*dest_cur++ = (reg >> 8) & 0xff;
 	*dest_cur++ = (reg >> 16) & 0xff;
 	*dest_cur++ = (reg >> 24) & 0xff;
-	ltfsmsg(LTFS_DEBUG, "39804D", "encode", n, reg);
+	ltfsmsg(LTFS_DEBUG, 39804D, "encode", (int)n, reg);
 
 	return dest;
 }
@@ -289,7 +289,7 @@ void crc32c_enc(void *buf, size_t n)
 	*reg_cur++ = (reg >> 8) & 0xff;
 	*reg_cur++ = (reg >> 16) & 0xff;
 	*reg_cur++ = (reg >> 24) & 0xff;
-	ltfsmsg(LTFS_DEBUG, "39804D", "encode", n, reg);
+	ltfsmsg(LTFS_DEBUG, 39804D, "encode", (int)n, reg);
 
 	return;
 }
@@ -307,10 +307,10 @@ int memcpy_crc32c_check(void *dest, const void *src, size_t n)
 	crc |= *src_cur++ << 24;
 
 	if (crc != reg) {
-		ltfsmsg(LTFS_ERR, "39803E", n, reg, crc);
+		ltfsmsg(LTFS_ERR, 39803E, (int)n, reg, crc);
 		return -1;
 	}
-	ltfsmsg(LTFS_DEBUG, "39804D", "check", n, crc);
+	ltfsmsg(LTFS_DEBUG, 39804D, "check", (int)n, crc);
 
 	return n;
 }
@@ -328,10 +328,10 @@ int crc32c_check(void *buf, size_t n)
 	crc |= *buf_cur++ << 24;
 
 	if (crc != reg) {
-		ltfsmsg(LTFS_ERR, "39803E", n, reg, crc);
+		ltfsmsg(LTFS_ERR, 39803E, (int)n, reg, crc);
 		return -1;
 	}
-	ltfsmsg(LTFS_DEBUG, "39804D", "check", n, crc);
+	ltfsmsg(LTFS_DEBUG, 39804D, "check", (int)n, crc);
 
 	return n;
 }

--- a/src/tape_drivers/generic/file/filedebug_conf_tc.c
+++ b/src/tape_drivers/generic/file/filedebug_conf_tc.c
@@ -80,7 +80,7 @@ static int _filedebug_tc_write_schema(xmlTextWriterPtr writer, const struct file
 	/* Create XML document */
 	ret = xmlTextWriterStartDocument(writer, NULL, "UTF-8", NULL);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "30150E", ret);
+		ltfsmsg(LTFS_ERR, 30150E, ret);
 		return -1;
 	}
 
@@ -151,7 +151,7 @@ static int _filedebug_tc_write_schema(xmlTextWriterPtr writer, const struct file
 
 	ret = xmlTextWriterEndDocument(writer);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "30151E", ret);
+		ltfsmsg(LTFS_ERR, 30151E, ret);
 		return -1;
 	}
 
@@ -166,15 +166,15 @@ int filedebug_conf_tc_write_xml(char *filename, const struct filedebug_conf_tc *
 	/* Create XML writer. */
 	writer = xmlNewTextWriterFilename(filename, 0);
 	if (! writer) {
-		ltfsmsg(LTFS_ERR, "30152E");
+		ltfsmsg(LTFS_ERR, 30152E);
 		return -1;
 	}
 
 	ret = _filedebug_tc_write_schema(writer, conf);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "30153E");
+		ltfsmsg(LTFS_ERR, 30153E);
 	} else if (ret == 0) {
-		ltfsmsg(LTFS_WARN, "30154W");
+		ltfsmsg(LTFS_WARN, 30154W);
 		ret = -1;
 	}
 
@@ -191,14 +191,14 @@ static int _filedebug_parser_init(xmlTextReaderPtr reader, const char *top_name)
 	if (xml_next_tag(reader, "", &name, &type) < 0)
 		return -1;
 	if (strcmp(name, top_name)) {
-		ltfsmsg(LTFS_ERR, "30155E", name);
+		ltfsmsg(LTFS_ERR, 30155E, name);
 		return -1;
 	}
 
 	/* reject this XML file if it isn't UTF-8 */
 	encoding = (const char *)xmlTextReaderConstEncoding(reader);
 	if (! encoding || strcmp(encoding, "UTF-8")) {
-		ltfsmsg(LTFS_ERR, "30156E", encoding);
+		ltfsmsg(LTFS_ERR, 30156E, encoding);
 		return -1;
 	}
 
@@ -347,7 +347,7 @@ int filedebug_conf_tc_read_xml(char *filename, struct filedebug_conf_tc *conf)
 
 	reader = xmlReaderForFile(filename, NULL, XML_PARSE_NOERROR | XML_PARSE_NOWARNING);
 	if (! reader) {
-		ltfsmsg(LTFS_ERR, "30157E");
+		ltfsmsg(LTFS_ERR, 30157E);
 		return -1;
 	}
 
@@ -357,7 +357,7 @@ int filedebug_conf_tc_read_xml(char *filename, struct filedebug_conf_tc *conf)
 	doc = xmlTextReaderCurrentDoc(reader);
 	ret = _filedebug_tc_parse_schema(reader, conf);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "30158E");
+		ltfsmsg(LTFS_ERR, 30158E);
 	}
 	if (doc)
 		xmlFreeDoc(doc);

--- a/src/tape_drivers/generic/file/filedebug_tc.c
+++ b/src/tape_drivers/generic/file/filedebug_tc.c
@@ -366,7 +366,7 @@ static void emulate_rewind_wait(struct filedebug_data *state)
 
 void filedebug_help_message(void)
 {
-	ltfsresult("30199I", filedebug_default_device);
+	ltfsresult(30199I, filedebug_default_device);
 }
 
 int filedebug_open(const char *name, void **handle)
@@ -378,14 +378,14 @@ int filedebug_open(const char *name, void **handle)
 	char *pid = NULL, *ser = NULL;
 	int ret, i;
 
-	ltfsmsg(LTFS_INFO, "30000I", name);
+	ltfsmsg(LTFS_INFO, 30000I, name);
 
 	CHECK_ARG_NULL(handle, -LTFS_NULL_ARG);
 	*handle = NULL;
 
 	state = (struct filedebug_data *)calloc(1,sizeof(struct filedebug_data));
 	if (!state) {
-		ltfsmsg(LTFS_ERR, "10001E", "filedebug_open: private data");
+		ltfsmsg(LTFS_ERR, 10001E, "filedebug_open: private data");
 		return -EDEV_NO_MEMORY;
 	}
 
@@ -393,10 +393,10 @@ int filedebug_open(const char *name, void **handle)
 	ret = stat(name, &d);
 	if (ret == 0 && S_ISREG(d.st_mode)) {
 		/* Run on file mode */
-		ltfsmsg(LTFS_INFO, "30001I", name);
+		ltfsmsg(LTFS_INFO, 30001I, name);
 		state->fd = open(name, O_RDWR | O_BINARY);
 		if (state->fd < 0) {
-			ltfsmsg(LTFS_ERR, "30002E", name);
+			ltfsmsg(LTFS_ERR, 30002E, name);
 			return -EDEV_INTERNAL_ERROR;
 		}
 
@@ -416,7 +416,7 @@ int filedebug_open(const char *name, void **handle)
 		if (pid && ser) {
 			ret = asprintf(&state->serial_number, "%s", ser);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "10001E", "filedebug_open: serial & pid");
+				ltfsmsg(LTFS_ERR, 10001E, "filedebug_open: serial & pid");
 				free(state);
 				return -EDEV_NO_MEMORY;
 			}
@@ -433,7 +433,7 @@ int filedebug_open(const char *name, void **handle)
 		/* Store directory base */
 		tmp = strdup(name);
 		if (!tmp) {
-			ltfsmsg(LTFS_ERR, "10001E", "filedebug_open: dirbase");
+			ltfsmsg(LTFS_ERR, 10001E, "filedebug_open: dirbase");
 			free(state);
 			return -EDEV_NO_MEMORY;
 		}
@@ -443,7 +443,7 @@ int filedebug_open(const char *name, void **handle)
 		p = dirname(tmp);
 		state->dirbase = (char *) calloc(strlen(p) + 1, sizeof(char));
 		if (!state->dirbase) {
-			ltfsmsg(LTFS_ERR, "10001E", "filedebug_open: dirbase");
+			ltfsmsg(LTFS_ERR, 10001E, "filedebug_open: dirbase");
 			free(state);
 			free(tmp);
 			return -EDEV_NO_MEMORY;
@@ -452,16 +452,16 @@ int filedebug_open(const char *name, void **handle)
 		free(tmp);
 	} else {
 		/* make sure directory exists */
-		ltfsmsg(LTFS_INFO, "30003I", name);
+		ltfsmsg(LTFS_INFO, 30003I, name);
 		if (ret || !S_ISDIR(d.st_mode)) {
-			ltfsmsg(LTFS_ERR, "30004E", name);
+			ltfsmsg(LTFS_ERR, 30004E, name);
 			free(state);
 			return -LTFS_INVALID_SRC_PATH;
 		}
 
 		state->dirname = strdup(name);
 		if (!state->dirname) {
-			ltfsmsg(LTFS_ERR, "10001E", "filedebug_open: dirname");
+			ltfsmsg(LTFS_ERR, 10001E, "filedebug_open: dirname");
 			free(state);
 			return -EDEV_NO_MEMORY;
 		}
@@ -579,12 +579,12 @@ int filedebug_read(void *device, char *buf, size_t count, struct tc_position *po
 	ssize_t bytes_read;
 	int fd;
 
-	ltfsmsg(LTFS_DEBUG, "30005D", count, state->current_position.partition,
+	ltfsmsg(LTFS_DEBUG, 30005D, (unsigned int)count, state->current_position.partition,
 		(unsigned long long)state->current_position.block,
 		(unsigned long long)state->current_position.filemarks);
 
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "30006E");
+		ltfsmsg(LTFS_ERR, 30006E);
 		return -EDEV_NOT_READY;
 	}
 
@@ -597,7 +597,7 @@ int filedebug_read(void *device, char *buf, size_t count, struct tc_position *po
 	if (state->force_readperm) {
 		state->read_counter++;
 		if (state->read_counter > state->force_readperm) {
-			ltfsmsg(LTFS_ERR, "30007E", "read");
+			ltfsmsg(LTFS_ERR, 30007E, "read");
 			if (state->force_errortype)
 				return -EDEV_READ_PERM;
 			else
@@ -635,7 +635,7 @@ int filedebug_read(void *device, char *buf, size_t count, struct tc_position *po
 			return ret;
 		}
 		if (ret > 0) {
-			ltfsmsg(LTFS_ERR, "30008E");
+			ltfsmsg(LTFS_ERR, 30008E);
 			free(fname);
 			return -EDEV_EOD_NOT_FOUND;
 		}
@@ -644,7 +644,7 @@ int filedebug_read(void *device, char *buf, size_t count, struct tc_position *po
 		fname[fname_len - 1] = rec_suffixes[SUFFIX_FILEMARK];
 		ret = _filedebug_check_file(fname);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "30009E", ret);
+			ltfsmsg(LTFS_ERR, 30009E, ret);
 			free(fname);
 			return ret;
 		}
@@ -661,7 +661,7 @@ int filedebug_read(void *device, char *buf, size_t count, struct tc_position *po
 		fname[fname_len - 1] = rec_suffixes[SUFFIX_RECORD];
 		ret = _filedebug_check_file(fname);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "30010E", ret);
+			ltfsmsg(LTFS_ERR, 30010E, ret);
 			free(fname);
 			return ret;
 		}
@@ -669,33 +669,33 @@ int filedebug_read(void *device, char *buf, size_t count, struct tc_position *po
 			fd = open(fname, O_RDONLY | O_BINARY);
 			free(fname);
 			if (fd < 0) {
-				ltfsmsg(LTFS_ERR, "30011E", errno);
+				ltfsmsg(LTFS_ERR, 30011E, errno);
 				return -EDEV_RW_PERM;
 			}
 
 			/* TODO: return -EDEV_INVALID_ARG if buffer is too small to hold complete record? */
 			bytes_read = read(fd, buf, count);
 			if (bytes_read < 0) {
-				ltfsmsg(LTFS_ERR, "30012E", errno);
+				ltfsmsg(LTFS_ERR, 30012E, errno);
 				close(fd);
 				return -EDEV_RW_PERM;
 			}
 
 			ret = close(fd);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "30013E", errno);
+				ltfsmsg(LTFS_ERR, 30013E, errno);
 				return -EDEV_RW_PERM;
 			}
 
 			++state->current_position.block;
 			pos->block = state->current_position.block;
 
-			ltfsmsg(LTFS_DEBUG, "30014D", bytes_read);
+			ltfsmsg(LTFS_DEBUG, 30014D, bytes_read);
 			return bytes_read;
 		}
 
 		/* couldn't find any records?! something is corrupted */
-		ltfsmsg(LTFS_ERR, "30015E");
+		ltfsmsg(LTFS_ERR, 30015E);
 		free(fname);
 	}
 
@@ -710,12 +710,12 @@ int filedebug_write(void *device, const char *buf, size_t count, struct tc_posit
 	int fd;
 	ssize_t written;
 
-	ltfsmsg(LTFS_DEBUG, "30016D", count, state->current_position.partition,
+	ltfsmsg(LTFS_DEBUG, 30016D, (unsigned int)count, state->current_position.partition,
 		(unsigned long long)state->current_position.block,
 		(unsigned long long)state->current_position.filemarks);
 
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "30017E");
+		ltfsmsg(LTFS_ERR, 30017E);
 		ret = -EDEV_NOT_READY;
 		return ret;
 	}
@@ -733,7 +733,7 @@ int filedebug_write(void *device, const char *buf, size_t count, struct tc_posit
 		else
 			ret = -EDEV_DATA_PROTECT;    /* Emulate 07/3005 */
 
-		ltfsmsg(LTFS_INFO, "30085I", ret, state->serial_number);
+		ltfsmsg(LTFS_INFO, 30085I, ret, state->serial_number);
 
 		return ret;
 	}
@@ -747,7 +747,7 @@ int filedebug_write(void *device, const char *buf, size_t count, struct tc_posit
 	/* TODO: It is nicer if we have a append only mode support */
 
 	if (! buf && count > 0) {
-		ltfsmsg(LTFS_ERR, "30018E");
+		ltfsmsg(LTFS_ERR, 30018E);
 		ret = -EDEV_INVALID_ARG;
 		return ret;
 	} else if (count == 0) {
@@ -758,20 +758,20 @@ int filedebug_write(void *device, const char *buf, size_t count, struct tc_posit
 	if ( state->force_writeperm ) {
 		state->write_counter++;
 		if ( state->write_counter > state->force_writeperm ) {
-			ltfsmsg(LTFS_ERR, "30007E", "write");
+			ltfsmsg(LTFS_ERR, 30007E, "write");
 			if (state->force_errortype)
 				return -EDEV_NO_SENSE;
 			else
 				return -EDEV_WRITE_PERM;
 		} else if ( state->write_counter > (state->force_writeperm - THREASHOLD_FORCE_WRITE_NO_WRITE) ) {
-			ltfsmsg(LTFS_INFO, "30019I");
+			ltfsmsg(LTFS_INFO, 30019I);
 			pos->block++;
 			return DEVICE_GOOD;
 		}
 	}
 
 	if (count > (size_t)state->max_block_size) {
-		ltfsmsg(LTFS_ERR, "30020E", count, (size_t)state->max_block_size);
+		ltfsmsg(LTFS_ERR, 30020E, (unsigned int)count, state->max_block_size);
 		ret = -EDEV_INVALID_ARG;
 		return ret;
 	}
@@ -794,7 +794,7 @@ int filedebug_write(void *device, const char *buf, size_t count, struct tc_posit
 		/* clean up old records at this position */
 		ret = _filedebug_remove_current_record(state);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "30021E", ret);
+			ltfsmsg(LTFS_ERR, 30021E, ret);
 			return ret;
 		}
 
@@ -802,7 +802,7 @@ int filedebug_write(void *device, const char *buf, size_t count, struct tc_posit
 		if(state->write_pass_prev == state->write_pass){
 			ret = _set_wp(device, ++(state->write_pass));
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "30022E", ret);
+				ltfsmsg(LTFS_ERR, 30022E, ret);
 				return ret;
 			}
 		}
@@ -810,7 +810,7 @@ int filedebug_write(void *device, const char *buf, size_t count, struct tc_posit
 		/* create the file */
 		fname = _filedebug_make_current_filename(state, rec_suffixes[SUFFIX_RECORD]);
 		if (!fname) {
-			ltfsmsg(LTFS_ERR, "30023E");
+			ltfsmsg(LTFS_ERR, 30023E);
 			ret = -EDEV_NO_MEMORY;
 			return ret;
 		}
@@ -818,7 +818,7 @@ int filedebug_write(void *device, const char *buf, size_t count, struct tc_posit
 				  O_WRONLY | O_CREAT | O_TRUNC | O_BINARY,
 				  S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH);
 		if (fd < 0) {
-			ltfsmsg(LTFS_ERR, "30024E", fname, errno);
+			ltfsmsg(LTFS_ERR, 30024E, fname, errno);
 			free(fname);
 			return -EDEV_RW_PERM;
 		}
@@ -827,13 +827,13 @@ int filedebug_write(void *device, const char *buf, size_t count, struct tc_posit
 		/* write and close the file */
 		written = write(fd, buf, count);
 		if (written < 0) {
-			ltfsmsg(LTFS_ERR, "30025E", errno);
+			ltfsmsg(LTFS_ERR, 30025E, errno);
 			close(fd);
 			return -EDEV_RW_PERM;
 		}
 		ret = close(fd);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "30026E", errno);
+			ltfsmsg(LTFS_ERR, 30026E, errno);
 			return -EDEV_RW_PERM;
 		}
 
@@ -843,7 +843,7 @@ int filedebug_write(void *device, const char *buf, size_t count, struct tc_posit
 
 		ret = _filedebug_write_eod(state);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "30027E", ret);
+			ltfsmsg(LTFS_ERR, 30027E, ret);
 			return ret;
 		}
 	}
@@ -874,12 +874,12 @@ int filedebug_writefm(void *device, size_t count, struct tc_position *pos, bool 
 	int fd;
 	size_t i;
 
-	ltfsmsg(LTFS_DEBUG, "30028D", count, state->current_position.partition,
+	ltfsmsg(LTFS_DEBUG, 30028D, (unsigned int)count, state->current_position.partition,
 		(unsigned long long)state->current_position.block,
 		(unsigned long long)state->current_position.filemarks);
 
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "30029E");
+		ltfsmsg(LTFS_ERR, 30029E);
 		ret = -EDEV_NOT_READY;
 		return ret;
 	}
@@ -912,7 +912,7 @@ int filedebug_writefm(void *device, size_t count, struct tc_position *pos, bool 
 		if(state->write_pass_prev == state->write_pass){
 			ret = _set_wp(device, ++(state->write_pass));
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "30030E", ret);
+				ltfsmsg(LTFS_ERR, 30030E, ret);
 				return ret;
 			}
 		}
@@ -920,13 +920,13 @@ int filedebug_writefm(void *device, size_t count, struct tc_position *pos, bool 
 		for (i=0; i<count; ++i) {
 			ret = _filedebug_remove_current_record(state);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "30031E", ret);
+				ltfsmsg(LTFS_ERR, 30031E, ret);
 				return ret;
 			}
 
 			fname = _filedebug_make_current_filename(state, rec_suffixes[SUFFIX_FILEMARK]);
 			if (!fname) {
-				ltfsmsg(LTFS_ERR, "30032E");
+				ltfsmsg(LTFS_ERR, 30032E);
 				ret = -EDEV_NO_MEMORY;
 				return ret;
 			}
@@ -935,7 +935,7 @@ int filedebug_writefm(void *device, size_t count, struct tc_position *pos, bool 
 					  O_WRONLY | O_CREAT | O_TRUNC | O_BINARY,
 					  S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH);
 			if (fd < 0) {
-				ltfsmsg(LTFS_ERR, "30033E", fname, errno);
+				ltfsmsg(LTFS_ERR, 30033E, fname, errno);
 				free(fname);
 				return -EDEV_RW_PERM;
 			}
@@ -943,7 +943,7 @@ int filedebug_writefm(void *device, size_t count, struct tc_position *pos, bool 
 
 			ret = close(fd);
 			if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "30034E", errno);
+			ltfsmsg(LTFS_ERR, 30034E, errno);
 			return -EDEV_RW_PERM;
 			}
 
@@ -954,7 +954,7 @@ int filedebug_writefm(void *device, size_t count, struct tc_position *pos, bool 
 
 			ret = _filedebug_write_eod(state);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "30035E", ret);
+				ltfsmsg(LTFS_ERR, 30035E, ret);
 				return ret;
 			}
 		}
@@ -980,7 +980,7 @@ int filedebug_rewind(void *device, struct tc_position *pos)
 	struct filedebug_data *state = (struct filedebug_data *)device;
 
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "30036E");
+		ltfsmsg(LTFS_ERR, 30036E);
 		return -EDEV_NOT_READY;
 	}
 
@@ -1013,11 +1013,11 @@ int filedebug_locate(void *device, struct tc_position dest, struct tc_position *
 	tape_filemarks_t count_fm = 0;
 	tape_block_t     i;
 
-	ltfsmsg(LTFS_DEBUG, "30197D", "locate", (unsigned long long)dest.partition,
+	ltfsmsg(LTFS_DEBUG, 30197D, "locate", (unsigned long long)dest.partition,
 		(unsigned long long)dest.block);
 
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "30037E");
+		ltfsmsg(LTFS_ERR, 30037E);
 		ret = -EDEV_NOT_READY;
 		return ret;
 	}
@@ -1029,7 +1029,7 @@ int filedebug_locate(void *device, struct tc_position dest, struct tc_position *
 	}
 
 	if (dest.partition >= MAX_PARTITIONS) {
-		ltfsmsg(LTFS_ERR, "30038E", (unsigned long)dest.partition);
+		ltfsmsg(LTFS_ERR, 30038E, (unsigned long)dest.partition);
 		ret = -EDEV_INVALID_ARG;
 		return ret;
 	}
@@ -1058,7 +1058,7 @@ int filedebug_locate(void *device, struct tc_position dest, struct tc_position *
 		fname = _filedebug_make_filename(state, state->current_position.partition,
 										 i, rec_suffixes[SUFFIX_FILEMARK]);
 		if (!fname) {
-			ltfsmsg(LTFS_ERR, "30039E");
+			ltfsmsg(LTFS_ERR, 30039E);
 			ret = -EDEV_NO_MEMORY;
 			return ret;
 		}
@@ -1097,7 +1097,7 @@ int filedebug_space(void *device, size_t count, TC_SPACE_TYPE type, struct tc_po
 	tape_block_t     i;
 
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "30040E");
+		ltfsmsg(LTFS_ERR, 30040E);
 		ret = -EDEV_NOT_READY;
 		return ret;
 	}
@@ -1110,7 +1110,7 @@ int filedebug_space(void *device, size_t count, TC_SPACE_TYPE type, struct tc_po
 
 	switch(type) {
 		case TC_SPACE_EOD:
-			ltfsmsg(LTFS_DEBUG, "30195D", "space to EOD");
+			ltfsmsg(LTFS_DEBUG, 30195D, "space to EOD");
 			state->current_position.block = state->eod[state->current_position.partition];
 			if(state->current_position.block == MISSING_EOD) {
 				ret = -EDEV_RW_PERM;
@@ -1119,7 +1119,7 @@ int filedebug_space(void *device, size_t count, TC_SPACE_TYPE type, struct tc_po
 				ret = 0;
 			break;
 		case TC_SPACE_FM_F:
-			ltfsmsg(LTFS_DEBUG, "30196D", "space forward file marks", (unsigned long long)count);
+			ltfsmsg(LTFS_DEBUG, 30196D, "space forward file marks", (unsigned long long)count);
 			if(state->current_position.block == MISSING_EOD) {
 				ret = -EDEV_RW_PERM;
 				return ret;
@@ -1127,7 +1127,7 @@ int filedebug_space(void *device, size_t count, TC_SPACE_TYPE type, struct tc_po
 				ret = _filedebug_space_fm(state, count, false);
 			break;
 		case TC_SPACE_FM_B:
-			ltfsmsg(LTFS_DEBUG, "30196D", "space back file marks", (unsigned long long)count);
+			ltfsmsg(LTFS_DEBUG, 30196D, "space back file marks", (unsigned long long)count);
 			if(state->current_position.block == MISSING_EOD) {
 				ret = -EDEV_RW_PERM;
 				return ret;
@@ -1135,7 +1135,7 @@ int filedebug_space(void *device, size_t count, TC_SPACE_TYPE type, struct tc_po
 				ret = _filedebug_space_fm(state, count, true);
 			break;
 		case TC_SPACE_F:
-			ltfsmsg(LTFS_DEBUG, "30196D", "space forward records", (unsigned long long)count);
+			ltfsmsg(LTFS_DEBUG, 30196D, "space forward records", (unsigned long long)count);
 			if(state->current_position.block == MISSING_EOD) {
 				ret = -EDEV_RW_PERM;
 				return ret;
@@ -1143,7 +1143,7 @@ int filedebug_space(void *device, size_t count, TC_SPACE_TYPE type, struct tc_po
 				ret = _filedebug_space_rec(state, count, false);
 			break;
 		case TC_SPACE_B:
-			ltfsmsg(LTFS_DEBUG, "30196D", "space back records", (unsigned long long)count);
+			ltfsmsg(LTFS_DEBUG, 30196D, "space back records", (unsigned long long)count);
 			if(state->current_position.block == MISSING_EOD) {
 				ret = -EDEV_RW_PERM;
 				return ret;
@@ -1151,7 +1151,7 @@ int filedebug_space(void *device, size_t count, TC_SPACE_TYPE type, struct tc_po
 				ret = _filedebug_space_rec(state, count, true);
 			break;
 		default:
-			ltfsmsg(LTFS_ERR, "30041E");
+			ltfsmsg(LTFS_ERR, 30041E);
 			ret = -EDEV_INVALID_ARG;
 			return ret;
 	}
@@ -1164,7 +1164,7 @@ int filedebug_space(void *device, size_t count, TC_SPACE_TYPE type, struct tc_po
 		fname = _filedebug_make_filename(state, state->current_position.partition,
 										 i, rec_suffixes[SUFFIX_FILEMARK]);
 		if (!fname) {
-			ltfsmsg(LTFS_ERR, "30042E");
+			ltfsmsg(LTFS_ERR, 30042E);
 			ret = -EDEV_NO_MEMORY;
 			return ret;
 		}
@@ -1204,11 +1204,11 @@ int filedebug_erase(void *device, struct tc_position *pos, bool long_erase)
 	struct filedebug_data *state = (struct filedebug_data *)device;
 
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "30043E");
+		ltfsmsg(LTFS_ERR, 30043E);
 		return -EDEV_NOT_READY;
 	}
 
-	ltfsmsg(LTFS_DEBUG, "30044D", (unsigned long)state->current_position.partition);
+	ltfsmsg(LTFS_DEBUG, 30044D, (unsigned long)state->current_position.partition);
 	pos->block     = state->current_position.block;
 	pos->filemarks = state->current_position.filemarks;
 
@@ -1231,7 +1231,7 @@ static inline int _sanitize_tape(struct filedebug_data *state)
 				/* Do nothing */
 				break;
 			default:
-				ltfsmsg(LTFS_INFO, "30086I", "LTO5", state->conf.cart_type);
+				ltfsmsg(LTFS_INFO, 30086I, "LTO5", state->conf.cart_type);
 				state->unsupported_tape = true;
 				ret = -EDEV_MEDIUM_FORMAT_ERROR;
 				break;
@@ -1243,7 +1243,7 @@ static inline int _sanitize_tape(struct filedebug_data *state)
 				/* Do nothing */
 				break;
 			default:
-				ltfsmsg(LTFS_INFO, "30086I", "LTO6", state->conf.cart_type);
+				ltfsmsg(LTFS_INFO, 30086I, "LTO6", state->conf.cart_type);
 				state->unsupported_tape = true;
 				ret = -EDEV_MEDIUM_FORMAT_ERROR;
 				break;
@@ -1256,7 +1256,7 @@ static inline int _sanitize_tape(struct filedebug_data *state)
 				/* Do nothing */
 				break;
 			default:
-				ltfsmsg(LTFS_INFO, "30086I", "LTO7", state->conf.cart_type);
+				ltfsmsg(LTFS_INFO, 30086I, "LTO7", state->conf.cart_type);
 				state->unsupported_tape = true;
 				ret = -EDEV_MEDIUM_FORMAT_ERROR;
 				break;
@@ -1269,7 +1269,7 @@ static inline int _sanitize_tape(struct filedebug_data *state)
 				/* Do nothing */
 				break;
 			default:
-				ltfsmsg(LTFS_INFO, "30086I", "LTO8", state->conf.cart_type);
+				ltfsmsg(LTFS_INFO, 30086I, "LTO8", state->conf.cart_type);
 				state->unsupported_tape = true;
 				ret = -EDEV_MEDIUM_FORMAT_ERROR;
 				break;
@@ -1286,7 +1286,7 @@ static inline int _sanitize_tape(struct filedebug_data *state)
 				state->is_worm = true;
 				break;
 			default:
-				ltfsmsg(LTFS_INFO, "30086I", "TS1140", state->conf.cart_type);
+				ltfsmsg(LTFS_INFO, 30086I, "TS1140", state->conf.cart_type);
 				state->is_worm = false;
 				state->unsupported_tape = true;
 				ret = -EDEV_MEDIUM_FORMAT_ERROR;
@@ -1305,7 +1305,7 @@ static inline int _sanitize_tape(struct filedebug_data *state)
 				state->is_worm = true;
 				break;
 			default:
-				ltfsmsg(LTFS_INFO, "30086I", "TS1150", state->conf.cart_type);
+				ltfsmsg(LTFS_INFO, 30086I, "TS1150", state->conf.cart_type);
 				state->is_worm = false;
 				state->unsupported_tape = true;
 				ret = -EDEV_MEDIUM_FORMAT_ERROR;
@@ -1324,14 +1324,14 @@ static inline int _sanitize_tape(struct filedebug_data *state)
 				state->is_worm = true;
 				break;
 			default:
-				ltfsmsg(LTFS_INFO, "30086I", "TS1155", state->conf.cart_type);
+				ltfsmsg(LTFS_INFO, 30086I, "TS1155", state->conf.cart_type);
 				state->is_worm = false;
 				state->unsupported_tape = true;
 				ret = -EDEV_MEDIUM_FORMAT_ERROR;
 				break;
 		}
 	} else {
-		ltfsmsg(LTFS_INFO, "30087I", "Unexpected Drive", state->conf.cart_type);
+		ltfsmsg(LTFS_INFO, 30086I, "Unexpected Drive", state->conf.cart_type);
 		state->is_worm = false;
 		state->unsupported_tape = true;
 		ret = -EDEV_MEDIUM_FORMAT_ERROR;
@@ -1371,7 +1371,7 @@ int filedebug_load(void *device, struct tc_position *pos)
 
 		ret = read(state->fd, buf, sizeof(buf));
 		if (ret != sizeof(buf)) {
-			ltfsmsg(LTFS_ERR, "30045E", "");
+			ltfsmsg(LTFS_ERR, 30045E, "");
 			return -EDEV_HARDWARE_ERROR;
 		}
 
@@ -1381,7 +1381,7 @@ int filedebug_load(void *device, struct tc_position *pos)
 			dirlink[strlen(dirlink) - 1] = '\0';
 
 		if(!strcmp(dirlink, "empty")) {
-			ltfsmsg(LTFS_INFO, "30046I", "");
+			ltfsmsg(LTFS_INFO, 30046I, "");
 			return -EDEV_NO_MEDIUM;
 		}
 
@@ -1392,30 +1392,30 @@ int filedebug_load(void *device, struct tc_position *pos)
 
 		ret = asprintf(&state->dirname, "%s/%s", state->dirbase, dirlink);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "10001E", "Directory name pointed by redirecting file");
+			ltfsmsg(LTFS_ERR, 10001E, "Directory name pointed by redirecting file");
 			return -EDEV_INTERNAL_ERROR;
 		}
 
 		/* make sure directory exists */
 		ret = stat(state->dirname, &d);
 		if (ret || !S_ISDIR(d.st_mode)) {
-			ltfsmsg(LTFS_ERR, "30047E", state->dirname);
+			ltfsmsg(LTFS_ERR, 30047E, state->dirname);
 			return -EDEV_NO_MEDIUM;
 		}
 	}
 
-	ltfsmsg(LTFS_INFO, "30048I", state->dirname);
+	ltfsmsg(LTFS_INFO, 30048I, state->dirname);
 
 	/* Load configuration of cartridge */
 	ret = asprintf(&config_file, "%s/%s", state->dirname, CARTRIDGE_CONFIG );
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "30049E", ret);
+		ltfsmsg(LTFS_ERR, 30049E, ret);
 		return -EDEV_INTERNAL_ERROR;
 	}
 
 	ret = stat(config_file, &d);
 	if (! ret && S_ISDIR(d.st_mode)) {
-		ltfsmsg(LTFS_ERR, "30050E", ret);
+		ltfsmsg(LTFS_ERR, 30050E, ret);
 		free(config_file);
 		return -EDEV_INTERNAL_ERROR;
 	}
@@ -1425,7 +1425,7 @@ int filedebug_load(void *device, struct tc_position *pos)
 	else if (! ret)
 		filedebug_conf_tc_read_xml(config_file, &state->conf);
 	else {
-		ltfsmsg(LTFS_ERR, "30051E", ret);
+		ltfsmsg(LTFS_ERR, 30051E, ret);
 		free(config_file);
 		return -EDEV_INTERNAL_ERROR;
 	}
@@ -1460,7 +1460,7 @@ int filedebug_load(void *device, struct tc_position *pos)
 			state->is_readonly = true;
 			break;
 		case MEDIUM_CANNOT_ACCESS:
-			ltfsmsg(LTFS_INFO, "30088I", state->drive_type, state->conf.density_code);
+			ltfsmsg(LTFS_INFO, 30088I, state->drive_type, state->conf.density_code);
 			state->unsupported_format = true;
 			if (IS_LTO(state->drive_type))
 				return -EDEV_MEDIUM_FORMAT_ERROR;
@@ -1476,7 +1476,7 @@ int filedebug_load(void *device, struct tc_position *pos)
 	for (i=0; i<MAX_PARTITIONS; ++i) {
 		ret = filedebug_search_eod(state, i);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "30052E", i, ret);
+			ltfsmsg(LTFS_ERR, 30052E, i, ret);
 			return -EDEV_INTERNAL_ERROR;
 		}
 	}
@@ -1498,7 +1498,7 @@ int filedebug_load(void *device, struct tc_position *pos)
 
 	wp = 0;
 	if(_get_wp(device, &wp) != 0) {
-		ltfsmsg(LTFS_ERR, "30053E");
+		ltfsmsg(LTFS_ERR, 30053E);
 		return -EDEV_INTERNAL_ERROR;
 	}
 
@@ -1560,7 +1560,7 @@ int filedebug_readpos(void *device, struct tc_position *pos)
 	struct filedebug_data *state = (struct filedebug_data *)device;
 
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "30054E");
+		ltfsmsg(LTFS_ERR, 30054E);
 		return -EDEV_NOT_READY;
 	}
 
@@ -1568,7 +1568,7 @@ int filedebug_readpos(void *device, struct tc_position *pos)
 	pos->block     = state->current_position.block;
 	pos->filemarks = state->current_position.filemarks;
 
-	ltfsmsg(LTFS_DEBUG, "30198D", "readpos", (unsigned long long)state->current_position.partition,
+	ltfsmsg(LTFS_DEBUG, 30198D, "readpos", (unsigned long long)state->current_position.partition,
 		(unsigned long long)state->current_position.block,
 		(unsigned long long)state->current_position.filemarks);
 	return DEVICE_GOOD;
@@ -1582,7 +1582,7 @@ int filedebug_setcap(void *device, uint16_t proportion)
 	if(state->current_position.partition != 0 ||
 		state->current_position.block != 0)
 	{
-		ltfsmsg(LTFS_ERR, "30055E");
+		ltfsmsg(LTFS_ERR, 30055E);
 		return -EDEV_ILLEGAL_REQUEST;
 	}
 
@@ -1608,7 +1608,7 @@ int filedebug_format(void *device, TC_FORMAT_TYPE format)
 	if(state->current_position.partition != 0 ||
 		state->current_position.block != 0)
 	{
-		ltfsmsg(LTFS_ERR, "30056E");
+		ltfsmsg(LTFS_ERR, 30056E);
 		return -EDEV_ILLEGAL_REQUEST;
 	}
 
@@ -1625,7 +1625,7 @@ int filedebug_format(void *device, TC_FORMAT_TYPE format)
 		else
 			ret = -EDEV_DATA_PROTECT;    /* Emulate 07/3005 */
 
-		ltfsmsg(LTFS_INFO, "30086I", ret, state->serial_number);
+		ltfsmsg(LTFS_INFO, 30085I, ret, state->serial_number);
 
 		return ret;
 	}
@@ -1639,7 +1639,7 @@ int filedebug_format(void *device, TC_FORMAT_TYPE format)
 			state->partitions = 2;
 			break;
 		default:
-			ltfsmsg(LTFS_ERR, "30057E");
+			ltfsmsg(LTFS_ERR, 30057E);
 			return -EDEV_INVALID_ARG;
 	}
 
@@ -1673,7 +1673,7 @@ int filedebug_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 	struct filedebug_data *state = (struct filedebug_data *)device;
 
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "30058E");
+		ltfsmsg(LTFS_ERR, 30058E);
 		return DEVICE_GOOD;
 	}
 
@@ -1733,7 +1733,7 @@ int filedebug_get_xattr(void *device, const char *name, char **buf)
 			state->accumulated_delay.tv_sec,
 			state->accumulated_delay.tv_nsec);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "10001E", "get_xattr buffer");
+			ltfsmsg(LTFS_ERR, 10001E, "get_xattr buffer");
 			ret = -LTFS_NO_MEMORY;
 		} else
 			ret = DEVICE_GOOD;
@@ -1754,7 +1754,7 @@ int filedebug_set_xattr(void *device, const char *name, const char *buf, size_t 
 
 	null_terminated = calloc(1, size + 1);
 	if (! null_terminated) {
-		ltfsmsg(LTFS_ERR, "10001E", "ibmtape_set_xattr: null_term");
+		ltfsmsg(LTFS_ERR, 10001E, "ibmtape_set_xattr: null_term");
 		return -LTFS_NO_MEMORY;
 	}
 	memcpy(null_terminated, buf, size);
@@ -1789,7 +1789,7 @@ int filedebug_set_xattr(void *device, const char *name, const char *buf, size_t 
 
 int filedebug_logsense(void *device, const uint8_t page, unsigned char *buf, const size_t size)
 {
-	ltfsmsg(LTFS_ERR, "10007E", __FUNCTION__);
+	ltfsmsg(LTFS_ERR, 10007E, __FUNCTION__);
 	return -EDEV_UNSUPPORTED_FUNCTION;
 }
 
@@ -1826,7 +1826,7 @@ int filedebug_reserve_unit(void *device)
 {
 	struct filedebug_data *state = (struct filedebug_data *)device;
 	if (state->device_reserved) {
-		ltfsmsg(LTFS_ERR, "30059E");
+		ltfsmsg(LTFS_ERR, 30059E);
 		return -EDEV_ILLEGAL_REQUEST;
 	}
 	state->device_reserved = true;
@@ -1844,7 +1844,7 @@ int filedebug_prevent_medium_removal(void *device)
 {
 	struct filedebug_data *state = (struct filedebug_data *)device;
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "30060E");
+		ltfsmsg(LTFS_ERR, 30060E);
 		return -EDEV_NOT_READY;
 	}
 	state->medium_locked = true; /* TODO: fail if medium is already locked? */
@@ -1855,7 +1855,7 @@ int filedebug_allow_medium_removal(void *device)
 {
 	struct filedebug_data *state = (struct filedebug_data *)device;
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "30061E");
+		ltfsmsg(LTFS_ERR, 30061E);
 		return -EDEV_NOT_READY;
 	}
 	state->medium_locked = false;
@@ -1870,7 +1870,7 @@ int filedebug_read_attribute(void *device, const tape_partition_t part, const ui
 	int fd;
 	ssize_t bytes_read;
 
-	ltfsmsg(LTFS_DEBUG, "30197D", "readattr", (unsigned long)part, id);
+	ltfsmsg(LTFS_DEBUG, 30197D, "readattr", (unsigned long long)part, (unsigned long long)id);
 
 	/* Open attribute record */
 	fname = _filedebug_make_attrname(state, part, id);
@@ -1879,14 +1879,14 @@ int filedebug_read_attribute(void *device, const tape_partition_t part, const ui
 	fd = open(fname, O_RDONLY | O_BINARY);
 	free(fname);
 	if (fd < 0) {
-		ltfsmsg(LTFS_WARN, "30062W", errno);
+		ltfsmsg(LTFS_WARN, 30062W, errno);
 		return -EDEV_CM_PERM;
 	}
 
 	/* TODO: return -EDEV_INVALID_ARG if buffer is too small to hold complete record? */
 	bytes_read = read(fd, buf, size);
 	if(bytes_read == -1) {
-		ltfsmsg(LTFS_WARN, "30063W", errno);
+		ltfsmsg(LTFS_WARN, 30063W, errno);
 		close(fd);
 		return -EDEV_CM_PERM;
 	}
@@ -1910,12 +1910,12 @@ int filedebug_write_attribute(void *device, const tape_partition_t part
 		id = ltfs_betou16(buf + i);
 		attr_size = ltfs_betou16(buf + (i + 3));
 
-		ltfsmsg(LTFS_DEBUG, "30197D", "writeattr", (unsigned long)part, id);
+		ltfsmsg(LTFS_DEBUG, 30197D, "writeattr", (unsigned long long)part, (unsigned long long)id);
 
 		/* Create attribute record */
 		fname = _filedebug_make_attrname(state, part, id);
 		if (!fname) {
-			ltfsmsg(LTFS_ERR, "30064E");
+			ltfsmsg(LTFS_ERR, 30064E);
 			return -EDEV_NO_MEMORY;
 		}
 		fd = open(fname,
@@ -1923,14 +1923,14 @@ int filedebug_write_attribute(void *device, const tape_partition_t part
 				  S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH);
 		free(fname);
 		if (fd < 0) {
-			ltfsmsg(LTFS_ERR, "30065E", errno);
+			ltfsmsg(LTFS_ERR, 30065E, errno);
 			return -EDEV_CM_PERM;
 		}
 
 		/* write and close the file */
 		written = write(fd, buf, size);
 		if (written < 0) {
-			ltfsmsg(LTFS_ERR, "30066E", errno);
+			ltfsmsg(LTFS_ERR, 30066E, errno);
 			close(fd);
 			return -EDEV_CM_PERM;
 		}
@@ -1961,7 +1961,7 @@ int filedebug_set_compression(void *device, bool enable_compression, struct tc_p
 {
 	struct filedebug_data *state = (struct filedebug_data *)device;
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "30067E");
+		ltfsmsg(LTFS_ERR, 30067E);
 		return -EDEV_NOT_READY;
 	}
 	pos->block = state->current_position.block;
@@ -2024,7 +2024,7 @@ int filedebug_search_eod(struct filedebug_data *state, int partition)
 		/* check for a record */
 		fname = _filedebug_make_current_filename(state, '.');
 		if (!fname) {
-			ltfsmsg(LTFS_ERR, "30068E");
+			ltfsmsg(LTFS_ERR, 30068E);
 			return -EDEV_NO_MEMORY;
 		}
 		fname_len = strlen(fname);
@@ -2033,7 +2033,7 @@ int filedebug_search_eod(struct filedebug_data *state, int partition)
 			fname[fname_len-1] = rec_suffixes[i];
 			f[i] = _filedebug_check_file(fname);
 			if (f[i] < 0) {
-				ltfsmsg(LTFS_ERR, "30069E", f[i]);
+				ltfsmsg(LTFS_ERR, 30069E, f[i]);
 				free(fname);
 				return f[i];
 			}
@@ -2050,7 +2050,7 @@ int filedebug_search_eod(struct filedebug_data *state, int partition)
 		if (state->conf.dummy_io) {
 			dp = opendir(state->dirname);
 			if (! dp) {
-				ltfsmsg(LTFS_ERR, "30004E", state->dirname);
+				ltfsmsg(LTFS_ERR, 30004E, state->dirname);
 				return 0;
 			}
 
@@ -2065,7 +2065,7 @@ int filedebug_search_eod(struct filedebug_data *state, int partition)
 						state->eod[partition] = 0;
 						ret = _filedebug_write_eod(state);
 						if (ret < 0) {
-							ltfsmsg(LTFS_ERR, "30070E", ret);
+							ltfsmsg(LTFS_ERR, 30070E, ret);
 							closedir(dp);
 							return ret;
 						}
@@ -2078,7 +2078,7 @@ int filedebug_search_eod(struct filedebug_data *state, int partition)
 	} else {
 		ret = _filedebug_write_eod(state);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "30070E", ret);
+			ltfsmsg(LTFS_ERR, 30070E, ret);
 			return ret;
 		}
 	}
@@ -2105,14 +2105,14 @@ int _filedebug_write_eod(struct filedebug_data *state)
 	/* remove any existing record at this position */
 	ret = _filedebug_remove_current_record(state);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "30071E", ret);
+		ltfsmsg(LTFS_ERR, 30071E, ret);
 		return ret;
 	}
 
 	/* create EOD record */
 	fname = _filedebug_make_current_filename(state, 'E');
 	if (!fname) {
-		ltfsmsg(LTFS_ERR, "30072E");
+		ltfsmsg(LTFS_ERR, 30072E);
 		return -EDEV_NO_MEMORY;
 	}
 	fd = open(fname,
@@ -2120,7 +2120,7 @@ int _filedebug_write_eod(struct filedebug_data *state)
 			  S_IWUSR | S_IRUSR | S_IRGRP | S_IROTH);
 	free(fname);
 	if (fd < 0 || close(fd) < 0) {
-		ltfsmsg(LTFS_ERR, "30073E", errno);
+		ltfsmsg(LTFS_ERR, 30073E, errno);
 		return -EDEV_RW_PERM;
 	}
 
@@ -2129,7 +2129,7 @@ int _filedebug_write_eod(struct filedebug_data *state)
 		for (i=state->current_position.block+1; i<=state->eod[state->current_position.partition]; ++i) {
 			ret = _filedebug_remove_record(state, state->current_position.partition, i);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "30074E", ret);
+				ltfsmsg(LTFS_ERR, 30074E, ret);
 				return ret;
 			}
 		}
@@ -2164,7 +2164,7 @@ int _filedebug_remove_record(const struct filedebug_data *state,
 
 	fname = _filedebug_make_filename(state, partition, blknum, '.');
 	if (!fname) {
-		ltfsmsg(LTFS_ERR, "30075E");
+		ltfsmsg(LTFS_ERR, 30075E);
 		return -EDEV_NO_MEMORY;
 	}
 	fname_len = strlen(fname);
@@ -2173,7 +2173,7 @@ int _filedebug_remove_record(const struct filedebug_data *state,
 		fname[fname_len-1] = rec_suffixes[i];
 		ret = unlink(fname);
 		if (ret < 0 && errno != ENOENT) {
-			ltfsmsg(LTFS_ERR, "30076E", errno);
+			ltfsmsg(LTFS_ERR, 30076E, errno);
 			free(fname);
 			return -EDEV_RW_PERM;
 		}
@@ -2231,7 +2231,7 @@ char *_filedebug_make_filename(const struct filedebug_data *state,
 	int ret;
 	ret = asprintf(&fname, "%s/%d_%"PRIu64"_%c", state->dirname, part, pos, type);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return NULL;
 	}
 	return fname;
@@ -2248,7 +2248,7 @@ char *_filedebug_make_attrname(const struct filedebug_data *state, int part, int
 	int ret;
 	ret = asprintf(&fname, "%s/attr_%d_%x", state->dirname, part, id);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return NULL;
 	}
 	return fname;
@@ -2277,7 +2277,7 @@ int _filedebug_space_fm(struct filedebug_data *state, uint64_t count, bool back)
 	while (1) {
 		if (!back &&
 			state->current_position.block == state->eod[state->current_position.partition]) {
-			ltfsmsg(LTFS_ERR, "30077E");
+			ltfsmsg(LTFS_ERR, 30077E);
 			return -EDEV_EOD_DETECTED;
 		}
 
@@ -2288,13 +2288,13 @@ int _filedebug_space_fm(struct filedebug_data *state, uint64_t count, bool back)
 
 		fname = _filedebug_make_current_filename(state, rec_suffixes[SUFFIX_FILEMARK]);
 		if (!fname) {
-			ltfsmsg(LTFS_ERR, "30078E");
+			ltfsmsg(LTFS_ERR, 30078E);
 			return -EDEV_NO_MEMORY;
 		}
 		ret = _filedebug_check_file(fname);
 		free(fname);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "30079E", ret);
+			ltfsmsg(LTFS_ERR, 30079E, ret);
 			return ret;
 		} else if (ret > 0) {
 			++fm_count;
@@ -2307,7 +2307,7 @@ int _filedebug_space_fm(struct filedebug_data *state, uint64_t count, bool back)
 
 		if (back) {
 			if (state->current_position.block == 0) {
-				ltfsmsg(LTFS_ERR, "30080E");
+				ltfsmsg(LTFS_ERR, 30080E);
 				return -EDEV_BOP_DETECTED;
 			}
 			--state->current_position.block;
@@ -2434,13 +2434,13 @@ int filedebug_get_device_list(struct tc_drive_info *buf, int count)
 	/* Create a file to indicate current directory of drive link (for tape file backend) */
 	asprintf(&filename, "%s/ltfs%ld", DRIVE_LIST_DIR, original_pid);
 	if (!filename) {
-		ltfsmsg(LTFS_ERR, "10001E", "filechanger_data drive file name");
+		ltfsmsg(LTFS_ERR, 10001E, "filechanger_data drive file name");
 		return -LTFS_NO_MEMORY;
 	}
-	ltfsmsg(LTFS_INFO, "30081I", filename);
+	ltfsmsg(LTFS_INFO, 30081I, filename);
 	infile = fopen(filename, "r");
 	if (!infile) {
-		ltfsmsg(LTFS_INFO, "30082I", filename);
+		ltfsmsg(LTFS_INFO, 30082I, filename);
 		return 0;
 	} else {
 		devdir = fgets(line, sizeof(line), infile);
@@ -2450,10 +2450,10 @@ int filedebug_get_device_list(struct tc_drive_info *buf, int count)
 		free(filename);
 	}
 
-	ltfsmsg(LTFS_INFO, "30083I", devdir);
+	ltfsmsg(LTFS_INFO, 30083I, devdir);
 	dp = opendir(devdir);
 	if (! dp) {
-		ltfsmsg(LTFS_ERR, "30004E", devdir);
+		ltfsmsg(LTFS_ERR, 30004E, devdir);
 		return 0;
 	}
 
@@ -2464,7 +2464,7 @@ int filedebug_get_device_list(struct tc_drive_info *buf, int count)
 		if (buf && deventries < count) {
 			tmp = strdup(entry->d_name);
 			if (! *tmp) {
-				ltfsmsg(LTFS_ERR, "10001E", "filedebug_get_device_list");
+				ltfsmsg(LTFS_ERR, 10001E, "filedebug_get_device_list");
 				return -ENOMEM;
 			}
 
@@ -2491,7 +2491,7 @@ int filedebug_get_device_list(struct tc_drive_info *buf, int count)
 					buf[deventries].product_name[i] = ' ';
 				buf[deventries].product_name[PRODUCT_NAME_REPORT_LENGTH] = '\0';
 			}
-			ltfsmsg(LTFS_DEBUG, "30084D", buf[deventries].name, buf[deventries].vendor,
+			ltfsmsg(LTFS_DEBUG, 30084D, buf[deventries].name, buf[deventries].vendor,
 					buf[deventries].model, buf[deventries].serial_number);
 
 			free(tmp);

--- a/src/tape_drivers/generic/itdtimg/itdtimg_tc.c
+++ b/src/tape_drivers/generic/itdtimg/itdtimg_tc.c
@@ -207,7 +207,7 @@ int itdtimage_parse_opts(void *vstate, void *opt_args)
 
 void itdtimage_help_message(void)
 {
-	ltfsresult("31199I");
+	ltfsresult(31199I);
 }
 
 int itdtimage_open(const char *name, void **handle)
@@ -221,14 +221,14 @@ int itdtimage_open(const char *name, void **handle)
 	int currentPartition = 0, i, j;
 	long bytes_read;
 
-	ltfsmsg(LTFS_INFO, "31000I", name);
+	ltfsmsg(LTFS_INFO, 31000I, name);
 
 	CHECK_ARG_NULL(handle, -LTFS_NULL_ARG);
 	*handle = NULL;
 
 	state = (struct itdtimage_data *)calloc(1,sizeof(struct itdtimage_data));
 	if (!state) {
-		ltfsmsg(LTFS_ERR, "10001E", "itdtimage_open: private data");
+		ltfsmsg(LTFS_ERR, 10001E, "itdtimage_open: private data");
 		return -EDEV_NO_MEMORY;
 	}
 
@@ -239,13 +239,13 @@ int itdtimage_open(const char *name, void **handle)
 	 */
 	state->img_file = fopen(name, "r");
 	if ( !state->img_file ) {
-		ltfsmsg(LTFS_ERR, "31001E", name, "fopen", errno);
+		ltfsmsg(LTFS_ERR, 31001E, name, "fopen", (unsigned long long)errno);
 		_itdtimage_free(state);
 		return -EDEV_DEVICE_UNOPENABLE;
 	}
 	state->filename = strdup(name);
 	if ( !state->filename ) {
-		ltfsmsg(LTFS_ERR, "10001E", "itdtimage_open: filename");
+		ltfsmsg(LTFS_ERR, 10001E, "itdtimage_open: filename");
 		_itdtimage_free(state);
 		return -EDEV_NO_MEMORY;
 	}
@@ -255,7 +255,7 @@ int itdtimage_open(const char *name, void **handle)
 	if ( length < XML_MIN_DATA_SIZE)
 		read_length = length;
 	if (_seek_file(state->img_file, length-read_length)!=0){
-		ltfsmsg(LTFS_ERR, "31002E", (long long)length-read_length, state->filename, errno);
+		ltfsmsg(LTFS_ERR, 31002E, (long long)length-read_length, state->filename, (unsigned long long)errno);
 		_itdtimage_free(state);
 		return -EDEV_HARDWARE_ERROR;
 	}
@@ -290,19 +290,19 @@ int itdtimage_open(const char *name, void **handle)
 	state->density_code   = _read_XML_tag_value(buffer,bytes_read, "densityCode");
 
 	if ( ! state->rll_count ){
-		ltfsmsg(LTFS_ERR, "31001E", state->filename, "Meta Info [rll_count] is not valid", state->rll_count);
+		ltfsmsg(LTFS_ERR, 31001E, state->filename, "Meta Info [rll_count] is not valid", (unsigned long long)state->rll_count);
 		_itdtimage_free(state);
 		free(buffer);
 		return -EDEV_DEVICE_UNOPENABLE;
 	}
 	if ( state->version < 2 ){
-		ltfsmsg(LTFS_ERR, "31001E", state->filename, "Unsupported ITDT Image file version", state->version);
+		ltfsmsg(LTFS_ERR, 31001E, state->filename, "Unsupported ITDT Image file version", (unsigned long long)state->version);
 		_itdtimage_free(state);
 		free(buffer);
 		return -EDEV_DEVICE_UNOPENABLE;
 	}
 	if ( ! state->byte_count ){
-		ltfsmsg(LTFS_ERR, "31001E", state->filename, "Meta Info [byte_count] is not valid", state->byte_count);
+		ltfsmsg(LTFS_ERR, 31001E, state->filename, "Meta Info [byte_count] is not valid", state->byte_count);
 		_itdtimage_free(state);
 		free(buffer);
 		return -EDEV_DEVICE_UNOPENABLE;
@@ -329,7 +329,7 @@ int itdtimage_open(const char *name, void **handle)
 		}
 	}
 	if (state->attr_count==0){
-		ltfsmsg(LTFS_ERR, "31001E", state->filename, "Meta Info [attr_] is not valid", state->attr_count);
+		ltfsmsg(LTFS_ERR, 31001E, state->filename, "Meta Info [attr_] is not valid", (unsigned long long)state->attr_count);
 		_itdtimage_free(state);
 		free(buffer);
 		return -EDEV_DEVICE_UNOPENABLE;
@@ -363,7 +363,7 @@ int itdtimage_open(const char *name, void **handle)
 
 	/* fill rllList with data from image file */
 	if ( _seek_file(state->img_file, state->byte_count) ) {
-		ltfsmsg(LTFS_ERR, "31002E", (long long)state->byte_count, state->filename, errno);
+		ltfsmsg(LTFS_ERR, 31002E, (long long)state->byte_count, state->filename, (unsigned long long)errno);
 		_itdtimage_free(state);
 		free(buffer);
 		return -EDEV_HARDWARE_ERROR;
@@ -420,7 +420,7 @@ int itdtimage_reopen(const char *name, void *vstate)
 int itdtimage_close(void *vstate)
 {
 	struct itdtimage_data *state = (struct itdtimage_data *)vstate;
-	ltfsmsg(LTFS_INFO, "31003I", state->filename);
+	ltfsmsg(LTFS_INFO, 31003I, state->filename);
 	_itdtimage_free(state);
 	return 0;
 }
@@ -479,12 +479,12 @@ int itdtimage_read(void *vstate, char *buf, size_t count, struct tc_position *po
 	long long offset;
 	size_t length_rec;
 
-	ltfsmsg(LTFS_DEBUG, "31004D", count, state->current_position.partition,
+	ltfsmsg(LTFS_DEBUG, 31004D, (unsigned long long)count, state->current_position.partition,
 			(unsigned long long)state->current_position.block,
 			(unsigned long long)state->current_position.filemarks);
 
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "31005E");
+		ltfsmsg(LTFS_ERR, 31005E);
 		return -EDEV_NOT_READY;
 	}
 
@@ -502,7 +502,7 @@ int itdtimage_read(void *vstate, char *buf, size_t count, struct tc_position *po
 	if (count < length_rec)
 		length_rec=count;
 	if ( _seek_file(state->img_file, offset) ){
-	 	ltfsmsg(LTFS_ERR, "31002E" , (long long)length_rec, state->filename, (long long)offset);
+	 	ltfsmsg(LTFS_ERR, 31002E , (long long)length_rec, state->filename, offset);
 		return -EDEV_HARDWARE_ERROR;
 	}
 
@@ -526,7 +526,7 @@ int itdtimage_rewind(void *vstate, struct tc_position *pos)
 {
 	struct itdtimage_data *state = (struct itdtimage_data *)vstate;
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "31006E");
+		ltfsmsg(LTFS_ERR, 31006E);
 		return -EDEV_NOT_READY;
 	}
 	/* Does rewinding reset the partition? */
@@ -547,16 +547,16 @@ int itdtimage_locate(void *vstate, struct tc_position dest, struct tc_position *
 	tape_filemarks_t count_fm = 0;
 	int i;
 
-	ltfsmsg(LTFS_DEBUG, "31197D", "locate", (unsigned long long)dest.partition,
+	ltfsmsg(LTFS_DEBUG, 31197D, "locate", (unsigned long long)dest.partition,
 			(unsigned long long)dest.block);
 
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "31007E");
+		ltfsmsg(LTFS_ERR, 31007E);
 		rc = -EDEV_NOT_READY;
 		return rc;
 	}
 	if (dest.partition >= MAX_PARTITIONS) {
-		ltfsmsg(LTFS_ERR, "31008E", (unsigned long)dest.partition);
+		ltfsmsg(LTFS_ERR, 31008E, (unsigned long)dest.partition);
 		rc = -EDEV_INVALID_ARG;
 		return rc;
 	}
@@ -590,14 +590,14 @@ int itdtimage_space(void *vstate, size_t count, TC_SPACE_TYPE type, struct tc_po
 	struct itdtimage_data *state = (struct itdtimage_data *)vstate;
 	tape_filemarks_t count_fm = 0;
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "31009E");
+		ltfsmsg(LTFS_ERR, 31009E);
 		rc = -EDEV_NOT_READY;
 		return rc;
 	}
 
 	switch(type) {
 	case TC_SPACE_EOD:
-		ltfsmsg(LTFS_DEBUG, "31195D", "space to EOD");
+		ltfsmsg(LTFS_DEBUG, 31195D, "space to EOD");
 		state->current_position.block = state->eod[state->current_position.partition];
 		if(state->current_position.block == MISSING_EOD) {
 			rc = -EDEV_RW_PERM;
@@ -606,7 +606,7 @@ int itdtimage_space(void *vstate, size_t count, TC_SPACE_TYPE type, struct tc_po
 			rc = 0;
 		break;
 	case TC_SPACE_FM_F:
-		ltfsmsg(LTFS_DEBUG, "31196D", "space forward file marks", (unsigned long long)count);
+		ltfsmsg(LTFS_DEBUG, 31196D, "space forward file marks", (unsigned long long)count);
 		if(state->current_position.block == MISSING_EOD) {
 			rc = -EDEV_RW_PERM;
 			return rc;
@@ -614,7 +614,7 @@ int itdtimage_space(void *vstate, size_t count, TC_SPACE_TYPE type, struct tc_po
 			rc = _itdtimage_space_fm(state, count, false);
 		break;
 	case TC_SPACE_FM_B:
-		ltfsmsg(LTFS_DEBUG, "31196D", "space back file marks", (unsigned long long)count);
+		ltfsmsg(LTFS_DEBUG, 31196D, "space back file marks", (unsigned long long)count);
 		if(state->current_position.block == MISSING_EOD) {
 			rc = -EDEV_RW_PERM;
 			return rc;
@@ -622,7 +622,7 @@ int itdtimage_space(void *vstate, size_t count, TC_SPACE_TYPE type, struct tc_po
 			rc = _itdtimage_space_fm(state, count, true);
 		break;
 	case TC_SPACE_F:
-		ltfsmsg(LTFS_DEBUG, "31196D", "space forward records", (unsigned long long)count);
+		ltfsmsg(LTFS_DEBUG, 31196D, "space forward records", (unsigned long long)count);
 		if(state->current_position.block == MISSING_EOD) {
 			rc = -EDEV_RW_PERM;
 			return rc;
@@ -630,7 +630,7 @@ int itdtimage_space(void *vstate, size_t count, TC_SPACE_TYPE type, struct tc_po
 			rc = _itdtimage_space_rec(state, count, false);
 		break;
 	case TC_SPACE_B:
-		ltfsmsg(LTFS_DEBUG, "31196D", "space back records", (unsigned long long)count);
+		ltfsmsg(LTFS_DEBUG, 31196D, "space back records", (unsigned long long)count);
 		if(state->current_position.block == MISSING_EOD) {
 			rc = -EDEV_RW_PERM;
 			return rc;
@@ -638,7 +638,7 @@ int itdtimage_space(void *vstate, size_t count, TC_SPACE_TYPE type, struct tc_po
 			rc = _itdtimage_space_rec(state, count, true);
 		break;
 	default:
-		ltfsmsg(LTFS_ERR, "31010E");
+		ltfsmsg(LTFS_ERR, 31010E);
 		rc = -EDEV_INVALID_ARG;
 		return rc;
 	}
@@ -653,7 +653,13 @@ int itdtimage_space(void *vstate, size_t count, TC_SPACE_TYPE type, struct tc_po
 
 	state->current_position.filemarks = count_fm;
 	pos->filemarks = state->current_position.filemarks;
-	ltfsmsg(LTFS_DEBUG, "31011D" , state->current_position.partition,state->current_position.block,state->current_position.filemarks,(int)state->device_reserved,(int)state->medium_locked,(int)state->ready);
+	ltfsmsg(LTFS_DEBUG, 31011D,
+			(unsigned long long)state->current_position.partition,
+			(unsigned long long)state->current_position.block,
+			(unsigned long long)state->current_position.filemarks,
+			(int)state->device_reserved,
+			(int)state->medium_locked,
+			(int)state->ready);
 
 	return rc;
 }
@@ -669,11 +675,11 @@ int itdtimage_erase(void *vstate, struct tc_position *pos, bool long_erase)
 	struct itdtimage_data *state = (struct itdtimage_data *)vstate;
 
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "31021E");
+		ltfsmsg(LTFS_ERR, 31021E);
 		return -EDEV_NOT_READY;
 	}
 
-	ltfsmsg(LTFS_DEBUG, "31022D", (unsigned long)state->current_position.partition);
+	ltfsmsg(LTFS_DEBUG, 31022D, (unsigned long)state->current_position.partition);
 	pos->block	 = state->current_position.block;
 	pos->filemarks = state->current_position.filemarks;
 
@@ -718,7 +724,7 @@ int itdtimage_readpos(void *vstate, struct tc_position *pos)
 	struct itdtimage_data *state = (struct itdtimage_data *)vstate;
 
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "31012E");
+		ltfsmsg(LTFS_ERR, 31012E);
 		return -EDEV_NOT_READY;
 	}
 
@@ -726,7 +732,7 @@ int itdtimage_readpos(void *vstate, struct tc_position *pos)
 	pos->block = state->current_position.block;
 	pos->filemarks = state->current_position.filemarks;
 
-	ltfsmsg(LTFS_DEBUG, "31198D", "readpos", (unsigned long long)state->current_position.partition,
+	ltfsmsg(LTFS_DEBUG, 31198D, "readpos", (unsigned long long)state->current_position.partition,
 			(unsigned long long)state->current_position.block,
 			(unsigned long long)state->current_position.filemarks);
 	return DEVICE_GOOD;
@@ -740,7 +746,7 @@ int itdtimage_setcap(void *vstate, uint16_t proportion)
 	if(state->current_position.partition != 0 ||
 	   state->current_position.block != 0)
 	{
-		ltfsmsg(LTFS_ERR, "31013E");
+		ltfsmsg(LTFS_ERR, 31013E);
 		return -EDEV_ILLEGAL_REQUEST;
 	}
 
@@ -765,7 +771,7 @@ int itdtimage_format(void *vstate, TC_FORMAT_TYPE format)
 	if(state->current_position.partition != 0 ||
 	   state->current_position.block != 0)
 	{
-		ltfsmsg(LTFS_ERR, "31014E");
+		ltfsmsg(LTFS_ERR, 31014E);
 		return -EDEV_ILLEGAL_REQUEST;
 	}
 
@@ -778,7 +784,7 @@ int itdtimage_format(void *vstate, TC_FORMAT_TYPE format)
 		state->partitions = 2;
 		break;
 	default:
-		ltfsmsg(LTFS_ERR, "31015E");
+		ltfsmsg(LTFS_ERR, 31015E);
 		return -EDEV_INVALID_ARG;
 	}
 
@@ -796,7 +802,7 @@ int itdtimage_remaining_capacity(void *vstate, struct tc_remaining_cap *cap)
 {
 	struct itdtimage_data *state = (struct itdtimage_data *)vstate;
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "31016E");
+		ltfsmsg(LTFS_ERR, 31016E);
 		return DEVICE_GOOD;
 	}
 	cap->remaining_p0 = 6UL * (GB / MB);
@@ -853,7 +859,7 @@ int itdtimage_set_xattr(void *device, const char *name, const char *buf, size_t 
 
 int itdtimage_logsense(void *device, const uint8_t page, unsigned char *buf, const size_t size)
 {
-	ltfsmsg(LTFS_ERR, "10007E", __FUNCTION__);
+	ltfsmsg(LTFS_ERR, 10007E, __FUNCTION__);
 	return -EDEV_UNSUPPORTED_FUNCTION;
 }
 
@@ -874,7 +880,7 @@ int itdtimage_reserve_unit(void *vstate)
 {
 	struct itdtimage_data *state = (struct itdtimage_data *)vstate;
 	if (state->device_reserved) {
-		ltfsmsg(LTFS_ERR, "31017E");
+		ltfsmsg(LTFS_ERR, 31017E);
 		return -EDEV_ILLEGAL_REQUEST;
 	}
 	state->device_reserved = true;
@@ -892,7 +898,7 @@ int itdtimage_prevent_medium_removal(void *vstate)
 {
 	struct itdtimage_data *state = (struct itdtimage_data *)vstate;
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "31018E");
+		ltfsmsg(LTFS_ERR, 31018E);
 		return -EDEV_NOT_READY;
 	}
 	state->medium_locked = true; /* TODO: fail if medium is already locked? */
@@ -902,9 +908,15 @@ int itdtimage_prevent_medium_removal(void *vstate)
 int itdtimage_allow_medium_removal(void *vstate)
 {
 	struct itdtimage_data *state = (struct itdtimage_data *)vstate;
-	ltfsmsg(LTFS_DEBUG, "31011D" , state->current_position.partition,state->current_position.block,state->current_position.filemarks,(int)state->device_reserved,(int)state->medium_locked,(int)state->ready);
+	ltfsmsg(LTFS_DEBUG, 31011D,
+			(unsigned long long)state->current_position.partition,
+			(unsigned long long)state->current_position.block,
+			(unsigned long long)state->current_position.filemarks,
+			(int)state->device_reserved,
+			(int)state->medium_locked,
+			(int)state->ready);
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "31019E");
+		ltfsmsg(LTFS_ERR, 31019E);
 		return -EDEV_NOT_READY;
 	}
 	state->medium_locked = false;
@@ -919,7 +931,7 @@ int itdtimage_read_attribute(void *vstate, const tape_partition_t part, const ui
 	size_t data2ReadFromFile = size;
 	size_t attrLength=_itdtimage_getattr_len(state,part,id);
 
-	ltfsmsg(LTFS_DEBUG, "31020D" , part , id );
+	ltfsmsg(LTFS_DEBUG, 31020D , part , id );
 
 	/* Open attribute record */
 	if (offset == -1){
@@ -931,7 +943,7 @@ int itdtimage_read_attribute(void *vstate, const tape_partition_t part, const ui
 	}
 
 	if (_seek_file(state->img_file, offset)!=0){
-		ltfsmsg(LTFS_ERR, "31002E", (long long)attrLength, state->filename, (long long)offset);
+		ltfsmsg(LTFS_ERR, 31002E, (long long)attrLength, state->filename, offset);
 		return -EDEV_HARDWARE_ERROR;
 	}
 
@@ -963,7 +975,7 @@ int itdtimage_set_compression(void *vstate, bool enable_compression, struct tc_p
 {
 	struct itdtimage_data *state = (struct itdtimage_data *)vstate;
 	if (!state->ready) {
-		ltfsmsg(LTFS_ERR, "31024E");
+		ltfsmsg(LTFS_ERR, 31024E);
 		return -EDEV_NOT_READY;
 	}
 	pos->block = state->current_position.block;
@@ -1120,7 +1132,7 @@ int _itdtimage_space_fm(struct itdtimage_data *state, uint64_t count, bool back)
 	long cur = -1;
 	uint64_t filemarkCount = 0;
 
-	ltfsmsg(LTFS_DEBUG, "31004D", count, state->current_position.partition,
+	ltfsmsg(LTFS_DEBUG, 31004D, (unsigned long long)count, state->current_position.partition,
 			(unsigned long long)state->current_position.block,
 			(unsigned long long)state->current_position.filemarks);
 
@@ -1189,7 +1201,7 @@ int _itdtimage_space_fm(struct itdtimage_data *state, uint64_t count, bool back)
 			}
 			cur++;
 		}
-		ltfsmsg(LTFS_ERR, "31025E", "fimemarks");
+		ltfsmsg(LTFS_ERR, 31025E, "fimemarks");
 		return -EDEV_EOD_DETECTED;
 	}
 }
@@ -1289,7 +1301,7 @@ int _itdtimage_space_rec(struct itdtimage_data *state, uint64_t count, bool back
 			}
 			cur++;
 		}
-		ltfsmsg(LTFS_ERR, "31025E", "records");
+		ltfsmsg(LTFS_ERR, 31025E, "records");
 		return -EDEV_EOD_DETECTED;
 	}
 }
@@ -1311,13 +1323,13 @@ int itdtimage_get_device_list(struct tc_drive_info *buf, int count)
 	/* Create a file to indicate current directory of drive link (for tape file backend) */
 	asprintf(&filename, "%s/ltfs%ld", DRIVE_LIST_DIR, (long)getpid());
 	if (!filename) {
-		ltfsmsg(LTFS_ERR, "10001E", "filechanger_data drive file name");
+		ltfsmsg(LTFS_ERR, 10001E, "filechanger_data drive file name");
 		return -LTFS_NO_MEMORY;
 	}
-	ltfsmsg(LTFS_INFO, "31026I", filename);
+	ltfsmsg(LTFS_INFO, 31026I, filename);
 	infile = fopen(filename, "r");
 	if (!infile) {
-		ltfsmsg(LTFS_INFO, "31027I", filename);
+		ltfsmsg(LTFS_INFO, 31027I, filename);
 		return 0;
 	} else {
 		devdir = fgets(line, sizeof(line), infile);
@@ -1327,10 +1339,10 @@ int itdtimage_get_device_list(struct tc_drive_info *buf, int count)
 		free(filename);
 	}
 
-	ltfsmsg(LTFS_INFO, "31028I", devdir);
+	ltfsmsg(LTFS_INFO, 31028I, devdir);
 	dp = opendir(devdir);
 	if (! dp) {
-		ltfsmsg(LTFS_ERR, "31029E", devdir);
+		ltfsmsg(LTFS_ERR, 31029E, devdir);
 		return 0;
 	}
 	while ((entry = readdir(dp))) {
@@ -1342,7 +1354,7 @@ int itdtimage_get_device_list(struct tc_drive_info *buf, int count)
 			snprintf(buf[deventries].vendor, TAPE_VENDOR_NAME_LEN_MAX, "DUMMY");
 			snprintf(buf[deventries].model, TAPE_MODEL_NAME_LEN_MAX, "DUMMYDEV");
 			snprintf(buf[deventries].serial_number, TAPE_SERIAL_LEN_MAX, "%s", &(entry->d_name[strlen(DRIVE_FILE_PREFIX)]));
-			ltfsmsg(LTFS_DEBUG, "31030D", buf[deventries].name, buf[deventries].vendor,
+			ltfsmsg(LTFS_DEBUG, 31030D, buf[deventries].name, buf[deventries].vendor,
 					buf[deventries].model, buf[deventries].serial_number);
 		}
 

--- a/src/tape_drivers/ibm_tape.c
+++ b/src/tape_drivers/ibm_tape.c
@@ -887,7 +887,7 @@ static int _create_table_tape(struct timeout_tape **result,
 	entry->timeout = base->timeout;
 	HASH_ADD_INT(*result, op_code, entry);
 	if (! *result) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 
@@ -973,7 +973,7 @@ int ibm_tape_get_timeout(struct timeout_tape* table, int op_code)
 	struct timeout_tape *out = NULL;
 
 	if (!table) {
-		ltfsmsg(LTFS_WARN, "39802W", op_code);
+		ltfsmsg(LTFS_WARN, 39802W, op_code);
 		return DEFAULT_TIMEOUT;
 	}
 
@@ -981,14 +981,14 @@ int ibm_tape_get_timeout(struct timeout_tape* table, int op_code)
 
 	if (out) {
 		if (out->timeout == -1) {
-			ltfsmsg(LTFS_WARN, "39800W", op_code);
+			ltfsmsg(LTFS_WARN, 39800W, op_code);
 			return -1;
 		} else {
-			ltfsmsg(LTFS_DEBUG3, "39801D", op_code, out->timeout);
+			ltfsmsg(LTFS_DEBUG3, 39801D, op_code, out->timeout);
 			return out->timeout;
 		}
 	} else {
-		ltfsmsg(LTFS_WARN, "39805W", op_code);
+		ltfsmsg(LTFS_WARN, 39805W, op_code);
 		return DEFAULT_TIMEOUT;
 	}
 }
@@ -1083,7 +1083,7 @@ static inline int _is_mountable(const int drive_type,
 				num_table = num_lto_drive_density;
 			}
 		} else {
-			ltfsmsg(LTFS_INFO, "39808I", barcode);
+			ltfsmsg(LTFS_INFO, 39808I, barcode);
 			return MEDIUM_CANNOT_ACCESS;
 		}
 	} else {
@@ -1096,7 +1096,7 @@ static inline int _is_mountable(const int drive_type,
 				num_table = num_jaguar_drive_density;
 			}
 		} else {
-			ltfsmsg(LTFS_INFO, "39808I", barcode);
+			ltfsmsg(LTFS_INFO, 39808I, barcode);
 			return MEDIUM_CANNOT_ACCESS;
 		}
 	}
@@ -1140,13 +1140,13 @@ int ibmtape_is_mountable(const int drive_type,
 		switch (bc_len) {
 			case 6:
 				/* Always supported */
-				ltfsmsg(LTFS_DEBUG, "39806D", barcode);
+				ltfsmsg(LTFS_DEBUG, 39806D, barcode);
 				return MEDIUM_WRITABLE;
 			case 8:
 				break;
 			default:
 				// invalid bar code length
-				ltfsmsg(LTFS_ERR, "39807E", barcode);
+				ltfsmsg(LTFS_ERR, 39807E, barcode);
 				return MEDIUM_CANNOT_ACCESS;
 				break;
 		}
@@ -1165,7 +1165,7 @@ int ibmtape_is_supported_tape(unsigned char type, unsigned char density, bool *i
 		if(type == supported_cart[i]) {
 			if (type == TC_MP_JY || type == TC_MP_JZ) {
 				/* Detect WORM cartridge */
-				ltfsmsg(LTFS_DEBUG, "39809D");
+				ltfsmsg(LTFS_DEBUG, 39809D);
 				*is_worm = true;
 			}
 			ret = 0;
@@ -1257,9 +1257,9 @@ int ibmtape_genkey(unsigned char *key)
 			return 0;
 		}
 
-		ltfsmsg(LTFS_WARN, "39810W");
+		ltfsmsg(LTFS_WARN, 39810W);
 	} else
-		ltfsmsg(LTFS_WARN, "39811W", errno);
+		ltfsmsg(LTFS_WARN, 39811W, errno);
 
 	/* Return host name based key */
 	*key = KEY_PREFIX_HOST;
@@ -1310,21 +1310,21 @@ bool ibmtape_is_supported_firmware(int drive_type, const unsigned char * const r
 	case DRIVE_LTO5:
 	case DRIVE_LTO5_HH:
 		if (rev < ltfs_betou32(base_firmware_level_lto5)) {
-			ltfsmsg(LTFS_WARN, "39812W", base_firmware_level_lto5);
-			ltfsmsg(LTFS_WARN, "39813W");
+			ltfsmsg(LTFS_WARN, 39812W, base_firmware_level_lto5);
+			ltfsmsg(LTFS_WARN, 39813W);
 			supported = false;
 		}
 		break;
 	case DRIVE_LTO8:
 	case DRIVE_LTO8_HH:
 		if (rev < ltfs_betou32(base_firmware_level_lto8)) {
-			ltfsmsg(LTFS_WARN, "39812W", base_firmware_level_lto8);
+			ltfsmsg(LTFS_WARN, 39812W, base_firmware_level_lto8);
 			supported = false;
 		}
 		break;
 	case DRIVE_TS1140:
 		if (rev < ltfs_betou32(base_firmware_level_ts1140)) {
-			ltfsmsg(LTFS_WARN, "39812W", base_firmware_level_ts1140);
+			ltfsmsg(LTFS_WARN, 39812W, base_firmware_level_ts1140);
 			supported = false;
 		}
 		break;

--- a/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
+++ b/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
@@ -269,7 +269,7 @@ static inline int _lin_tape_ibmtape_get_sense(void *device, struct sioc_pass_thr
 	}
 	else {
 		rc = -EDEV_INTERNAL_ERROR;
-		ltfsmsg(LTFS_INFO, "30412I", rc);
+		ltfsmsg(LTFS_INFO, 30412I, rc);
 	}
 
 	return rc;
@@ -289,14 +289,14 @@ static inline int _sioc_paththrough(void *device, struct sioc_pass_through *spt)
 
 	ret = _ioctl(fd, SIOC_PASS_THROUGH, spt);
 	if (ret == -1) {
-		ltfsmsg(LTFS_INFO, "30400I", errno, ((struct lin_tape_ibmtape *) device)->drive_serial);
+		ltfsmsg(LTFS_INFO, 30400I, errno, ((struct lin_tape_ibmtape *) device)->drive_serial);
 		ret = -3;
 	}
 
 	/* check returned status */
 	if (spt->target_status || spt->msg_status || spt->host_status || spt->driver_status) {
 		if (!spt->sense_length) {
-			ltfsmsg(LTFS_DEBUG, "30401D", spt->target_status,
+			ltfsmsg(LTFS_DEBUG, 30401D, spt->target_status,
 					spt->msg_status, spt->host_status, spt->driver_status,
 					((struct lin_tape_ibmtape *) device)->drive_serial);
 			if(spt->driver_status & (DRIVER_SENSE | SUGGEST_SENSE))
@@ -304,13 +304,13 @@ static inline int _sioc_paththrough(void *device, struct sioc_pass_through *spt)
 		}
 
 		if (spt->sense_length) {
-			ltfsmsg(LTFS_DEBUG, "30402D", spt->sense[2] & 0x0F, spt->sense[12], spt->sense[13]);
-			ltfsmsg(LTFS_DEBUG, "30403D", spt->sense[45], spt->sense[46], spt->sense[47], spt->sense[48],
+			ltfsmsg(LTFS_DEBUG, 30402D, spt->sense[2] & 0x0F, spt->sense[12], spt->sense[13]);
+			ltfsmsg(LTFS_DEBUG, 30403D, spt->sense[45], spt->sense[46], spt->sense[47], spt->sense[48],
 					((struct lin_tape_ibmtape *) device)->drive_serial);
 			ret = -1;
 		} else {
-			ltfsmsg(LTFS_INFO, "30404I");
-			ltfsmsg(LTFS_INFO, "30405I", spt->target_status, spt->msg_status,
+			ltfsmsg(LTFS_INFO, 30404I);
+			ltfsmsg(LTFS_INFO, 30405I, spt->target_status, spt->msg_status,
 					spt->host_status, spt->driver_status, ((struct lin_tape_ibmtape *) device)->drive_serial);
 			if(spt->target_status)
 				ret = EDEV_TARGET_ERROR;
@@ -323,7 +323,7 @@ static inline int _sioc_paththrough(void *device, struct sioc_pass_through *spt)
 		}
 	} else if(ret == -3 && errno == EIO &&
 			(spt->cdb[0] == 0x0A || spt->cdb[0] == 0x10)) { /* EIO against write and writefm command */
-		ltfsmsg(LTFS_DEBUG, "30401D", spt->target_status,
+		ltfsmsg(LTFS_DEBUG, 30401D, spt->target_status,
 				spt->msg_status, spt->host_status, spt->driver_status,
 				((struct lin_tape_ibmtape *) device)->drive_serial);
 
@@ -336,13 +336,13 @@ static inline int _sioc_paththrough(void *device, struct sioc_pass_through *spt)
 		_lin_tape_ibmtape_get_sense(device, spt);
 
 		if (spt->sense_length) {
-			ltfsmsg(LTFS_DEBUG, "30402D", spt->sense[2] & 0x0F, spt->sense[12], spt->sense[13]);
-			ltfsmsg(LTFS_DEBUG, "30403D", spt->sense[45], spt->sense[46], spt->sense[47], spt->sense[48],
+			ltfsmsg(LTFS_DEBUG, 30402D, spt->sense[2] & 0x0F, spt->sense[12], spt->sense[13]);
+			ltfsmsg(LTFS_DEBUG, 30403D, spt->sense[45], spt->sense[46], spt->sense[47], spt->sense[48],
 					((struct lin_tape_ibmtape *) device)->drive_serial);
 			ret = -1;
 		} else {
-			ltfsmsg(LTFS_INFO, "30404I");
-			ltfsmsg(LTFS_INFO, "30405I", spt->target_status, spt->msg_status,
+			ltfsmsg(LTFS_INFO, 30404I);
+			ltfsmsg(LTFS_INFO, 30405I, spt->target_status, spt->msg_status,
 					spt->host_status, spt->driver_status, ((struct lin_tape_ibmtape *) device)->drive_serial);
 			if(spt->target_status)
 				ret = EDEV_TARGET_ERROR;
@@ -432,15 +432,15 @@ static inline int lin_tape_ibmtape_ioctlrc2err(void *device, int fd, struct requ
 
 	if (rc_sense == 0) {
 		if (!sense_data->err_code) {
-			ltfsmsg(LTFS_DEBUG, "30409D");
+			ltfsmsg(LTFS_DEBUG, 30409D);
 
 			if (msg)
 				*msg = "Driver Error";
 			rc = -EDEV_DRIVER_ERROR;
 		}
 		else {
-			ltfsmsg(LTFS_DEBUG, "30406D", sense_data->key, sense_data->asc, sense_data->ascq);
-			ltfsmsg(LTFS_DEBUG, "30407D", sense_data->vendor[27], sense_data->vendor[28], sense_data->vendor[29], sense_data->vendor[30],
+			ltfsmsg(LTFS_DEBUG, 30406D, sense_data->key, sense_data->asc, sense_data->ascq);
+			ltfsmsg(LTFS_DEBUG, 30407D, sense_data->vendor[27], sense_data->vendor[28], sense_data->vendor[29], sense_data->vendor[30],
 										((struct lin_tape_ibmtape *) device)->drive_serial);
 
 			sense += (uint32_t) sense_data->key << 16;
@@ -455,7 +455,7 @@ static inline int lin_tape_ibmtape_ioctlrc2err(void *device, int fd, struct requ
 		}
 	}
 	else {
-		ltfsmsg(LTFS_INFO, "30412I", rc_sense);
+		ltfsmsg(LTFS_INFO, 30412I, rc_sense);
 		if (msg)
 			*msg = "Cannot get sense information";
 
@@ -501,15 +501,15 @@ start:
 		rc = lin_tape_ibmtape_ioctlrc2err(device, fd, &sense_data, msg);
 
 		if (rc == -EDEV_TIME_STAMP_CHANGED) {
-			ltfsmsg(LTFS_DEBUG, "30411D", cmd_name, cmd, rc);
+			ltfsmsg(LTFS_DEBUG, 30411D, cmd_name, cmd, rc);
 			goto start;
 		}
 
 		if (is_expected_error(cmd, param, rc)) {
-			ltfsmsg(LTFS_DEBUG, "30410D", cmd_name, cmd, rc);
+			ltfsmsg(LTFS_DEBUG, 30410D, cmd_name, cmd, rc);
 		}
 		else {
-			ltfsmsg(LTFS_INFO, "30408I", cmd_name, cmd, rc, errno, ((struct lin_tape_ibmtape *) device)->drive_serial);
+			ltfsmsg(LTFS_INFO, 30408I, cmd_name, cmd, rc, errno, ((struct lin_tape_ibmtape *) device)->drive_serial);
 		}
 	}
 	else {
@@ -556,9 +556,9 @@ static inline void lin_tape_ibmtape_process_errors(void *device, int rc, char *m
 	bool nonforced_dump = false;
 
 	if(msg != NULL)
-		ltfsmsg(LTFS_INFO, "30413I", cmd, msg, rc, priv->drive_serial);
+		ltfsmsg(LTFS_INFO, 30413I, cmd, msg, rc, priv->drive_serial);
 	else
-		ltfsmsg(LTFS_ERR, "30414E", cmd, rc, priv->drive_serial);
+		ltfsmsg(LTFS_ERR, 30414E, cmd, rc, priv->drive_serial);
 
 	if (device) {
 		priv = (struct lin_tape_ibmtape *) device;
@@ -585,12 +585,12 @@ int lin_tape_ibmtape_check_lin_tape_version(void)
 	fd_version = open("/sys/module/lin_tape/version", O_RDONLY);
 
 	if (fd_version == -1) {
-		ltfsmsg(LTFS_WARN, "30415W");
+		ltfsmsg(LTFS_WARN, 30415W);
 	} else {
 		read(fd_version, lin_tape_version, sizeof(lin_tape_version));
 		if ((tmp = strchr(lin_tape_version, '\n')) != NULL)
 			*tmp = '\0';
-		ltfsmsg(LTFS_INFO, "30416I", lin_tape_version);
+		ltfsmsg(LTFS_INFO, 30416I, lin_tape_version);
 		close(fd_version);
 	}
 
@@ -601,7 +601,7 @@ int lin_tape_ibmtape_check_lin_tape_version(void)
 		|| (version_num[0] < version_base[0])
 		|| (version_num[0] == version_base[0] && version_num[1] < version_base[1])
 		|| (version_num[0] == version_base[0] && version_num[1] == version_base[1] && version_num[2] < version_base[2])) {
-		ltfsmsg(LTFS_ERR, "30417E");
+		ltfsmsg(LTFS_ERR, 30417E);
 		return -EDEV_DRIVER_ERROR;
 	}
 
@@ -622,7 +622,7 @@ int lin_tape_ibmtape_test_unit_ready(void *device)
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_TUR));
-	ltfsmsg(LTFS_DEBUG3, "30592D", "test unit ready",
+	ltfsmsg(LTFS_DEBUG3, 30592D, "test unit ready",
 			((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	rc = _sioc_stioc_command(device, SIOC_TEST_UNIT_READY, "TEST UNIT READY", NULL, &msg);
@@ -666,7 +666,7 @@ int lin_tape_ibmtape_reserve_unit(void *device)
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_RESERVEUNIT));
-	ltfsmsg(LTFS_DEBUG, "30592D", "reserve unit (6)", ((struct lin_tape_ibmtape *) device)->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30592D, "reserve unit (6)", ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	rc = _sioc_stioc_command(device, SIOC_RESERVE, "RESERVE", NULL, &msg);
 
@@ -691,7 +691,7 @@ int lin_tape_ibmtape_release_unit(void *device)
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_RELEASEUNIT));
-	ltfsmsg(LTFS_DEBUG, "30592D", "release unit (6)", ((struct lin_tape_ibmtape *) device)->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30592D, "release unit (6)", ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	/* Invoke _ioctl to Release Unit */
 	rc = _sioc_stioc_command(device, SIOC_RELEASE, "RELEASE", NULL, &msg);
@@ -729,7 +729,7 @@ int lin_tape_ibmtape_get_serialnumber(void *device, char **result)
 
 	*result = strdup((const char *) priv->drive_serial);
 	if (! *result) {
-		ltfsmsg(LTFS_ERR, "10001E", "lin_tape_ibmtape_get_serialnumber: result");
+		ltfsmsg(LTFS_ERR, 10001E, "lin_tape_ibmtape_get_serialnumber: result");
 		ltfs_profiler_add_entry(priv->profiler, NULL, CHANGER_REQ_EXIT(REQ_TC_GETSER));
 		return -EDEV_NO_MEMORY;
 	}
@@ -763,7 +763,7 @@ int lin_tape_ibmtape_set_profiler(void *device, char *work_dir, bool enable)
 		rc = asprintf(&path, "%s/%s%s%s", work_dir, DRIVER_PROFILER_BASE,
 					   priv->drive_serial, PROFILER_EXTENSION);
 		if (rc < 0) {
-			ltfsmsg(LTFS_ERR, "10001E", __FILE__);
+			ltfsmsg(LTFS_ERR, 10001E, __FILE__);
 			return -LTFS_NO_MEMORY;
 		}
 
@@ -813,7 +813,7 @@ int parse_logPage(const unsigned char *logdata, const uint16_t param, int *param
 		if (param_code == param) {
 			*param_size = param_len;
 			if (bufsize < param_len) {
-				ltfsmsg(LTFS_INFO, "30418I", bufsize, i + LOG_PAGE_PARAM_OFFSET);
+				ltfsmsg(LTFS_INFO, 30418I, bufsize, i + LOG_PAGE_PARAM_OFFSET);
 				memcpy(buf, &logdata[i + LOG_PAGE_PARAM_OFFSET], bufsize);
 				return -2;
 			}
@@ -857,7 +857,7 @@ int lin_tape_ibmtape_parse_opts(void *device, void *opt_args)
 	/* fuse_opt_parse can handle a NULL device parameter just fine */
 	ret = fuse_opt_parse(args, &global_data, lin_tape_ibmtape_global_opts, null_parser);
 	if (ret < 0) {
-		ltfsmsg(LTFS_INFO, "30419I", ret);
+		ltfsmsg(LTFS_INFO, 30419I, ret);
 		return ret;
 	}
 
@@ -868,7 +868,7 @@ int lin_tape_ibmtape_parse_opts(void *device, void *opt_args)
 		else if (strcasecmp(global_data.str_crc_checking, "off") == 0)
 			global_data.crc_checking = 0;
 		else {
-			ltfsmsg(LTFS_ERR, "30420E", global_data.str_crc_checking);
+			ltfsmsg(LTFS_ERR, 30420E, global_data.str_crc_checking);
 			return -EINVAL;
 		}
 	} else
@@ -893,7 +893,7 @@ int _lin_tape_ibmtape_inquiry_page(void *device, unsigned char page, struct tc_i
 	if (!inq)
 		return -EDEV_INVALID_ARG;
 
-	ltfsmsg(LTFS_DEBUG, "30593D", "inquiry", page, ((struct lin_tape_ibmtape *) device)->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30593D, "inquiry", page, ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	/* init value */
 	memset(inq_page.data, 0, sizeof(inq_page.data));
@@ -984,11 +984,11 @@ int lin_tape_ibmtape_open(const char *devname, void **handle)
 		return ret;
 	}
 
-	ltfsmsg(LTFS_INFO, "30423I", devname);
+	ltfsmsg(LTFS_INFO, 30423I, devname);
 
 	priv = calloc(1, sizeof(struct lin_tape_ibmtape));
 	if (! priv) {
-		ltfsmsg(LTFS_ERR, "10001E", "lin_tape_ibmtape_open: device private data");
+		ltfsmsg(LTFS_ERR, 10001E, "lin_tape_ibmtape_open: device private data");
 		return -EDEV_NO_MEMORY;
 	}
 
@@ -997,27 +997,27 @@ int lin_tape_ibmtape_open(const char *devname, void **handle)
 		priv->fd = open(devname, O_RDONLY | O_NDELAY);
 		if (priv->fd < 0) {
 			if (errno == EAGAIN) {
-				ltfsmsg(LTFS_ERR, "30424E", devname);
+				ltfsmsg(LTFS_ERR, 30424E, devname);
 				ret = -EDEV_DEVICE_BUSY;
 			} else {
-				ltfsmsg(LTFS_INFO, "30425I", devname, errno);
+				ltfsmsg(LTFS_INFO, 30425I, devname, errno);
 				ret = -EDEV_DEVICE_UNOPENABLE;
 			}
 			free(priv);
 			return ret;
 		}
-		ltfsmsg(LTFS_WARN, "30426W", devname);
+		ltfsmsg(LTFS_WARN, 30426W, devname);
 	}
 
 	ret = lin_tape_ibmtape_inquiry(priv, &inq_data);
 	if (ret) {
-		ltfsmsg(LTFS_INFO, "30427I", ret);
+		ltfsmsg(LTFS_INFO, 30427I, ret);
 		close(priv->fd);
 		free(priv);
 		return ret;
 	} else {
-		ltfsmsg(LTFS_INFO, "30428I", inq_data.pid);
-		ltfsmsg(LTFS_INFO, "30429I", inq_data.vid);
+		ltfsmsg(LTFS_INFO, 30428I, inq_data.pid);
+		ltfsmsg(LTFS_INFO, 30429I, inq_data.vid);
 
 		/* Check the drive is supportable */
 		struct supported_device **cur = ibm_supported_drives;
@@ -1040,7 +1040,7 @@ int lin_tape_ibmtape_open(const char *devname, void **handle)
 			/* Set specific timeout value based on drive type */
 			ibm_tape_init_timeout(&priv->timeouts, priv->drive_type);
 		} else {
-			ltfsmsg(LTFS_INFO, "30430I", inq_data.pid);
+			ltfsmsg(LTFS_INFO, 30430I, inq_data.pid);
 			close(priv->fd);
 			free(priv);
 			return -EDEV_DEVICE_UNSUPPORTABLE;
@@ -1050,7 +1050,7 @@ int lin_tape_ibmtape_open(const char *devname, void **handle)
 	memset(&inq_page_data, 0, sizeof(struct tc_inq_page));
 	ret = lin_tape_ibmtape_inquiry_page(priv, TC_INQ_PAGE_DRVSERIAL, &inq_page_data);
 	if (ret) {
-		ltfsmsg(LTFS_INFO, "30431I", TC_INQ_PAGE_DRVSERIAL, ret);
+		ltfsmsg(LTFS_INFO, 30431I, TC_INQ_PAGE_DRVSERIAL, ret);
 		close(priv->fd);
 		free(priv);
 		return ret;
@@ -1064,15 +1064,15 @@ int lin_tape_ibmtape_open(const char *devname, void **handle)
 		priv->drive_serial[i - 4] = inq_page_data.data[i];
 	}
 
-	ltfsmsg(LTFS_INFO, "30432I", inq_data.revision);
+	ltfsmsg(LTFS_INFO, 30432I, inq_data.revision);
 	if (! ibmtape_is_supported_firmware(priv->drive_type, (unsigned char*)inq_data.revision)) {
-		ltfsmsg(LTFS_INFO, "30430I", "firmware");
+		ltfsmsg(LTFS_INFO, 30430I, "firmware");
 		close(priv->fd);
 		free(priv);
 		return -EDEV_UNSUPPORTED_FIRMWARE;
 	}
 
-	ltfsmsg(LTFS_INFO, "30433I", priv->drive_serial);
+	ltfsmsg(LTFS_INFO, 30433I, priv->drive_serial);
 
 	priv->loaded = false; /* Assume tape is not loaded until a successful load call. */
 	priv->devname = strdup(devname);
@@ -1181,10 +1181,10 @@ start:
 	if (rc != 0) {
 		rc = lin_tape_ibmtape_ioctlrc2err(device, fd, &sense_data, msg);
 		if (rc == -EDEV_TIME_STAMP_CHANGED) {
-			ltfsmsg(LTFS_DEBUG, "30411D", cmd_name, cmd, rc);
+			ltfsmsg(LTFS_DEBUG, 30411D, cmd_name, cmd, rc);
 			goto start;
 		}
-		ltfsmsg(LTFS_INFO, "30408I", cmd_name, cmd, rc, errno, ((struct lin_tape_ibmtape *) device)->drive_serial);
+		ltfsmsg(LTFS_INFO, 30408I, cmd_name, cmd, rc, errno, ((struct lin_tape_ibmtape *) device)->drive_serial);
 	}
 	else {
 		*msg = "Command succeeded";
@@ -1207,10 +1207,10 @@ start:
 	if (rc != 0) {
 		rc = lin_tape_ibmtape_ioctlrc2err(device, fd, &sense_data, msg);
 		if (rc == -EDEV_TIME_STAMP_CHANGED) {
-			ltfsmsg(LTFS_DEBUG, "30411D", cmd_name, cmd, rc);
+			ltfsmsg(LTFS_DEBUG, 30411D, cmd_name, cmd, rc);
 			goto start;
 		}
-		ltfsmsg(LTFS_INFO, "30408I", cmd_name, cmd, rc, errno, ((struct lin_tape_ibmtape *) device)->drive_serial);
+		ltfsmsg(LTFS_INFO, 30408I, cmd_name, cmd, rc, errno, ((struct lin_tape_ibmtape *) device)->drive_serial);
 	}
 	else {
 		*msg = "Command succeeded";
@@ -1247,12 +1247,12 @@ int lin_tape_ibmtape_read(void *device, char *buf, size_t count, struct tc_posit
 	 */
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_READ));
-	ltfsmsg(LTFS_DEBUG3, "30595D", "read", count, ((struct lin_tape_ibmtape *) device)->drive_serial);
+	ltfsmsg(LTFS_DEBUG3, 30595D, "read", count, ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	if (priv->force_readperm) {
 		priv->read_counter++;
 		if (priv->read_counter > priv->force_readperm) {
-			ltfsmsg(LTFS_INFO, "30434I", "read");
+			ltfsmsg(LTFS_INFO, 30434I, "read");
 			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_READ));
 			if (priv->force_errortype)
 				return -EDEV_NO_SENSE;
@@ -1278,7 +1278,7 @@ int lin_tape_ibmtape_read(void *device, char *buf, size_t count, struct tc_posit
 		case -EDEV_NO_SENSE:
 			if (sense_data.fm) {
 				/* Filemark Detected */
-				ltfsmsg(LTFS_DEBUG, "30436D");
+				ltfsmsg(LTFS_DEBUG, 30436D);
 				rc = DEVICE_GOOD;
 				pos->block++;
 				pos->filemarks++;
@@ -1291,29 +1291,29 @@ int lin_tape_ibmtape_read(void *device, char *buf, size_t count, struct tc_posit
 				diff_len = (int32_t)sense_data.info;
 
 				if (diff_len < 0) {
-					ltfsmsg(LTFS_INFO, "30437I", diff_len, count - diff_len); // "Detect overrun condition"
+					ltfsmsg(LTFS_INFO, 30437I, diff_len, (int)count - diff_len); // "Detect overrun condition"
 					rc = -EDEV_OVERRUN;
 				}
 				else {
-					ltfsmsg(LTFS_DEBUG, "30438D", diff_len, count - diff_len); // "Detect underrun condition"
+					ltfsmsg(LTFS_DEBUG, 30438D, diff_len, (int)count - diff_len); // "Detect underrun condition"
 					len = count - diff_len;
 					rc = DEVICE_GOOD;
 					pos->block++;
 				}
 			}
 			else if (errno == EOVERFLOW) {
-				ltfsmsg(LTFS_INFO, "30437I", count - read_len, read_len); // "Detect overrun condition"
+				ltfsmsg(LTFS_INFO, 30437I, (int)(count - read_len), (int)read_len); // "Detect overrun condition"
 				rc = -EDEV_OVERRUN;
 			}
 			else if ((size_t)read_len < count) {
-				ltfsmsg(LTFS_DEBUG, "30438D", count - read_len, read_len); // "Detect underrun condition"
+				ltfsmsg(LTFS_DEBUG, 30438D, (int)(count - read_len), (int)read_len); // "Detect underrun condition"
 				len = read_len;
 				rc = DEVICE_GOOD;
 				pos->block++;
 			}
 			break;
 		case -EDEV_FILEMARK_DETECTED:
-			ltfsmsg(LTFS_DEBUG, "30436D");
+			ltfsmsg(LTFS_DEBUG, 30436D);
 			rc = DEVICE_GOOD;
 			pos->block++;
 			pos->filemarks++;
@@ -1323,7 +1323,7 @@ int lin_tape_ibmtape_read(void *device, char *buf, size_t count, struct tc_posit
 
 		if (rc != DEVICE_GOOD) {
 			if ((rc != -EDEV_CRYPTO_ERROR && rc != -EDEV_KEY_REQUIRED) || ((struct lin_tape_ibmtape *) device)->is_data_key_set) {
-				ltfsmsg(LTFS_INFO, "30408I", "READ", count, rc, errno, ((struct lin_tape_ibmtape *) device)->drive_serial);
+				ltfsmsg(LTFS_INFO, 30408I, "READ", (int)count, rc, errno, ((struct lin_tape_ibmtape *) device)->drive_serial);
 				lin_tape_ibmtape_process_errors(device, rc, msg, "read", true);
 			}
 			len = rc;
@@ -1338,7 +1338,7 @@ int lin_tape_ibmtape_read(void *device, char *buf, size_t count, struct tc_posit
 		if (priv->f_crc_check)
 			len = priv->f_crc_check(buf, len - 4);
 		if (len < 0) {
-			ltfsmsg(LTFS_ERR, "30439E");
+			ltfsmsg(LTFS_ERR, 30439E);
 			len = -EDEV_LBP_READ_ERROR;
 		}
 	}
@@ -1355,33 +1355,33 @@ static inline int _handle_block_allocation_failure(void *device, struct tc_posit
     struct tc_position tmp_pos = {0, 0};
 
     /* Sleep 3 secs to wait garbage correction in kernel side and retry */
-    ltfsmsg(LTFS_WARN, "30440W", ++(*retry));
+    ltfsmsg(LTFS_WARN, 30440W, ++(*retry));
     sleep(3);
 
     ret = lin_tape_ibmtape_readpos(device, &tmp_pos);
     if (ret == DEVICE_GOOD && pos->partition == tmp_pos.partition) {
         if (pos->block == tmp_pos.block) {
             /* No record was written on the tape */
-            ltfsmsg(LTFS_INFO, "30441I", (unsigned long) tmp_pos.partition, (unsigned long long)tmp_pos.block);
+            ltfsmsg(LTFS_INFO, 30441I, (unsigned int)tmp_pos.partition, (unsigned long long)tmp_pos.block);
             ret = WRITE_RETRY;
         } else if (pos->block == tmp_pos.block - 1) {
             /* The record was written on the tape */
-            ltfsmsg(LTFS_INFO, "30442I",
-                    (unsigned long)pos->partition, (unsigned long long)pos->block,
-                    (unsigned long)tmp_pos.partition, (unsigned long long)tmp_pos.block);
+            ltfsmsg(LTFS_INFO, 30442I,
+                    (unsigned int)pos->partition, (unsigned long long)pos->block,
+                    (unsigned int)tmp_pos.partition, (unsigned long long)tmp_pos.block);
             ret = DEVICE_GOOD;
             pos->block++;
         } else {
             /* Unexpected position */
-            ltfsmsg(LTFS_WARN, "30443W", ret,
-                    (unsigned long)pos->partition, (unsigned long long)pos->block,
-                    (unsigned long)tmp_pos.partition, (unsigned long long)tmp_pos.block);
+            ltfsmsg(LTFS_WARN, 30443W, ret,
+                    (unsigned int)pos->partition, (unsigned long long)pos->block,
+                    (unsigned int)tmp_pos.partition, (unsigned long long)tmp_pos.block);
             ret = -EDEV_NO_MEMORY;
         }
     } else
-        ltfsmsg(LTFS_WARN, "30444W", ret,
-                (unsigned long)pos->partition, (unsigned long long)pos->block,
-                (unsigned long)tmp_pos.partition, (unsigned long long)tmp_pos.block);
+        ltfsmsg(LTFS_WARN, 30444W, ret,
+                (unsigned int)pos->partition, (unsigned long long)pos->block,
+                (unsigned int)tmp_pos.partition, (unsigned long long)tmp_pos.block);
 
     return ret;
 }
@@ -1415,19 +1415,19 @@ int lin_tape_ibmtape_write(void *device, const char *buf, size_t count, struct t
 	 */
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_WRITE));
-	ltfsmsg(LTFS_DEBUG3, "30595D", "write", count, ((struct lin_tape_ibmtape *) device)->drive_serial);
+	ltfsmsg(LTFS_DEBUG3, 30595D, "write", count, ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	if ( priv->force_writeperm ) {
 		priv->write_counter++;
 		if ( priv->write_counter > priv->force_writeperm ) {
-			ltfsmsg(LTFS_INFO, "30434I", "write");
+			ltfsmsg(LTFS_INFO, 30434I, "write");
 			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_WRITE));
 			if (priv->force_errortype)
 				return -EDEV_NO_SENSE;
 			else
 				return -EDEV_WRITE_PERM;
 		} else if ( priv->write_counter > (priv->force_writeperm - THREASHOLD_FORCE_WRITE_NO_WRITE) ) {
-			ltfsmsg(LTFS_INFO, "30435I");
+			ltfsmsg(LTFS_INFO, 30435I);
 			pos->block++;
 			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_WRITE));
 			return DEVICE_GOOD;
@@ -1445,15 +1445,15 @@ int lin_tape_ibmtape_write(void *device, const char *buf, size_t count, struct t
 write_start:
 	written = write(fd, buf, datacount);
 	if ((size_t)written != datacount || errno == ENOSPC) {
-		ltfsmsg(LTFS_INFO, "30408I", "WRITE", count, written, errno, ((struct lin_tape_ibmtape *) device)->drive_serial);
+		ltfsmsg(LTFS_INFO, 30408I, "WRITE", (int)count, (int)written, errno, ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 		if (errno == ENOSPC) {
 			lin_tape_ibmtape_readpos(device, pos);
 			if (pos->early_warning) {
-				ltfsmsg(LTFS_WARN, "30445W", "write");
+				ltfsmsg(LTFS_WARN, 30445W, "write");
 				rc = DEVICE_GOOD;
 			} else if (pos->programmable_early_warning) {
-				ltfsmsg(LTFS_WARN, "30446W", "write");
+				ltfsmsg(LTFS_WARN, 30446W, "write");
 				rc = DEVICE_GOOD;
 			}
 		} else if (errno == ENOMEM && retry < MAX_WRITE_RETRY) {
@@ -1468,13 +1468,13 @@ write_start:
 
 			switch (rc) {
 			case -EDEV_EARLY_WARNING:
-				ltfsmsg(LTFS_WARN, "30445W", "write");
+				ltfsmsg(LTFS_WARN, 30445W, "write");
 				rc = DEVICE_GOOD;
 				lin_tape_ibmtape_readpos(device, pos);
 				pos->early_warning = true;
 				break;
 			case -EDEV_PROG_EARLY_WARNING:
-				ltfsmsg(LTFS_WARN, "30446W", "write");
+				ltfsmsg(LTFS_WARN, 30446W, "write");
 				rc = DEVICE_GOOD;
 				lin_tape_ibmtape_readpos(device, pos);
 				pos->programmable_early_warning = true;
@@ -1495,7 +1495,7 @@ write_start:
 			lin_tape_ibmtape_process_errors(device, rc, msg, "write", true);
 
 		if (rc == -EDEV_LBP_WRITE_ERROR)
-			ltfsmsg(LTFS_ERR, "30447E");
+			ltfsmsg(LTFS_ERR, 30447E);
 	} else {
 		rc = DEVICE_GOOD;
 		pos->block++;
@@ -1524,7 +1524,7 @@ int lin_tape_ibmtape_writefm(void *device, size_t count, struct tc_position *pos
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_WRITEFM));
-	ltfsmsg(LTFS_DEBUG, "30596D", "writefm", count, ((struct lin_tape_ibmtape *) device)->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30596D, "writefm", count, ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 start_wfm:
 	errno = 0;
@@ -1534,12 +1534,12 @@ start_wfm:
 	if (rc != DEVICE_GOOD) {
 		switch (rc) {
 		case -EDEV_EARLY_WARNING:
-			ltfsmsg(LTFS_WARN, "30445W", "writefm");
+			ltfsmsg(LTFS_WARN, 30445W, "writefm");
 			rc = DEVICE_GOOD;
 			pos->early_warning = true;
 			break;
 		case -EDEV_PROG_EARLY_WARNING:
-			ltfsmsg(LTFS_WARN, "30446W", "writefm");
+			ltfsmsg(LTFS_WARN, 30446W, "writefm");
 			rc = DEVICE_GOOD;
 			pos->programmable_early_warning = true;
 			break;
@@ -1556,11 +1556,11 @@ start_wfm:
 			break;
 		default:
 			if (pos->early_warning) {
-				ltfsmsg(LTFS_WARN, "30445W", "writefm");
+				ltfsmsg(LTFS_WARN, 30445W, "writefm");
 				rc = DEVICE_GOOD;
 			}
 			if (pos->programmable_early_warning) {
-				ltfsmsg(LTFS_WARN, "30446W", "writefm");
+				ltfsmsg(LTFS_WARN, 30446W, "writefm");
 				rc = DEVICE_GOOD;
 			}
 			break;
@@ -1571,11 +1571,11 @@ start_wfm:
 		}
 	} else {
 		if (pos->early_warning) {
-			ltfsmsg(LTFS_WARN, "30445W", "writefm");
+			ltfsmsg(LTFS_WARN, 30445W, "writefm");
 			rc = DEVICE_GOOD;
 		}
 		if (pos->programmable_early_warning) {
-			ltfsmsg(LTFS_WARN, "30446W", "writefm");
+			ltfsmsg(LTFS_WARN, 30446W, "writefm");
 			rc = DEVICE_GOOD;
 		}
 	}
@@ -1597,7 +1597,7 @@ int lin_tape_ibmtape_rewind(void *device, struct tc_position *pos)
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_REWIND));
-	ltfsmsg(LTFS_DEBUG, "30592D", "rewind", ((struct lin_tape_ibmtape *) device)->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30592D, "rewind", ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	rc = _mt_command(device, MTREW, "REWIND", 0, &msg);
 	lin_tape_ibmtape_readpos(device, pos);
@@ -1631,7 +1631,7 @@ int lin_tape_ibmtape_locate(void *device, struct tc_position dest, struct tc_pos
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOCATE));
-	ltfsmsg(LTFS_DEBUG, "30597D", "locate", (unsigned long long)dest.partition,
+	ltfsmsg(LTFS_DEBUG, 30597D, "locate", (unsigned long long)dest.partition,
 		(unsigned long long)dest.block, ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	if (pos->partition != dest.partition) {
@@ -1656,7 +1656,7 @@ int lin_tape_ibmtape_locate(void *device, struct tc_position dest, struct tc_pos
 
 	if (rc != DEVICE_GOOD) {
 		if ((unsigned long long)dest.block == TAPE_BLOCK_MAX && rc == -EDEV_EOD_DETECTED) {
-			ltfsmsg(LTFS_DEBUG, "30448D", "Locate");
+			ltfsmsg(LTFS_DEBUG, 30448D, "Locate");
 			rc = DEVICE_GOOD;
 		}
 
@@ -1688,40 +1688,40 @@ int lin_tape_ibmtape_space(void *device, size_t count, TC_SPACE_TYPE type, struc
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_SPACE));
 	switch (type) {
 		case TC_SPACE_EOD:
-			ltfsmsg(LTFS_DEBUG, "30592D", "space to EOD", ((struct lin_tape_ibmtape *) device)->drive_serial);
+			ltfsmsg(LTFS_DEBUG, 30592D, "space to EOD", ((struct lin_tape_ibmtape *) device)->drive_serial);
 			cmd = MTEOM;
 			count = 0;
 			break;
 		case TC_SPACE_FM_F:
-			ltfsmsg(LTFS_DEBUG, "30594D", "space forward file marks", (unsigned long long)count,
+			ltfsmsg(LTFS_DEBUG, 30594D, "space forward file marks", (unsigned long long)count,
 					((struct lin_tape_ibmtape *) device)->drive_serial);
 			cmd = MTFSF;
 			break;
 		case TC_SPACE_FM_B:
-			ltfsmsg(LTFS_DEBUG, "30594D", "space back file marks", (unsigned long long)count,
+			ltfsmsg(LTFS_DEBUG, 30594D, "space back file marks", (unsigned long long)count,
 					((struct lin_tape_ibmtape *) device)->drive_serial);
 			cmd = MTBSF;
 			break;
 		case TC_SPACE_F:
-			ltfsmsg(LTFS_DEBUG, "30594D", "space forward records", (unsigned long long)count,
+			ltfsmsg(LTFS_DEBUG, 30594D, "space forward records", (unsigned long long)count,
 					((struct lin_tape_ibmtape *) device)->drive_serial);
 			cmd = MTFSR;
 			break;
 		case TC_SPACE_B:
-			ltfsmsg(LTFS_DEBUG, "30594D", "space back records", (unsigned long long)count,
+			ltfsmsg(LTFS_DEBUG, 30594D, "space back records", (unsigned long long)count,
 					((struct lin_tape_ibmtape *) device)->drive_serial);
 			cmd = MTBSR;
 			break;
 		default:
 			/* unexpected space type */
-			ltfsmsg(LTFS_INFO, "30449I");
+			ltfsmsg(LTFS_INFO, 30449I);
 			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SPACE));
 			return EDEV_INVALID_ARG;
 	}
 
 	if ((unsigned long long)count > 0xFFFFFF) {
 		/* count is too large for SPACE 6 command */
-		ltfsmsg(LTFS_INFO, "30450I", count);
+		ltfsmsg(LTFS_INFO, 30450I, (int)count);
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SPACE));
 		return EDEV_INVALID_ARG;
 	}
@@ -1796,12 +1796,12 @@ int lin_tape_ibmtape_erase(void *device, struct tc_position *pos, bool long_eras
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_ERASE));
 	if (long_erase) {
-		ltfsmsg(LTFS_DEBUG, "30592D", "long erase", ((struct lin_tape_ibmtape *) device)->drive_serial);
+		ltfsmsg(LTFS_DEBUG, 30592D, "long erase", ((struct lin_tape_ibmtape *) device)->drive_serial);
 		get_current_timespec(&ts_start);
 
 		rc = lin_tape_ibmtape_long_erase(device);
 		if (rc == -EDEV_TIME_STAMP_CHANGED) {
-			ltfsmsg(LTFS_DEBUG, "30411D", "erase", -1, rc);
+			ltfsmsg(LTFS_DEBUG, 30411D, "erase", -1, rc);
 			rc = lin_tape_ibmtape_long_erase(device);
 		}
 
@@ -1817,19 +1817,19 @@ int lin_tape_ibmtape_erase(void *device, struct tc_position *pos, bool long_eras
 
 			if (IS_ENTERPRISE(priv->drive_type)) {
 				get_current_timespec(&ts_now);
-				ltfsmsg(LTFS_INFO, "30451I", (ts_now.tv_sec - ts_start.tv_sec)/60);
+				ltfsmsg(LTFS_INFO, 30451I, (int)(ts_now.tv_sec - ts_start.tv_sec)/60);
 			}
 			else {
 				progress = (int)(sense_data.field[0] & 0xFF)<<8;
 				progress += (int)(sense_data.field[1] & 0xFF);
-				ltfsmsg(LTFS_INFO, "30452I", progress*100/0xFFFF);
+				ltfsmsg(LTFS_INFO, 30452I, progress*100/0xFFFF);
 			}
 			sleep(60);
 		}
 
 	}
 	else {
-		ltfsmsg(LTFS_DEBUG, "30592D", "erase", ((struct lin_tape_ibmtape *) device)->drive_serial);
+		ltfsmsg(LTFS_DEBUG, 30592D, "erase", ((struct lin_tape_ibmtape *) device)->drive_serial);
 		rc = _st_command(device, STERASE, "ERASE", 1, &msg);	// param=1 means invoking short erase.
 	}
 
@@ -1907,7 +1907,7 @@ int lin_tape_ibmtape_load(void *device, struct tc_position *pos)
 	struct lin_tape_ibmtape *priv = ((struct lin_tape_ibmtape *) device);
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOAD));
-	ltfsmsg(LTFS_DEBUG, "30592D", "load", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30592D, "load", priv->drive_serial);
 
 	memset(buf, 0, sizeof(buf));
 
@@ -1935,14 +1935,14 @@ int lin_tape_ibmtape_load(void *device, struct tc_position *pos)
 	priv->density_code = buf[8];
 
 	if (priv->cart_type == 0x00) {
-		ltfsmsg(LTFS_WARN, "30453W");
+		ltfsmsg(LTFS_WARN, 30453W);
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOAD));
 		return 0;
 	}
 
 	rc = ibmtape_is_supported_tape(priv->cart_type, priv->density_code, &(priv->is_worm));
 	if(rc == -LTFS_UNSUPPORTED_MEDIUM)
-		ltfsmsg(LTFS_INFO, "30455I", priv->cart_type, priv->density_code);
+		ltfsmsg(LTFS_INFO, 30455I, priv->cart_type, priv->density_code);
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOAD));
 	return rc;
@@ -1960,7 +1960,7 @@ int lin_tape_ibmtape_unload(void *device, struct tc_position *pos)
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_UNLOAD));
-	ltfsmsg(LTFS_DEBUG, "30592D", "unload", ((struct lin_tape_ibmtape *) device)->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30592D, "unload", ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	rc = _lin_tape_ibmtape_load_unload(device, false, pos);
 
@@ -2032,7 +2032,7 @@ int lin_tape_ibmtape_readpos(void *device, struct tc_position *pos)
 		pos->block = ltfs_betou64(rp.rp_data.rp_long.logical_obj_number);
 		pos->filemarks = ltfs_betou64(rp.rp_data.rp_long.logical_file_id);
 
-		ltfsmsg(LTFS_DEBUG, "30598D", "readpos", (unsigned long long)pos->partition,
+		ltfsmsg(LTFS_DEBUG, 30598D, "readpos", (unsigned long long)pos->partition,
 				(unsigned long long)pos->block, (unsigned long long)pos->filemarks,
 				((struct lin_tape_ibmtape *) device)->drive_serial);
 	}
@@ -2061,10 +2061,10 @@ int lin_tape_ibmtape_format(void *device, TC_FORMAT_TYPE format)
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_FORMAT));
-	ltfsmsg(LTFS_DEBUG, "30592D", "format", ((struct lin_tape_ibmtape *) device)->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30592D, "format", ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	if ((unsigned char) format >= (unsigned char) TC_FORMAT_MAX) {
-		ltfsmsg(LTFS_INFO, "30456I", format);
+		ltfsmsg(LTFS_INFO, 30456I, format);
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_FORMAT));
 		return -1;
 	}
@@ -2125,7 +2125,7 @@ int lin_tape_ibmtape_logsense_page(void *device, const uint8_t page, const uint8
 	char *msg;
 	struct log_sense10_page log_page;
 
-	ltfsmsg(LTFS_DEBUG3, "30597D", "logsense", (unsigned long long)page, (unsigned long long)subpage,
+	ltfsmsg(LTFS_DEBUG3, 30597D, "logsense", (unsigned long long)page, (unsigned long long)subpage,
 			((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	log_page.page_code = page;
@@ -2181,7 +2181,7 @@ int lin_tape_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *c
 		/* Issue LogPage 0x31 */
 		rc = lin_tape_ibmtape_logsense(device, LOG_TAPECAPACITY, logdata, LOGSENSEPAGE);
 		if (rc) {
-			ltfsmsg(LTFS_INFO, "30457I", LOG_TAPECAPACITY, rc);
+			ltfsmsg(LTFS_INFO, 30457I, LOG_TAPECAPACITY, rc);
 			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REMAINCAP));
 			return rc;
 		}
@@ -2189,7 +2189,7 @@ int lin_tape_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *c
 		for(i = TAPECAP_REMAIN_0; i < TAPECAP_SIZE; i++) {
 			if (parse_logPage(logdata, (uint16_t) i, &param_size, buf, sizeof(buf))
 				|| param_size != sizeof(uint32_t)) {
-				ltfsmsg(LTFS_INFO, "30458I");
+				ltfsmsg(LTFS_INFO, 30458I);
 				ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REMAINCAP));
 				return -EDEV_NO_MEMORY;
 			}
@@ -2210,7 +2210,7 @@ int lin_tape_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *c
 				cap->max_p1 = logcap;
 				break;
 			default:
-				ltfsmsg(LTFS_INFO, "30459I", i);
+				ltfsmsg(LTFS_INFO, 30459I, i);
 				ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REMAINCAP));
 				return -EDEV_INVALID_ARG;
 				break;
@@ -2221,14 +2221,14 @@ int lin_tape_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *c
 		/* Issue LogPage 0x17 */
 		rc = lin_tape_ibmtape_logsense(device, LOG_VOLUMESTATS, logdata, LOGSENSEPAGE);
 		if (rc) {
-			ltfsmsg(LTFS_INFO, "30457I", LOG_VOLUMESTATS, rc);
+			ltfsmsg(LTFS_INFO, 30457I, LOG_VOLUMESTATS, rc);
 			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REMAINCAP));
 			return rc;
 		}
 
 		/* parse param 0x202 - nominal capacity of the partitions */
 		if (parse_logPage(logdata, (uint16_t)VOLSTATS_PARTITION_CAP, &param_size, buf, sizeof(buf))) {
-			ltfsmsg(LTFS_INFO, "30458I");
+			ltfsmsg(LTFS_INFO, 30458I);
 			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REMAINCAP));
 			return -EDEV_NO_MEMORY;
 		}
@@ -2245,7 +2245,7 @@ int lin_tape_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *c
 
 		/* parse param 0x204 - remaining capacity of the partitions */
 		if (parse_logPage(logdata, (uint16_t)VOLSTATS_PART_REMAIN_CAP, &param_size, buf, sizeof(buf))) {
-			ltfsmsg(LTFS_INFO, "30458I");
+			ltfsmsg(LTFS_INFO, 30458I);
 			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REMAINCAP));
 			return -EDEV_NO_MEMORY;
 		}
@@ -2265,9 +2265,9 @@ int lin_tape_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *c
 		cap->remaining_p1 = (cap->remaining_p1 * 1000 * 1000) >> 20;
 	}
 
-	ltfsmsg(LTFS_DEBUG3, "30597D", "capacity part0", (unsigned long long)cap->remaining_p0,
+	ltfsmsg(LTFS_DEBUG3, 30597D, "capacity part0", (unsigned long long)cap->remaining_p0,
 			(unsigned long long)cap->max_p0, ((struct lin_tape_ibmtape *) device)->drive_serial);
-	ltfsmsg(LTFS_DEBUG3, "30597D", "capacity part1", (unsigned long long)cap->remaining_p1,
+	ltfsmsg(LTFS_DEBUG3, 30597D, "capacity part1", (unsigned long long)cap->remaining_p1,
 		(unsigned long long)cap->max_p1, ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REMAINCAP));
@@ -2295,7 +2295,7 @@ int lin_tape_ibmtape_modesense(void *device, const uint8_t page, const TC_MP_PC_
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_MODESENSE));
-	ltfsmsg(LTFS_DEBUG3, "30593D", "modesense", page, ((struct lin_tape_ibmtape *) device)->drive_serial);
+	ltfsmsg(LTFS_DEBUG3, 30593D, "modesense", page, ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	memset(&spt, 0, sizeof(spt));
 	memset(cdb, 0, sizeof(cdb));
@@ -2351,7 +2351,7 @@ int lin_tape_ibmtape_modeselect(void *device, unsigned char *buf, const size_t s
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_MODESELECT));
-	ltfsmsg(LTFS_DEBUG3, "30592D", "modeselect", ((struct lin_tape_ibmtape *) device)->drive_serial);
+	ltfsmsg(LTFS_DEBUG3, 30592D, "modeselect", ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	memset(&spt, 0, sizeof(spt));
 	memset(cdb, 0, sizeof(cdb));
@@ -2402,7 +2402,7 @@ int lin_tape_ibmtape_prevent_medium_removal(void *device)
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_PREVENTM));
-	ltfsmsg(LTFS_DEBUG, "30592D", "prevent medium removal", ((struct lin_tape_ibmtape *) device)->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30592D, "prevent medium removal", ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	rc = _sioc_stioc_command(device, STIOC_PREVENT_MEDIUM_REMOVAL, "PREVENT MED REMOVAL", NULL, &msg);
 
@@ -2426,7 +2426,7 @@ int lin_tape_ibmtape_allow_medium_removal(void *device)
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_ALLOWMREM));
-	ltfsmsg(LTFS_DEBUG, "30592D", "allow medium removal", ((struct lin_tape_ibmtape *) device)->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30592D, "allow medium removal", ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	rc = _sioc_stioc_command(device, STIOC_ALLOW_MEDIUM_REMOVAL, "ALLOW MED REMOVAL", NULL, &msg);
 
@@ -2459,7 +2459,7 @@ int lin_tape_ibmtape_read_attribute(void *device, const tape_partition_t part, c
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_READATTR));
-	ltfsmsg(LTFS_DEBUG3, "30597D", "readattr", (unsigned long long)part,
+	ltfsmsg(LTFS_DEBUG3, 30597D, "readattr", (unsigned long long)part,
 			(unsigned long long)id, ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	memset(&spt, 0, sizeof(spt));
@@ -2470,7 +2470,7 @@ int lin_tape_ibmtape_read_attribute(void *device, const tape_partition_t part, c
 	spt.buffer_length = size + 4;
 	spt.buffer = calloc(1, spt.buffer_length);
 	if (spt.buffer == NULL) {
-		ltfsmsg(LTFS_ERR, "10001E", "lin_tape_ibmtape_read_attribute: data buffer");
+		ltfsmsg(LTFS_ERR, 10001E, "lin_tape_ibmtape_read_attribute: data buffer");
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_READATTR));
 		return -EDEV_NO_MEMORY;
 	}
@@ -2510,7 +2510,7 @@ int lin_tape_ibmtape_read_attribute(void *device, const tape_partition_t part, c
 			id != TC_MAM_TEXT_LOCALIZATION_IDENTIFIER &&
 			id != TC_MAM_BARCODE &&
 			id != TC_MAM_APP_FORMAT_VERSION)
-			ltfsmsg(LTFS_INFO, "30460I", rc);
+			ltfsmsg(LTFS_INFO, 30460I, rc);
 	} else {
 		memcpy(buf, (spt.buffer + 4), size);
 		free(spt.buffer);
@@ -2541,7 +2541,7 @@ int lin_tape_ibmtape_write_attribute(void *device, const tape_partition_t part, 
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_WRITEATTR));
-	ltfsmsg(LTFS_DEBUG3, "30594D", "writeattr", (unsigned long long)part,
+	ltfsmsg(LTFS_DEBUG3, 30594D, "writeattr", (unsigned long long)part,
 			((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	memset(&spt, 0, sizeof(spt));
@@ -2552,7 +2552,7 @@ int lin_tape_ibmtape_write_attribute(void *device, const tape_partition_t part, 
 	spt.buffer_length = size + 4;
 	spt.buffer = calloc(1, spt.buffer_length);
 	if (spt.buffer == NULL) {
-		ltfsmsg(LTFS_ERR, "10001E", "lin_tape_ibmtape_write_attribute: data buffer");
+		ltfsmsg(LTFS_ERR, 10001E, "lin_tape_ibmtape_write_attribute: data buffer");
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_WRITEATTR));
 		return -EDEV_NO_MEMORY;
 	}
@@ -2595,7 +2595,7 @@ int lin_tape_ibmtape_allow_overwrite(void *device, const struct tc_position pos)
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_ALLOWOVERW));
-	ltfsmsg(LTFS_DEBUG, "30597D", "allow overwrite", (unsigned long long)pos.partition,
+	ltfsmsg(LTFS_DEBUG, 30597D, "allow overwrite", (unsigned long long)pos.partition,
 		(unsigned long long)pos.block, ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	memset(&append_pos, 0, sizeof(append_pos));
@@ -2607,7 +2607,7 @@ int lin_tape_ibmtape_allow_overwrite(void *device, const struct tc_position pos)
 
 	if (rc != DEVICE_GOOD) {
 		if (rc == -EDEV_EOD_DETECTED) {
-			ltfsmsg(LTFS_DEBUG, "30448D", "Allow Overwrite");
+			ltfsmsg(LTFS_DEBUG, 30448D, "Allow Overwrite");
 			rc = DEVICE_GOOD;
 		}
 
@@ -2670,7 +2670,7 @@ int lin_tape_ibmtape_set_default(void *device)
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_SETDEFAULT));
 	/* Disable Read across EOD on 3592 drive */
 	if (IS_ENTERPRISE(priv->drive_type)) {
-		ltfsmsg(LTFS_DEBUG, "30592D", __FUNCTION__, "Disabling read across EOD");
+		ltfsmsg(LTFS_DEBUG, 30592D, __FUNCTION__, "Disabling read across EOD");
 		rc = lin_tape_ibmtape_modesense(device, TC_MP_READ_WRITE_CTRL, TC_MP_PC_CURRENT, 0, buf, sizeof(buf));
 		if (rc != DEVICE_GOOD) {
 			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETDEFAULT));
@@ -2689,7 +2689,7 @@ int lin_tape_ibmtape_set_default(void *device)
 	}
 
 	/* set SILI bit */
-	ltfsmsg(LTFS_DEBUG, "30592D", __FUNCTION__, "Setting SILI bit");
+	ltfsmsg(LTFS_DEBUG, 30592D, __FUNCTION__, "Setting SILI bit");
 	while (true) {
 		memset(&param, 0, sizeof(struct stchgp_s));
 		rc = _sioc_stioc_command(device, STIOCQRYP, "GET PARAM", &param, &msg);
@@ -2712,11 +2712,11 @@ int lin_tape_ibmtape_set_default(void *device)
 		if (priv->fd < 0) {
 			priv->fd = open(priv->devname, O_RDONLY | O_NDELAY);
 			if (priv->fd < 0) {
-				ltfsmsg(LTFS_INFO, "30425I", priv->devname, errno);
+				ltfsmsg(LTFS_INFO, 30425I, priv->devname, errno);
 				rc = -EDEV_DEVICE_UNOPENABLE;
 				break;
 			}
-			ltfsmsg(LTFS_WARN, "30426W", priv->devname);
+			ltfsmsg(LTFS_WARN, 30426W, priv->devname);
 		}
 		retry ++;
 	}
@@ -2729,10 +2729,10 @@ int lin_tape_ibmtape_set_default(void *device)
 
 	/* set logical block protection */
 	if (global_data.crc_checking) {
-		ltfsmsg(LTFS_DEBUG, "30592D", __FUNCTION__, "Setting LBP");
+		ltfsmsg(LTFS_DEBUG, 30592D, __FUNCTION__, "Setting LBP");
 		rc = lin_tape_ibmtape_set_lbp(device, true);
 	} else {
-		ltfsmsg(LTFS_DEBUG, "30592D", __FUNCTION__, "Resetting LBP");
+		ltfsmsg(LTFS_DEBUG, 30592D, __FUNCTION__, "Resetting LBP");
 		rc = lin_tape_ibmtape_set_lbp(device, false);
 	}
 	if (rc != DEVICE_GOOD) {
@@ -2816,11 +2816,11 @@ int lin_tape_ibmtape_get_cartridge_health(void *device, struct tc_cartridge_heal
 	cart_health->tape_efficiency  = UNSUPPORTED_CARTRIDGE_HEALTH;
 	rc = lin_tape_ibmtape_logsense(device, LOG_PERFORMANCE, logdata, LOGSENSEPAGE);
 	if (rc)
-		ltfsmsg(LTFS_INFO, "30461I", LOG_PERFORMANCE, rc, "get cart health");
+		ltfsmsg(LTFS_INFO, 30461I, LOG_PERFORMANCE, rc, "get cart health");
 	else {
 		for(i = 0; i < (int)((sizeof(perfstats)/sizeof(perfstats[0]))); i++) { /* BEAM: loop doesn't iterate - Use loop for future enhancement. */
 			if (parse_logPage(logdata, perfstats[i], &param_size, buf, 16)) {
-				ltfsmsg(LTFS_INFO, "30462I", LOG_PERFORMANCE, "get cart health");
+				ltfsmsg(LTFS_INFO, 30462I, LOG_PERFORMANCE, "get cart health");
 			} else {
 				switch(param_size) {
 				case sizeof(uint8_t):
@@ -2867,11 +2867,11 @@ int lin_tape_ibmtape_get_cartridge_health(void *device, struct tc_cartridge_heal
 	cart_health->passes_middle    = UNSUPPORTED_CARTRIDGE_HEALTH;
 	rc = lin_tape_ibmtape_logsense(device, LOG_VOLUMESTATS, logdata, LOGSENSEPAGE);
 	if (rc)
-		ltfsmsg(LTFS_INFO, "30461I", LOG_VOLUMESTATS, rc, "get cart health");
+		ltfsmsg(LTFS_INFO, 30461I, LOG_VOLUMESTATS, rc, "get cart health");
 	else {
 		for(i = 0; i < (int)((sizeof(volstats)/sizeof(volstats[0]))); i++) {
 			if (parse_logPage(logdata, volstats[i], &param_size, buf, 16)) {
-				ltfsmsg(LTFS_INFO, "30462I", LOG_VOLUMESTATS, "get cart health");
+				ltfsmsg(LTFS_INFO, 30462I, LOG_VOLUMESTATS, "get cart health");
 			} else {
 				switch(param_size) {
 				case sizeof(uint8_t):
@@ -2964,12 +2964,12 @@ int lin_tape_ibmtape_get_tape_alert(void *device, uint64_t *tape_alert)
 	ta = 0;
 	rc = lin_tape_ibmtape_logsense(device, LOG_TAPE_ALERT, logdata, LOGSENSEPAGE);
 	if (rc)
-		ltfsmsg(LTFS_INFO, "30461I", LOG_TAPE_ALERT, rc, "get tape alert");
+		ltfsmsg(LTFS_INFO, 30461I, LOG_TAPE_ALERT, rc, "get tape alert");
 	else {
 		for(i = 1; i <= 64; i++) {
 			if (parse_logPage(logdata, (uint16_t) i, &param_size, buf, 16)
 				|| param_size != sizeof(uint8_t)) {
-				ltfsmsg(LTFS_INFO, "30462I", LOG_TAPE_ALERT, "get tape alert");
+				ltfsmsg(LTFS_INFO, 30462I, LOG_TAPE_ALERT, "get tape alert");
 				ta = 0;
 			}
 
@@ -3017,7 +3017,7 @@ int lin_tape_ibmtape_clear_tape_alert(void *device, uint64_t tape_alert)
 	uint32_t length = 0;
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
-	ltfsmsg(LTFS_DEBUG, "30592D", "read block limits", ((struct lin_tape_ibmtape *) device)->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30592D, "read block limits", ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	memset(&spt, 0, sizeof(spt));
 	memset(cdb, 0, sizeof(cdb));
@@ -3155,7 +3155,7 @@ int lin_tape_ibmtape_get_device_list(struct tc_drive_info *buf, int count)
 	list = fopen(DEV_LIST_FILE, "r");
 	if (!list) {
 		/* Failed to open file '%s' (%d) */
-		ltfsmsg(LTFS_ERR, "30463E", DEV_LIST_FILE, errno);
+		ltfsmsg(LTFS_ERR, 30463E, DEV_LIST_FILE, errno);
 		return i;
 	}
 
@@ -3296,7 +3296,7 @@ int lin_tape_ibmtape_get_eod_status(void *device, int part)
 	/* Issue LogPage 0x17 */
 	rc = lin_tape_ibmtape_logsense(device, LOG_VOL_STATISTICS, logdata, LOGSENSEPAGE);
 	if (rc) {
-		ltfsmsg(LTFS_WARN, "30464W", LOG_VOL_STATISTICS, rc);
+		ltfsmsg(LTFS_WARN, 30464W, LOG_VOL_STATISTICS, rc);
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETEODSTAT));
 		return EOD_UNKNOWN;
 	}
@@ -3304,7 +3304,7 @@ int lin_tape_ibmtape_get_eod_status(void *device, int part)
 	/* Parse Approximate used native capacity of partitions (0x203)*/
 	if (parse_logPage(logdata, (uint16_t)LOG_VOL_USED_CAPACITY, &param_size, buf, sizeof(buf))
 		|| (param_size != sizeof(buf) ) ) {
-		ltfsmsg(LTFS_WARN, "30465W");
+		ltfsmsg(LTFS_WARN, 30465W);
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETEODSTAT));
 		return EOD_UNKNOWN;
 	}
@@ -3323,7 +3323,7 @@ int lin_tape_ibmtape_get_eod_status(void *device, int part)
 				((uint32_t) buf[i + 6] << 8) +
 				(uint32_t) buf[i + 7];
 		} else
-			ltfsmsg(LTFS_WARN, "30466W", i, part_buf, len);
+			ltfsmsg(LTFS_WARN, 30466W, i, part_buf, len);
 
 		i += (len + 1);
 	}
@@ -3366,10 +3366,10 @@ int lin_tape_ibmtape_get_xattr(void *device, const char *name, char **buf)
 			rc = lin_tape_ibmtape_logsense_page(device, LOG_PERFORMANCE, LOG_PERFORMANCE_CAPACITY_SUB,
 									   logdata, LOGSENSEPAGE);
 			if (rc)
-				ltfsmsg(LTFS_INFO, "30461I", LOG_PERFORMANCE, rc, "get xattr");
+				ltfsmsg(LTFS_INFO, 30461I, LOG_PERFORMANCE, rc, "get xattr");
 			else {
 				if (parse_logPage(logdata, PERF_ACTIVE_CQ_LOSS_W, &param_size, logbuf, 16)) {
-					ltfsmsg(LTFS_INFO, "30462I", LOG_PERFORMANCE, "get xattr");
+					ltfsmsg(LTFS_INFO, 30462I, LOG_PERFORMANCE, "get xattr");
 					rc = -LTFS_NO_XATTR;
 				} else {
 					switch(param_size) {
@@ -3380,7 +3380,7 @@ int lin_tape_ibmtape_get_xattr(void *device, const char *name, char **buf)
 						priv->dirty_acq_loss_w = false;
 						break;
 					default:
-						ltfsmsg(LTFS_INFO, "30467I", param_size);
+						ltfsmsg(LTFS_INFO, 30467I, param_size);
 						rc = -LTFS_NO_XATTR;
 						break;
 					}
@@ -3393,7 +3393,7 @@ int lin_tape_ibmtape_get_xattr(void *device, const char *name, char **buf)
 			rc = asprintf(buf, "%2.2f", priv->acq_loss_w);
 			if (rc < 0) {
 				rc = -LTFS_NO_MEMORY;
-				ltfsmsg(LTFS_INFO, "30468I", "getting active CQ loss write");
+				ltfsmsg(LTFS_INFO, 30468I, "getting active CQ loss write");
 			}
 			else
 				rc = DEVICE_GOOD;
@@ -3426,7 +3426,7 @@ int lin_tape_ibmtape_set_xattr(void *device, const char *name, const char *buf, 
 
 	null_terminated = malloc(size + 1);
 	if (! null_terminated) {
-		ltfsmsg(LTFS_ERR, "10001E", "lin_tape_ibmtape_set_xattr: null_term");
+		ltfsmsg(LTFS_ERR, 10001E, "lin_tape_ibmtape_set_xattr: null_term");
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETXATTR));
 		return -LTFS_NO_MEMORY;
 	}
@@ -3454,7 +3454,7 @@ int lin_tape_ibmtape_set_xattr(void *device, const char *name, const char *buf, 
 
 void lin_tape_ibmtape_help_message(void)
 {
-	ltfsresult("30599I", lin_tape_ibmtape_default_device);
+	ltfsresult(30599I, lin_tape_ibmtape_default_device);
 }
 
 const char *lin_tape_ibmtape_default_device_name(void)
@@ -3477,7 +3477,7 @@ static void ltfsmsg_keyalias(const char * const title, const unsigned char * con
 	else
 		sprintf(s, "keyalias: NULL");
 
-	ltfsmsg(LTFS_DEBUG, "30592D", title, s);
+	ltfsmsg(LTFS_DEBUG, 30592D, title, s);
 }
 
 static bool is_ame(void *device)
@@ -3488,7 +3488,7 @@ static bool is_ame(void *device)
 	if (rc != 0) {
 		char message[100] = {0};
 		sprintf(message, "failed to get MP %02Xh (%d)", TC_MP_READ_WRITE_CTRL, rc);
-		ltfsmsg(LTFS_DEBUG, "30592D", __FUNCTION__, message);
+		ltfsmsg(LTFS_DEBUG, 30592D, __FUNCTION__, message);
 
 		return false; /* Consider that the encryption method is not AME */
 	} else {
@@ -3522,10 +3522,10 @@ static bool is_ame(void *device)
 			break;
 		}
 		sprintf(message, "Encryption Method is %s (0x%02X)", method, encryption_method);
-		ltfsmsg(LTFS_DEBUG, "30592D", __FUNCTION__, message);
+		ltfsmsg(LTFS_DEBUG, 30592D, __FUNCTION__, message);
 
 		if (encryption_method != 0x50) {
-			ltfsmsg(LTFS_ERR, "30469E", method, encryption_method);
+			ltfsmsg(LTFS_ERR, 30469E, method, encryption_method);
 		}
 		return encryption_method == 0x50;
 	}
@@ -3536,7 +3536,7 @@ static int is_encryption_capable(void *device)
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
 	if (IS_ENTERPRISE(priv->drive_type)) {
-		ltfsmsg(LTFS_ERR, "30470E", priv->drive_type);
+		ltfsmsg(LTFS_ERR, 30470E, priv->drive_type);
 		return -EDEV_INTERNAL_ERROR;
 	}
 
@@ -3562,7 +3562,7 @@ int lin_tape_ibmtape_security_protocol_out(void *device, const uint16_t sps, uns
 	char *msg = NULL;
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
-	ltfsmsg(LTFS_DEBUG, "30592D", "Security Protocol Out (SPOUT)", ((struct lin_tape_ibmtape *) device)->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30592D, "Security Protocol Out (SPOUT)", ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	/* Prepare Data Buffer */
 	spt.buffer_length = size;
@@ -3715,7 +3715,7 @@ static void show_hex_dump(const char * const title, const unsigned char * const 
 		p += sprintf(p, "%c", isprint(buf[i-j]) ? buf[i-j] : '.');
 	}
 
-	ltfsmsg(LTFS_DEBUG, "30592D", title, s);
+	ltfsmsg(LTFS_DEBUG, 30592D, title, s);
 }
 
 int lin_tape_ibmtape_get_keyalias(void *device, unsigned char **keyalias) /* This is not IBM method but T10 method. */
@@ -3746,7 +3746,7 @@ int lin_tape_ibmtape_get_keyalias(void *device, unsigned char **keyalias) /* Thi
 		free(spt.buffer);
 		spt.buffer = (unsigned char*) calloc(spt.buffer_length, sizeof(unsigned char));
 		if (spt.buffer == NULL) {
-			ltfsmsg(LTFS_ERR, "10001E", "lin_tape_ibmtape_get_keyalias: data buffer");
+			ltfsmsg(LTFS_ERR, 10001E, "lin_tape_ibmtape_get_keyalias: data buffer");
 			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETKEYALIAS));
 			return -EDEV_NO_MEMORY;
 		}
@@ -3848,8 +3848,8 @@ int lin_tape_ibmtape_set_lbp(void *device, bool enable)
 		lbp_method = REED_SOLOMON_CRC;
 
 	/* set logical block protection */
-	ltfsmsg(LTFS_DEBUG, "30593D", "LBP Enable", enable, "");
-	ltfsmsg(LTFS_DEBUG, "30593D", "LBP Method", lbp_method, "");
+	ltfsmsg(LTFS_DEBUG, 30593D, "LBP Enable", enable, "");
+	ltfsmsg(LTFS_DEBUG, 30593D, "LBP Method", lbp_method, "");
 	memset(&lbp, 0, sizeof(struct logical_block_protection));
 	rc = _sioc_stioc_command(device, STIOC_QUERY_BLK_PROTECTION, "GET LBP", &lbp, &msg);
 	if (rc != DEVICE_GOOD) {
@@ -3886,11 +3886,11 @@ int lin_tape_ibmtape_set_lbp(void *device, bool enable)
 			priv->f_crc_check = NULL;
 			break;
 		}
-		ltfsmsg(LTFS_INFO, "30471I");
+		ltfsmsg(LTFS_INFO, 30471I);
 	} else {
 		priv->f_crc_enc   = NULL;
 		priv->f_crc_check = NULL;
-		ltfsmsg(LTFS_INFO, "30472I");
+		ltfsmsg(LTFS_INFO, 30472I);
 	}
 
 	return rc;
@@ -3952,7 +3952,7 @@ int lin_tape_ibmtape_readbuffer(void *device, int id, unsigned char *buf, size_t
 	int rc;
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
-	ltfsmsg(LTFS_DEBUG, "30593D", "read buffer", id, ((struct lin_tape_ibmtape *) device)->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30593D, "read buffer", id, ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	memset(&spt, 0, sizeof(spt));
 	memset(cdb, 0, sizeof(cdb));
@@ -4015,13 +4015,13 @@ int lin_tape_ibmtape_getdump_drive(void *device, const char *fname)
 	unsigned char *dump_buf;
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
-	ltfsmsg(LTFS_INFO, "30478I", fname);
+	ltfsmsg(LTFS_INFO, 30478I, fname);
 
 	/* Set transfer size */
 	transfer_size = DUMP_TRANSFER_SIZE;
 	dump_buf = calloc(1, DUMP_TRANSFER_SIZE);
 	if (dump_buf == NULL) {
-		ltfsmsg(LTFS_ERR, "10001E", "lin_tape_ibmtape_getdump_drive: dump buffer");
+		ltfsmsg(LTFS_ERR, 10001E, "lin_tape_ibmtape_getdump_drive: dump buffer");
 		return -EDEV_NO_MEMORY;
 	}
 
@@ -4040,7 +4040,7 @@ int lin_tape_ibmtape_getdump_drive(void *device, const char *fname)
 	dumpfd = open(fname, O_WRONLY | O_CREAT | O_TRUNC, 0666);
 	if (dumpfd < 0) {
 		rc = -errno;
-		ltfsmsg(LTFS_WARN, "30479W", rc);
+		ltfsmsg(LTFS_WARN, 30479W, rc);
 		free(dump_buf);
 		return rc;
 	}
@@ -4052,13 +4052,13 @@ int lin_tape_ibmtape_getdump_drive(void *device, const char *fname)
 		num_transfers += 1;
 
 	/* Total dump data length is %lld. Total number of transfers is %d. */
-	ltfsmsg(LTFS_DEBUG, "30480D", data_length);
-	ltfsmsg(LTFS_DEBUG, "30481D", num_transfers);
+	ltfsmsg(LTFS_DEBUG, 30480D, data_length);
+	ltfsmsg(LTFS_DEBUG, 30481D, num_transfers);
 
 	/* start to transfer data */
 	buf_offset = 0;
 	i = 0;
-	ltfsmsg(LTFS_DEBUG, "30482D");
+	ltfsmsg(LTFS_DEBUG, 30482D);
 	while (num_transfers) {
 		int length;
 
@@ -4072,7 +4072,7 @@ int lin_tape_ibmtape_getdump_drive(void *device, const char *fname)
 
 		rc = lin_tape_ibmtape_readbuffer(device, buf_id, dump_buf, buf_offset, length, 0x02);
 		if (rc) {
-			ltfsmsg(LTFS_WARN, "30483W", rc);
+			ltfsmsg(LTFS_WARN, 30483W, rc);
 			free(dump_buf);
 			close(dumpfd);
 			return rc;
@@ -4082,15 +4082,15 @@ int lin_tape_ibmtape_getdump_drive(void *device, const char *fname)
 		bytes = write(dumpfd, dump_buf, length);
 		if (bytes == -1) {
 			rc = -errno;
-			ltfsmsg(LTFS_WARN, "30484W", rc);
+			ltfsmsg(LTFS_WARN, 30484W, rc);
 			free(dump_buf);
 			close(dumpfd);
 			return rc;
 		}
 
-		ltfsmsg(LTFS_DEBUG, "30485D", i, bytes);
+		ltfsmsg(LTFS_DEBUG, 30485D, i, bytes);
 		if (bytes != length) {
-			ltfsmsg(LTFS_WARN, "30486W", bytes, length);
+			ltfsmsg(LTFS_WARN, 30486W, bytes, length);
 			free(dump_buf);
 			close(dumpfd);
 			return -EDEV_DUMP_EIO;
@@ -4124,7 +4124,7 @@ int lin_tape_ibmtape_forcedump_drive(void *device)
 	char *msg;
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
-	ltfsmsg(LTFS_DEBUG, "30593D", "force dump", 0, ((struct lin_tape_ibmtape *) device)->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30593D, "force dump", 0, ((struct lin_tape_ibmtape *) device)->drive_serial);
 
 	memset(&spt, 0, sizeof(spt));
 	memset(cdb, 0, sizeof(cdb));
@@ -4194,11 +4194,11 @@ int lin_tape_ibmtape_takedump_drive(void *device, bool nonforced_dump)
 		strcpy(fname, fname_base);
 		strcat(fname, ".dmp");
 
-		ltfsmsg(LTFS_INFO, "30487I");
+		ltfsmsg(LTFS_INFO, 30487I);
 		lin_tape_ibmtape_getdump_drive(device, fname);
 	}
 
-	ltfsmsg(LTFS_INFO, "30488I");
+	ltfsmsg(LTFS_INFO, 30488I);
 	lin_tape_ibmtape_forcedump_drive(device);
 	strcpy(fname, fname_base);
 	strcat(fname, "_f.dmp");
@@ -4218,7 +4218,7 @@ int lin_tape_ibmtape_get_worm_status(void *device, bool *is_worm)
 	if (priv->loaded) {
 		*is_worm = priv->is_worm;
 	} else {
-		ltfsmsg(LTFS_INFO, "30489I");
+		ltfsmsg(LTFS_INFO, 30489I);
 		*is_worm = false;
 		rc = -1;
 	}

--- a/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
@@ -189,8 +189,8 @@ static int _set_lbp(void *device, bool enable)
 		lbp_method = REED_SOLOMON_CRC;
 
 	/* set logical block protection */
-	ltfsmsg(LTFS_DEBUG, "30393D", "LBP Enable", enable, "");
-	ltfsmsg(LTFS_DEBUG, "30393D", "LBP Method", lbp_method, "");
+	ltfsmsg(LTFS_DEBUG, 30393D, "LBP Enable", enable, "");
+	ltfsmsg(LTFS_DEBUG, 30393D, "LBP Method", lbp_method, "");
 	ret = sg_ibmtape_modesense(device, TC_MP_CTRL, TC_MP_PC_CURRENT,
 							   TC_MP_SUB_DP_CTRL, buf, sizeof(buf));
 	if (ret < 0)
@@ -226,11 +226,11 @@ static int _set_lbp(void *device, bool enable)
 					priv->f_crc_check = NULL;
 					break;
 			}
-			ltfsmsg(LTFS_INFO, "30251I");
+			ltfsmsg(LTFS_INFO, 30251I);
 		} else {
 			priv->f_crc_enc   = NULL;
 			priv->f_crc_check = NULL;
-			ltfsmsg(LTFS_INFO, "30252I");
+			ltfsmsg(LTFS_INFO, 30252I);
 		}
 	}
 
@@ -269,13 +269,13 @@ static int _get_dump(struct sg_ibmtape_data *priv, char *fname)
 	unsigned char           *dump_buf;
 	int                     buf_id;
 
-	ltfsmsg(LTFS_INFO, "30253I", fname);
+	ltfsmsg(LTFS_INFO, 30253I, fname);
 
 	/* Set transfer size */
 	transfer_size = DUMP_TRANSFER_SIZE;
 	dump_buf = calloc(1, DUMP_TRANSFER_SIZE);
 	if(!dump_buf){
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -EDEV_NO_MEMORY;
 	}
 
@@ -293,7 +293,7 @@ static int _get_dump(struct sg_ibmtape_data *priv, char *fname)
 	/* Open dump file for write only*/
 	dumpfd = open(fname, O_WRONLY|O_CREAT|O_TRUNC, 0666);
 	if(dumpfd < 0){
-		ltfsmsg(LTFS_WARN, "30254W", errno);
+		ltfsmsg(LTFS_WARN, 30254W, errno);
 		free(dump_buf);
 		return -2;
 	}
@@ -305,13 +305,13 @@ static int _get_dump(struct sg_ibmtape_data *priv, char *fname)
 		num_transfers += 1;
 
 	/* Total dump data length is %lld. Total number of transfers is %d. */
-	ltfsmsg(LTFS_DEBUG, "30255D", data_length);
-	ltfsmsg(LTFS_DEBUG, "30256D", num_transfers);
+	ltfsmsg(LTFS_DEBUG, 30255D, data_length);
+	ltfsmsg(LTFS_DEBUG, 30256D, num_transfers);
 
 	/* start to transfer data */
 	buf_offset = 0;
 	i = 0;
-	ltfsmsg(LTFS_DEBUG, "30257D");
+	ltfsmsg(LTFS_DEBUG, 30257D);
 	while(num_transfers)
 	{
 		int length;
@@ -326,7 +326,7 @@ static int _get_dump(struct sg_ibmtape_data *priv, char *fname)
 
 		ret = _cdb_read_buffer(priv, buf_id, dump_buf, buf_offset, length, 0x02);
 		if (ret) {
-			ltfsmsg(LTFS_WARN, "30258W", ret);
+			ltfsmsg(LTFS_WARN, 30258W, ret);
 			free(dump_buf);
 			close(dumpfd);
 			return ret;
@@ -336,7 +336,7 @@ static int _get_dump(struct sg_ibmtape_data *priv, char *fname)
 		bytes = write(dumpfd, dump_buf, length);
 		if(bytes == -1)
 		{
-			ltfsmsg(LTFS_WARN, "30259W", ret);
+			ltfsmsg(LTFS_WARN, 30259W, ret);
 			free(dump_buf);
 			close(dumpfd);
 			return -1;
@@ -344,7 +344,7 @@ static int _get_dump(struct sg_ibmtape_data *priv, char *fname)
 
 		if(bytes != length)
 		{
-			ltfsmsg(LTFS_WARN, "30260W", bytes, length);
+			ltfsmsg(LTFS_WARN, 30260W, bytes, length);
 			free(dump_buf);
 			close(dumpfd);
 			return -2;
@@ -383,13 +383,13 @@ static int _take_dump(struct sg_ibmtape_data *priv, bool capture_unforced)
 			, tm_now->tm_sec);
 
 	if (capture_unforced) {
-		ltfsmsg(LTFS_INFO, "30261I");
+		ltfsmsg(LTFS_INFO, 30261I);
 		strcpy(fname, fname_base);
 		strcat(fname, ".dmp");
 		_get_dump(priv, fname);
 	}
 
-	ltfsmsg(LTFS_INFO, "30262I");
+	ltfsmsg(LTFS_INFO, 30262I);
 	_cdb_force_dump(priv);
 	strcpy(fname, fname_base);
 	strcat(fname, "_f.dmp");
@@ -405,9 +405,9 @@ static void _process_errors(struct sg_ibmtape_data *priv, int ret, char *msg, ch
 	bool unforced_dump;
 
 	if (msg != NULL) {
-		ltfsmsg(LTFS_INFO, "30263I", cmd, msg, ret, priv->devname);
+		ltfsmsg(LTFS_INFO, 30263I, cmd, msg, ret, priv->devname);
 	} else {
-		ltfsmsg(LTFS_ERR, "30264E", cmd, ret, priv->devname);
+		ltfsmsg(LTFS_ERR, 30264E, cmd, ret, priv->devname);
 	}
 
 	if (priv) {
@@ -430,7 +430,7 @@ static int _cdb_read_buffer(void *device, int id, unsigned char *buf, size_t off
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "READ_BUFFER";
 	char *msg;
 
-	ltfsmsg(LTFS_DEBUG, "30393D", "read buffer", id, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30393D, "read buffer", id, priv->drive_serial);
 
 	/* Zero out the CDB and the result buffer */
 	ret = init_sg_io_header(&req);
@@ -487,7 +487,7 @@ static int _cdb_force_dump(struct sg_ibmtape_data *priv)
 
 	unsigned char buf[SENDDIAG_BUF_LEN];
 
-	ltfsmsg(LTFS_DEBUG, "30393D", "force dump", 0, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30393D, "force dump", 0, priv->drive_serial);
 
 	/* Zero out the CDB and the result buffer */
 	ret = init_sg_io_header(&req);
@@ -597,7 +597,7 @@ static int _fetch_reservation_key(void *device, struct reservation_info *r)
 start:
 	buf = calloc(1, bufsize);
 	if (!buf) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -EDEV_NO_MEMORY;
 	}
 
@@ -699,13 +699,13 @@ static int _cdb_pro(void *device,
 			memset(&r_info, 0x00, sizeof(r_info));
 			f_ret = _fetch_reservation_key(device, &r_info);
 			if (!f_ret) {
-				ltfsmsg(LTFS_WARN, "30266W", r_info.hint, priv->drive_serial);
-				ltfsmsg(LTFS_WARN, "30267W",
+				ltfsmsg(LTFS_WARN, 30266W, r_info.hint, priv->drive_serial);
+				ltfsmsg(LTFS_WARN, 30267W,
 						r_info.wwid[0], r_info.wwid[1], r_info.wwid[2], r_info.wwid[3],
 						r_info.wwid[6], r_info.wwid[5], r_info.wwid[6], r_info.wwid[7],
 						priv->drive_serial);
 			} else {
-				ltfsmsg(LTFS_WARN, "30266W", "unknown host (reserve command)", priv->drive_serial);
+				ltfsmsg(LTFS_WARN, 30266W, "unknown host (reserve command)", priv->drive_serial);
 			}
 		} else {
 			_process_errors(device, ret, msg, cmd_desc, true);
@@ -746,17 +746,17 @@ int sg_ibmtape_open(const char *devname, void **handle)
 
 	*handle = NULL;
 
-	ltfsmsg(LTFS_INFO, "30209I", devname);
+	ltfsmsg(LTFS_INFO, 30209I, devname);
 
 	priv = calloc(1, sizeof(struct sg_ibmtape_data));
 	if(!priv) {
-		ltfsmsg(LTFS_ERR, "10001E", "sg_ibmtape_open: device private data");
+		ltfsmsg(LTFS_ERR, 10001E, "sg_ibmtape_open: device private data");
 		return -EDEV_NO_MEMORY;
 	}
 
 	priv->devname = strdup(devname);
 	if (!priv->devname) {
-		ltfsmsg(LTFS_ERR, "10001E", "sg_ibmtape_open: devname");
+		ltfsmsg(LTFS_ERR, 10001E, "sg_ibmtape_open: devname");
 		free(priv);
 		return -EDEV_NO_MEMORY;
 	}
@@ -769,7 +769,7 @@ int sg_ibmtape_open(const char *devname, void **handle)
 	 */
 	priv->dev.fd = open(priv->devname, O_RDWR | O_EXCL | O_NONBLOCK);
 	if (priv->dev.fd < 0) {
-		ltfsmsg(LTFS_INFO, "30210I", devname, errno);
+		ltfsmsg(LTFS_INFO, 30210I, devname, errno);
 		ret = -EDEV_DEVICE_UNOPENABLE;
 		goto free;
 	}
@@ -777,7 +777,7 @@ int sg_ibmtape_open(const char *devname, void **handle)
 	/* Get the device back to blocking mode */
 	flags = fcntl(priv->dev.fd, F_GETFL, 0);
 	if (flags < 0) {
-		ltfsmsg(LTFS_INFO, "30211I", "get", errno);
+		ltfsmsg(LTFS_INFO, 30211I, "get", errno);
 		close(priv->dev.fd);
 		ret = -EDEV_DEVICE_UNOPENABLE;
 		goto free;
@@ -785,7 +785,7 @@ int sg_ibmtape_open(const char *devname, void **handle)
 	flags = (flags & (~O_NONBLOCK));
 	flags = fcntl(priv->dev.fd, F_SETFL, 0);
 	if (flags < 0) {
-		ltfsmsg(LTFS_INFO, "30211I", "set", errno);
+		ltfsmsg(LTFS_INFO, 30211I, "set", errno);
 		close(priv->dev.fd);
 		ret = -EDEV_DEVICE_UNOPENABLE;
 		goto free;
@@ -794,7 +794,7 @@ int sg_ibmtape_open(const char *devname, void **handle)
 	/* Check the drive is supportable */
 	ret = sg_get_drive_identifier(&priv->dev, &id_data);
 	if (ret < 0) {
-		ltfsmsg(LTFS_INFO, "30212I", priv->devname);
+		ltfsmsg(LTFS_INFO, 30212I, priv->devname);
 		close(priv->dev.fd);
 		goto free;
 	}
@@ -816,17 +816,17 @@ int sg_ibmtape_open(const char *devname, void **handle)
 		} else
 			priv->drive_type = drive_type;
 	} else {
-		ltfsmsg(LTFS_INFO, "30213I", id_data.product_id);
+		ltfsmsg(LTFS_INFO, 30213I, id_data.product_id);
 		ret = -EDEV_DEVICE_UNSUPPORTABLE; /* Unsupported device */
 		goto free;
 	}
 
 	strncpy(priv->drive_serial, id_data.unit_serial, sizeof(priv->drive_serial) - 1);
 
-	ltfsmsg(LTFS_INFO, "30207I", id_data.vendor_id);
-	ltfsmsg(LTFS_INFO, "30208I", id_data.product_id);
-	ltfsmsg(LTFS_INFO, "30214I", id_data.product_rev);
-	ltfsmsg(LTFS_INFO, "30215I", priv->drive_serial);
+	ltfsmsg(LTFS_INFO, 30207I, id_data.vendor_id);
+	ltfsmsg(LTFS_INFO, 30208I, id_data.product_id);
+	ltfsmsg(LTFS_INFO, 30214I, id_data.product_rev);
+	ltfsmsg(LTFS_INFO, 30215I, priv->drive_serial);
 
 	/* Setup IBM tape specific parameters */
 	standard_table = standard_tape_errors;
@@ -926,7 +926,7 @@ int sg_ibmtape_inquiry_page(void *device, unsigned char page, struct tc_inq_page
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_INQUIRYPAGE));
-	ltfsmsg(LTFS_DEBUG, "30393D", "inquiry", page, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30393D, "inquiry", page, priv->drive_serial);
 
 	/* Zero out the CDB and the result buffer */
 	ret = init_sg_io_header(&req);
@@ -1010,7 +1010,7 @@ int sg_ibmtape_test_unit_ready(void *device)
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_TUR));
-	ltfsmsg(LTFS_DEBUG3, "30392D", "test unit ready", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG3, 30392D, "test unit ready", priv->drive_serial);
 
 	/* Zero out the CDB and the result buffer */
 	ret = init_sg_io_header(&req);
@@ -1123,33 +1123,33 @@ static int _cdb_read(void *device, char *buf, size_t size, bool sili)
 				if ((*(sense + 2)) & SK_ILI_SET) {
 					diff_len = ltfs_betou32(sense + 3);
 					if (!req.dxfer_len || diff_len != req.resid) {
-						ltfsmsg(LTFS_WARN, "30216W", req.dxfer_len, req.resid, diff_len);
+						ltfsmsg(LTFS_WARN, 30216W, req.dxfer_len, req.resid, diff_len);
 						return -EDEV_LENGTH_MISMATCH;
 					} else {
 						if (diff_len < 0) {
 							/* Over-run condition */
-							ltfsmsg(LTFS_INFO, "30217I", diff_len, size - diff_len);
+							ltfsmsg(LTFS_INFO, 30217I, diff_len, (int)size - diff_len);
 							ret = -EDEV_OVERRUN;
 						} else {
 							/* Under-run condition */
-							ltfsmsg(LTFS_DEBUG, "30218D", diff_len, size - diff_len);
+							ltfsmsg(LTFS_DEBUG, 30218D, diff_len, (int)size - diff_len);
 							length = size - diff_len;
 							ret = DEVICE_GOOD;
 						}
 					}
 				} else if ((*(sense + 2)) & SK_FM_SET) {
-					ltfsmsg(LTFS_DEBUG, "30219D");
+					ltfsmsg(LTFS_DEBUG, 30219D);
 					ret = -EDEV_FILEMARK_DETECTED;
 					length = -EDEV_FILEMARK_DETECTED;
 				}
 				break;
 			case -EDEV_FILEMARK_DETECTED:
-				ltfsmsg(LTFS_DEBUG, "30219D");
+				ltfsmsg(LTFS_DEBUG, 30219D);
 				ret = -EDEV_FILEMARK_DETECTED;
 				length = -EDEV_FILEMARK_DETECTED;
 				break;
 			case -EDEV_CLEANING_REQUIRED:
-				ltfsmsg(LTFS_INFO, "30220I");
+				ltfsmsg(LTFS_INFO, 30220I);
 				length = 0;
 				ret = DEVICE_GOOD;
 				break;
@@ -1177,7 +1177,7 @@ int sg_ibmtape_read(void *device, char *buf, size_t size,
 	struct tc_position pos_retry = {0, 0};
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_READ));
-	ltfsmsg(LTFS_DEBUG3, "30395D", "read", size, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG3, 30395D, "read", size, priv->drive_serial);
 
 	if(global_data.crc_checking) {
 		datacount = size + 4;
@@ -1232,7 +1232,7 @@ read_retry:
 			if (priv->f_crc_check)
 				ret = priv->f_crc_check(buf, ret - 4);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "30221E");
+				ltfsmsg(LTFS_ERR, 30221E);
 				_take_dump(priv, false);
 				ret = -EDEV_LBP_READ_ERROR;
 			}
@@ -1292,18 +1292,18 @@ static int _cdb_write(void *device, uint8_t *buf, size_t size, bool *ew, bool *p
 	if (ret < 0){
 		switch (ret) {
 			case -EDEV_EARLY_WARNING:
-				ltfsmsg(LTFS_WARN, "30222W", "write");
+				ltfsmsg(LTFS_WARN, 30222W, "write");
 				*ew = true;
 				*pew = true;
 				ret = DEVICE_GOOD;
 				break;
 			case -EDEV_PROG_EARLY_WARNING:
-				ltfsmsg(LTFS_WARN, "30223W", "write");
+				ltfsmsg(LTFS_WARN, 30223W, "write");
 				*pew = true;
 				ret = DEVICE_GOOD;
 				break;
 			case -EDEV_CLEANING_REQUIRED:
-				ltfsmsg(LTFS_INFO, "30220I");
+				ltfsmsg(LTFS_INFO, 30220I);
 				ret = DEVICE_GOOD;
 				break;
 			default:
@@ -1327,7 +1327,7 @@ int sg_ibmtape_write(void *device, const char *buf, size_t count, struct tc_posi
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_WRITE));
 
-	ltfsmsg(LTFS_DEBUG3, "30395D", "write", count, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG3, 30395D, "write", count, priv->drive_serial);
 
 	if(global_data.crc_checking) {
 		if (priv->f_crc_enc)
@@ -1362,7 +1362,7 @@ int sg_ibmtape_writefm(void *device, size_t count, struct tc_position *pos, bool
 	bool ew = false, pew = false;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_WRITEFM));
-	ltfsmsg(LTFS_DEBUG, "30394D", "write file marks", count, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30394D, "write file marks", count, priv->drive_serial);
 
 	/* Zero out the CDB and the result buffer */
 	ret = init_sg_io_header(&req);
@@ -1397,18 +1397,18 @@ int sg_ibmtape_writefm(void *device, size_t count, struct tc_position *pos, bool
 	if (ret < 0){
 		switch (ret) {
 			case -EDEV_EARLY_WARNING:
-				ltfsmsg(LTFS_WARN, "30222W", "write filemarks");
+				ltfsmsg(LTFS_WARN, 30222W, "write filemarks");
 				ew = true;
 				pew = true;
 				ret = DEVICE_GOOD;
 				break;
 			case -EDEV_PROG_EARLY_WARNING:
-				ltfsmsg(LTFS_WARN, "30223W", "write filemarks");
+				ltfsmsg(LTFS_WARN, 30223W, "write filemarks");
 				pew = true;
 				ret = DEVICE_GOOD;
 				break;
 			case -EDEV_CLEANING_REQUIRED:
-				ltfsmsg(LTFS_INFO, "30220I");
+				ltfsmsg(LTFS_INFO, 30220I);
 				ret = DEVICE_GOOD;
 				break;
 			default:
@@ -1448,7 +1448,7 @@ int sg_ibmtape_rewind(void *device, struct tc_position *pos)
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_REWIND));
-	ltfsmsg(LTFS_DEBUG, "30397D", "rewind", 0, 0, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30397D, "rewind", (unsigned long long)0, (unsigned long long)0, priv->drive_serial);
 
 	/* Zero out the CDB and the result buffer */
 	ret = init_sg_io_header(&req);
@@ -1484,9 +1484,9 @@ int sg_ibmtape_rewind(void *device, struct tc_position *pos)
 
 		if(ret == DEVICE_GOOD) {
 			if(pos->early_warning)
-				ltfsmsg(LTFS_WARN, "30222W", "rewind");
+				ltfsmsg(LTFS_WARN, 30222W, "rewind");
 			else if(pos->programmable_early_warning)
-				ltfsmsg(LTFS_WARN, "30223W", "rewind");
+				ltfsmsg(LTFS_WARN, 30223W, "rewind");
 		}
 	}
 
@@ -1508,7 +1508,10 @@ int sg_ibmtape_locate(void *device, struct tc_position dest, struct tc_position 
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOCATE));
-	ltfsmsg(LTFS_DEBUG, "30397D", "locate", dest.partition, dest.block, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30397D, "locate",
+			(unsigned long long)dest.partition,
+			(unsigned long long)dest.block,
+			priv->drive_serial);
 
 	/* Zero out the CDB and the result buffer */
 	ret = init_sg_io_header(&req);
@@ -1540,7 +1543,7 @@ int sg_ibmtape_locate(void *device, struct tc_position dest, struct tc_position 
 	ret = sg_issue_cdb_command(&priv->dev, &req, &msg);
 	if (ret < 0){
 		if (dest.block == TAPE_BLOCK_MAX && ret == -EDEV_EOD_DETECTED) {
-			ltfsmsg(LTFS_DEBUG, "30224D", "Locate");
+			ltfsmsg(LTFS_DEBUG, 30224D, "Locate");
 			ret = DEVICE_GOOD;
 		} else {
 			_process_errors(device, ret, msg, cmd_desc, true);
@@ -1551,9 +1554,9 @@ int sg_ibmtape_locate(void *device, struct tc_position dest, struct tc_position 
 
 	if(ret == DEVICE_GOOD) {
 		if(pos->early_warning)
-			ltfsmsg(LTFS_WARN, "30222W", "locate");
+			ltfsmsg(LTFS_WARN, 30222W, "locate");
 		else if(pos->programmable_early_warning)
-			ltfsmsg(LTFS_WARN, "30223W", "locate");
+			ltfsmsg(LTFS_WARN, 30223W, "locate");
 	}
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOCATE));
@@ -1587,23 +1590,23 @@ int sg_ibmtape_space(void *device, size_t count, TC_SPACE_TYPE type, struct tc_p
 	cdb[0] = SPACE16;
 	switch(type) {
 		case TC_SPACE_EOD:
-			ltfsmsg(LTFS_DEBUG, "30392D", "space to EOD", priv->drive_serial);
+			ltfsmsg(LTFS_DEBUG, 30392D, "space to EOD", priv->drive_serial);
 			cdb[1] = 0x03;
 			break;
 		case TC_SPACE_FM_F:
-			ltfsmsg(LTFS_DEBUG, "30396D", "space forward file marks", (unsigned long long)count,
+			ltfsmsg(LTFS_DEBUG, 30396D, "space forward file marks", (unsigned long long)count,
 					priv->drive_serial);
 			cdb[1] = 0x01;
 			ltfs_u64tobe(cdb + 4, count);
 			break;
 		case TC_SPACE_FM_B:
-			ltfsmsg(LTFS_DEBUG, "30396D", "space back file marks", (unsigned long long)count,
+			ltfsmsg(LTFS_DEBUG, 30396D, "space back file marks", (unsigned long long)count,
 					priv->drive_serial);
 			cdb[1] = 0x01;
 			ltfs_u64tobe(cdb + 4, -count);
 			break;
 		case TC_SPACE_F:
-			ltfsmsg(LTFS_DEBUG, "30396D", "space forward records", (unsigned long long)count,
+			ltfsmsg(LTFS_DEBUG, 30396D, "space forward records", (unsigned long long)count,
 					priv->drive_serial);
 			cdb[1] = 0x00;
 			ltfs_u64tobe(cdb + 4, count);
@@ -1614,7 +1617,7 @@ int sg_ibmtape_space(void *device, size_t count, TC_SPACE_TYPE type, struct tc_p
 			break;
 		default:
 			/* unexpected space type */
-			ltfsmsg(LTFS_INFO, "30225I");
+			ltfsmsg(LTFS_INFO, 30225I);
 			ret = -EDEV_INVALID_ARG;
 			break;
 	}
@@ -1642,9 +1645,9 @@ int sg_ibmtape_space(void *device, size_t count, TC_SPACE_TYPE type, struct tc_p
 
 	if(ret == DEVICE_GOOD) {
 		if(pos->early_warning)
-			ltfsmsg(LTFS_WARN, "30222W", "space");
+			ltfsmsg(LTFS_WARN, 30222W, "space");
 		else if(pos->programmable_early_warning)
-			ltfsmsg(LTFS_WARN, "30223W", "space");
+			ltfsmsg(LTFS_WARN, 30223W, "space");
 	}
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SPACE));
@@ -1714,9 +1717,9 @@ int sg_ibmtape_erase(void *device, struct tc_position *pos, bool long_erase)
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_ERASE));
 	if (long_erase)
-		ltfsmsg(LTFS_DEBUG, "30392D", "long erase", priv->drive_serial);
+		ltfsmsg(LTFS_DEBUG, 30392D, "long erase", priv->drive_serial);
 	else
-		ltfsmsg(LTFS_DEBUG, "30392D", "short erase", priv->drive_serial);
+		ltfsmsg(LTFS_DEBUG, 30392D, "short erase", priv->drive_serial);
 
 	get_current_timespec(&ts_start);
 
@@ -1768,11 +1771,11 @@ int sg_ibmtape_erase(void *device, struct tc_position *pos, bool long_erase)
 
 			if (IS_ENTERPRISE(priv->drive_type)) {
 				get_current_timespec(&ts_now);
-				ltfsmsg(LTFS_INFO, "30226I", (ts_now.tv_sec - ts_start.tv_sec)/60);
+				ltfsmsg(LTFS_INFO, 30226I, (int)(ts_now.tv_sec - ts_start.tv_sec)/60);
 			} else {
 				progress = ((uint32_t) sense_buf[16] & 0xFF) << 8;
 				progress += ((uint32_t) sense_buf[17] & 0xFF);
-				ltfsmsg(LTFS_INFO, "30227I", (progress*100/0xFFFF));
+				ltfsmsg(LTFS_INFO, 30227I, (progress*100/0xFFFF));
 			}
 
 			sleep(60);
@@ -1845,7 +1848,7 @@ int sg_ibmtape_load(void *device, struct tc_position *pos)
 	unsigned char buf[TC_MP_SUPPORTEDPAGE_SIZE];
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOAD));
-	ltfsmsg(LTFS_DEBUG, "30392D", "load", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30392D, "load", priv->drive_serial);
 
 	ret = _cdb_load_unload(device, true);
 	sg_ibmtape_readpos(device, pos);
@@ -1855,9 +1858,9 @@ int sg_ibmtape_load(void *device, struct tc_position *pos)
 	} else {
 		if(ret == DEVICE_GOOD) {
 			if(pos->early_warning)
-				ltfsmsg(LTFS_WARN, "30222W", "load");
+				ltfsmsg(LTFS_WARN, 30222W, "load");
 			else if(pos->programmable_early_warning)
-				ltfsmsg(LTFS_WARN, "30223W", "load");
+				ltfsmsg(LTFS_WARN, 30223W, "load");
 		}
 	}
 
@@ -1874,14 +1877,14 @@ int sg_ibmtape_load(void *device, struct tc_position *pos)
 	priv->density_code = buf[8];
 
 	if (priv->cart_type == 0x00) {
-		ltfsmsg(LTFS_WARN, "30265W");
+		ltfsmsg(LTFS_WARN, 30265W);
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOAD));
 		return 0;
 	}
 
 	ret = ibmtape_is_supported_tape(priv->cart_type, priv->density_code, &(priv->is_worm));
 	if(ret == -LTFS_UNSUPPORTED_MEDIUM)
-		ltfsmsg(LTFS_INFO, "30228I", priv->cart_type, priv->density_code);
+		ltfsmsg(LTFS_INFO, 30228I, priv->cart_type, priv->density_code);
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOAD));
 
@@ -1894,7 +1897,7 @@ int sg_ibmtape_unload(void *device, struct tc_position *pos)
 	struct sg_ibmtape_data *priv = (struct sg_ibmtape_data*)device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_UNLOAD));
-	ltfsmsg(LTFS_DEBUG, "30392D", "unload", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30392D, "unload", priv->drive_serial);
 
 	ret = _cdb_load_unload(device, false);
 	if (ret < 0) {
@@ -1962,7 +1965,7 @@ int sg_ibmtape_readpos(void *device, struct tc_position *pos)
 		pos->early_warning = buf[0] & 0x40;
 		pos->programmable_early_warning = buf[0] & 0x01;
 
-		ltfsmsg(LTFS_DEBUG, "30398D", "readpos", (unsigned long long)pos->partition,
+		ltfsmsg(LTFS_DEBUG, 30398D, "readpos", (unsigned long long)pos->partition,
 				(unsigned long long)pos->block, (unsigned long long)pos->filemarks,
 				priv->drive_serial);
 	} else {
@@ -1987,7 +1990,7 @@ int sg_ibmtape_setcap(void *device, uint16_t proportion)
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_SETCAP));
-	ltfsmsg(LTFS_DEBUG, "30393D", "setcap", proportion, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30393D, "setcap", proportion, priv->drive_serial);
 
 	if (IS_ENTERPRISE(priv->drive_type)) {
 		unsigned char buf[TC_MP_MEDIUM_SENSE_SIZE];
@@ -2062,7 +2065,7 @@ int sg_ibmtape_format(void *device, TC_FORMAT_TYPE format)
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_FORMAT));
-	ltfsmsg(LTFS_DEBUG, "30392D", "format", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30392D, "format", priv->drive_serial);
 
 	/* Zero out the CDB and the result buffer */
 	ret = init_sg_io_header(&req);
@@ -2127,7 +2130,7 @@ int sg_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 		ret = sg_ibmtape_logsense(device, (uint8_t)LOG_TAPECAPACITY, (void *)buffer, LOGSENSEPAGE);
 		if(ret < 0)
 		{
-			ltfsmsg(LTFS_INFO, "30229I", LOG_VOLUMESTATS, ret);
+			ltfsmsg(LTFS_INFO, 30229I, LOG_VOLUMESTATS, ret);
 			goto out;
 		}
 
@@ -2136,7 +2139,7 @@ int sg_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 			ret = _parse_logPage(buffer, (uint16_t)i, &param_size, buf, sizeof(buf));
 			if(ret < 0 || param_size != sizeof(uint32_t))
 			{
-				ltfsmsg(LTFS_INFO, "30230I", i, param_size);
+				ltfsmsg(LTFS_INFO, 30230I, i, param_size);
 				ret = -EDEV_INTERNAL_ERROR;
 				goto out;
 			}
@@ -2158,7 +2161,7 @@ int sg_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 					cap->max_p1 = logcap;
 					break;
 				default:
-					ltfsmsg(LTFS_INFO, "30231I", i);
+					ltfsmsg(LTFS_INFO, 30231I, i);
 					ret = -EDEV_INTERNAL_ERROR;
 					goto out;
 					break;
@@ -2170,14 +2173,14 @@ int sg_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 		ret = sg_ibmtape_logsense(device, LOG_VOLUMESTATS, (void *)buffer, LOGSENSEPAGE);
 		if(ret < 0)
 		{
-			ltfsmsg(LTFS_INFO, "30229I", LOG_VOLUMESTATS, ret);
+			ltfsmsg(LTFS_INFO, 30229I, LOG_VOLUMESTATS, ret);
 			goto out;
 		}
 
 		/* Capture Total Cap */
 		ret = _parse_logPage(buffer, (uint16_t)VOLSTATS_PARTITION_CAP, &param_size, buf, sizeof(buf));
 		if (ret < 0) {
-			ltfsmsg(LTFS_INFO, "30232I");
+			ltfsmsg(LTFS_INFO, 30232I);
 			goto out;
 		}
 
@@ -2194,7 +2197,7 @@ int sg_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 		/* Capture Remaining Cap  */
 		ret = _parse_logPage(buffer, (uint16_t)VOLSTATS_PART_REMAIN_CAP, &param_size, buf, sizeof(buf));
 		if (ret < 0) {
-			ltfsmsg(LTFS_INFO, "30232I");
+			ltfsmsg(LTFS_INFO, 30232I);
 			goto out;
 		}
 
@@ -2215,9 +2218,9 @@ int sg_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 		ret = DEVICE_GOOD;
 	}
 
-	ltfsmsg(LTFS_DEBUG3, "30397D", "capacity part0", (unsigned long long)cap->remaining_p0,
+	ltfsmsg(LTFS_DEBUG3, 30397D, "capacity part0", (unsigned long long)cap->remaining_p0,
 			(unsigned long long)cap->max_p0, priv->drive_serial);
-	ltfsmsg(LTFS_DEBUG3, "30397D", "capacity part1", (unsigned long long)cap->remaining_p1,
+	ltfsmsg(LTFS_DEBUG3, 30397D, "capacity part1", (unsigned long long)cap->remaining_p1,
 			(unsigned long long)cap->max_p1, priv->drive_serial);
 
 out:
@@ -2283,7 +2286,7 @@ int sg_ibmtape_logsense(void *device, const unsigned char page, unsigned char *b
 {
 	int ret = -EDEV_UNKNOWN;
 
-	ltfsmsg(LTFS_DEBUG3, "30393D", "logsense", page, "");
+	ltfsmsg(LTFS_DEBUG3, 30393D, "logsense", page, "");
 	ret = _cdb_logsense(device, page, 0x00, buf, size);
 
 	return ret;
@@ -2303,7 +2306,7 @@ int sg_ibmtape_modesense(void *device, const unsigned char page, const TC_MP_PC_
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_MODESENSE));
-	ltfsmsg(LTFS_DEBUG3, "30393D", "modesense", page, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG3, 30393D, "modesense", page, priv->drive_serial);
 
 	/* Zero out the CDB and the result buffer */
 	ret = init_sg_io_header(&req);
@@ -2357,7 +2360,7 @@ int sg_ibmtape_modeselect(void *device, unsigned char *buf, const size_t size)
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_MODESELECT));
-	ltfsmsg(LTFS_DEBUG3, "30392D", "modeselect", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG3, 30392D, "modeselect", priv->drive_serial);
 
 	/* Zero out the CDB and the result buffer */
 	ret = init_sg_io_header(&req);
@@ -2402,7 +2405,7 @@ int sg_ibmtape_reserve(void *device)
 	struct sg_ibmtape_data *priv = (struct sg_ibmtape_data*)device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_RESERVEUNIT));
-	ltfsmsg(LTFS_DEBUG, "30392D", "reserve (PRO)", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30392D, "reserve (PRO)", priv->drive_serial);
 
 start:
 	ret = _cdb_pro(device, PRO_ACT_RESERVE, PRO_TYPE_EXCLUSIVE,
@@ -2414,7 +2417,7 @@ start:
 		   ret == -EDEV_REGISTRATION_PREEMPTED ||
 		   ret == -EDEV_RESERVATION_CONFLICT)
 		) {
-		ltfsmsg(LTFS_INFO, "30268I", priv->drive_serial);
+		ltfsmsg(LTFS_INFO, 30268I, priv->drive_serial);
 		_register_key(device, priv->key);
 		count++;
 		goto start;
@@ -2431,7 +2434,7 @@ int sg_ibmtape_release(void *device)
 	struct sg_ibmtape_data *priv = (struct sg_ibmtape_data*)device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_RELEASEUNIT));
-	ltfsmsg(LTFS_DEBUG, "30392D", "release (PRO)", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30392D, "release (PRO)", priv->drive_serial);
 
 	ret = _cdb_pro(device, PRO_ACT_RELEASE, PRO_TYPE_EXCLUSIVE,
 				   priv->key, NULL);
@@ -2493,7 +2496,7 @@ int sg_ibmtape_prevent_medium_removal(void *device)
 	struct sg_ibmtape_data *priv = (struct sg_ibmtape_data*)device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_PREVENTM));
-	ltfsmsg(LTFS_DEBUG, "30392D", "prevent medium removal", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30392D, "prevent medium removal", priv->drive_serial);
 	ret = _cdb_prevent_allow_medium_removal(device, true);
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_PREVENTM));
 
@@ -2506,7 +2509,7 @@ int sg_ibmtape_allow_medium_removal(void *device)
 	struct sg_ibmtape_data *priv = (struct sg_ibmtape_data*)device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_ALLOWMREM));
-	ltfsmsg(LTFS_DEBUG, "30392D", "allow medium removal", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30392D, "allow medium removal", priv->drive_serial);
 	ret = _cdb_prevent_allow_medium_removal(device, false);
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_ALLOWMREM));
 
@@ -2527,14 +2530,14 @@ int sg_ibmtape_write_attribute(void *device, const tape_partition_t part,
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_WRITEATTR));
-	ltfsmsg(LTFS_DEBUG3, "30396D", "writeattr", (unsigned long long)part,
+	ltfsmsg(LTFS_DEBUG3, 30396D, "writeattr", (unsigned long long)part,
 			priv->drive_serial);
 
 	/* Prepare the buffer to transfer */
 	uint32_t len = size + 4;
 	unsigned char *buffer = calloc(1, len);
 	if (!buffer) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -EDEV_NO_MEMORY;
 	}
 
@@ -2598,13 +2601,13 @@ int sg_ibmtape_read_attribute(void *device, const tape_partition_t part,
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_READATTR));
-	ltfsmsg(LTFS_DEBUG3, "30397D", "readattr", (unsigned long)part, id, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG3, 30397D, "readattr", (unsigned long long)part, (unsigned long long)id, priv->drive_serial);
 
 	/* Prepare the buffer to transfer */
 	uint32_t len = size + 4;
 	unsigned char *buffer = calloc(1, len);
 	if (!buffer) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -EDEV_NO_MEMORY;
 	}
 
@@ -2655,7 +2658,7 @@ int sg_ibmtape_read_attribute(void *device, const tape_partition_t part,
 			id != TC_MAM_TEXT_LOCALIZATION_IDENTIFIER &&
 			id != TC_MAM_BARCODE &&
 			id != TC_MAM_APP_FORMAT_VERSION)
-			ltfsmsg(LTFS_INFO, "30233I", ret);
+			ltfsmsg(LTFS_INFO, 30233I, ret);
 	} else {
 		memcpy(buf, buffer + 4, size);
 	}
@@ -2679,7 +2682,7 @@ int sg_ibmtape_allow_overwrite(void *device, const struct tc_position pos)
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_ALLOWOVERW));
-	ltfsmsg(LTFS_DEBUG, "30397D", "allow overwrite", pos.partition, pos.block, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30397D, "allow overwrite", (unsigned long long)pos.partition, (unsigned long long)pos.block, priv->drive_serial);
 
 	/* Zero out the CDB and the result buffer */
 	ret = init_sg_io_header(&req);
@@ -2711,7 +2714,7 @@ int sg_ibmtape_allow_overwrite(void *device, const struct tc_position pos)
 	ret = sg_issue_cdb_command(&priv->dev, &req, &msg);
 	if (ret < 0){
 		if (pos.block == TAPE_BLOCK_MAX && ret == -EDEV_EOD_DETECTED) {
-			ltfsmsg(LTFS_DEBUG, "30224D", "Allow Overwrite");
+			ltfsmsg(LTFS_DEBUG, 30224D, "Allow Overwrite");
 			ret = DEVICE_GOOD;
 		} else {
 			_process_errors(device, ret, msg, cmd_desc, true);
@@ -2764,7 +2767,7 @@ int sg_ibmtape_set_default(void *device)
 	/* Disable Read across EOD on the enterprise drive */
 	if (IS_ENTERPRISE(priv->drive_type)) {
 		unsigned char buf[TC_MP_READ_WRITE_CTRL_SIZE];
-		ltfsmsg(LTFS_DEBUG, "30392D", __FUNCTION__, "Disabling read across EOD");
+		ltfsmsg(LTFS_DEBUG, 30392D, __FUNCTION__, "Disabling read across EOD");
 		ret = sg_ibmtape_modesense(device, TC_MP_READ_WRITE_CTRL, TC_MP_PC_CURRENT, 0, buf, sizeof(buf));
 		if (ret < 0) {
 			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETDEFAULT));
@@ -2784,10 +2787,10 @@ int sg_ibmtape_set_default(void *device)
 
 	/* set logical block protection */
 	if (global_data.crc_checking) {
-		ltfsmsg(LTFS_DEBUG, "30392D", __FUNCTION__, "Setting LBP");
+		ltfsmsg(LTFS_DEBUG, 30392D, __FUNCTION__, "Setting LBP");
 		ret = _set_lbp(device, true);
 	} else {
-		ltfsmsg(LTFS_DEBUG, "30392D", __FUNCTION__, "Resetting LBP");
+		ltfsmsg(LTFS_DEBUG, 30392D, __FUNCTION__, "Resetting LBP");
 		ret = _set_lbp(device, false);
 	}
 
@@ -2851,11 +2854,11 @@ int sg_ibmtape_get_cartridge_health(void *device, struct tc_cartridge_health *ca
 	cart_health->tape_efficiency  = UNSUPPORTED_CARTRIDGE_HEALTH;
 	ret = sg_ibmtape_logsense(device, LOG_PERFORMANCE, logdata, LOGSENSEPAGE);
 	if (ret)
-		ltfsmsg(LTFS_INFO, "30234I", LOG_PERFORMANCE, ret, "get cart health");
+		ltfsmsg(LTFS_INFO, 30234I, LOG_PERFORMANCE, ret, "get cart health");
 	else {
 		for(i = 0; i < (int)((sizeof(perfstats)/sizeof(perfstats[0]))); i++) {
 			if (_parse_logPage(logdata, perfstats[i], &param_size, buf, 16)) {
-				ltfsmsg(LTFS_INFO, "30235I", LOG_PERFORMANCE, "get cart health");
+				ltfsmsg(LTFS_INFO, 30235I, LOG_PERFORMANCE, "get cart health");
 			} else {
 				switch(param_size) {
 					case sizeof(uint8_t):
@@ -2906,11 +2909,11 @@ int sg_ibmtape_get_cartridge_health(void *device, struct tc_cartridge_health *ca
 	cart_health->passes_middle    = UNSUPPORTED_CARTRIDGE_HEALTH;
 	ret = sg_ibmtape_logsense(device, LOG_VOLUMESTATS, logdata, LOGSENSEPAGE);
 	if (ret < 0)
-		ltfsmsg(LTFS_INFO, "30234I", LOG_VOLUMESTATS, ret, "get cart health");
+		ltfsmsg(LTFS_INFO, 30234I, LOG_VOLUMESTATS, ret, "get cart health");
 	else {
 		for(i = 0; i < (int)((sizeof(volstats)/sizeof(volstats[0]))); i++) {
 			if (_parse_logPage(logdata, volstats[i], &param_size, buf, 16)) {
-				ltfsmsg(LTFS_INFO, "30235I", LOG_VOLUMESTATS, "get cart health");
+				ltfsmsg(LTFS_INFO, 30235I, LOG_VOLUMESTATS, "get cart health");
 			} else {
 				switch(param_size) {
 					case sizeof(uint8_t):
@@ -3002,12 +3005,12 @@ int sg_ibmtape_get_tape_alert(void *device, uint64_t *tape_alert)
 	ta = 0;
 	ret = sg_ibmtape_logsense(device, LOG_TAPE_ALERT, logdata, LOGSENSEPAGE);
 	if (ret < 0)
-		ltfsmsg(LTFS_INFO, "30234I", LOG_TAPE_ALERT, ret, "get tape alert");
+		ltfsmsg(LTFS_INFO, 30234I, LOG_TAPE_ALERT, ret, "get tape alert");
 	else {
 		for(i = 1; i <= 64; i++) {
 			if (_parse_logPage(logdata, (uint16_t) i, &param_size, buf, 16)
 				|| param_size != sizeof(uint8_t)) {
-				ltfsmsg(LTFS_INFO, "30235I", LOG_VOLUMESTATS, "get tape alert");
+				ltfsmsg(LTFS_INFO, 30235I, LOG_VOLUMESTATS, "get tape alert");
 				ta = 0;
 			}
 
@@ -3059,10 +3062,10 @@ int sg_ibmtape_get_xattr(void *device, const char *name, char **buf)
 			ret = _cdb_logsense(device, LOG_PERFORMANCE, LOG_PERFORMANCE_CAPACITY_SUB, logdata, LOGSENSEPAGE);
 
 			if (ret < 0) {
-				ltfsmsg(LTFS_INFO, "30234I", LOG_PERFORMANCE, ret, "get xattr");
+				ltfsmsg(LTFS_INFO, 30234I, LOG_PERFORMANCE, ret, "get xattr");
 			} else {
 				if (_parse_logPage(logdata, PERF_ACTIVE_CQ_LOSS_W, &param_size, logbuf, 16)) {
-					ltfsmsg(LTFS_INFO, "30235I", LOG_PERFORMANCE,  "get xattr");
+					ltfsmsg(LTFS_INFO, 30235I, LOG_PERFORMANCE,  "get xattr");
 					ret = -LTFS_NO_XATTR;
 				}
 				else {
@@ -3074,7 +3077,7 @@ int sg_ibmtape_get_xattr(void *device, const char *name, char **buf)
 							priv->dirty_acq_loss_w = false;
 							break;
 						default:
-							ltfsmsg(LTFS_INFO, "30236I", param_size);
+							ltfsmsg(LTFS_INFO, 30236I, param_size);
 							ret = -LTFS_NO_XATTR;
 							break;
 					}
@@ -3087,7 +3090,7 @@ int sg_ibmtape_get_xattr(void *device, const char *name, char **buf)
 		/* The buf allocated here shall be freed in xattr_get_virtual() */
 		ret = asprintf(buf, "%2.2f", priv->acq_loss_w);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			ret = -EDEV_NO_MEMORY;
 		} else {
 			ret = DEVICE_GOOD;
@@ -3124,7 +3127,7 @@ static int _cdb_read_block_limits(void *device) {
 
 	unsigned char buf[BLOCKLEN_DATA_SIZE];
 
-	ltfsmsg(LTFS_DEBUG, "30392D", "read block limits", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30392D, "read block limits", priv->drive_serial);
 
 	/* Zero out the CDB and the result buffer */
 	ret = init_sg_io_header(&req);
@@ -3257,7 +3260,7 @@ int sg_ibmtape_get_eod_status(void *device, int part)
 	/* Issue LogPage 0x17 */
 	ret = sg_ibmtape_logsense(device, LOG_VOLUMESTATS, logdata, LOGSENSEPAGE);
 	if (ret) {
-		ltfsmsg(LTFS_WARN, "30237W", LOG_VOLUMESTATS, ret);
+		ltfsmsg(LTFS_WARN, 30237W, LOG_VOLUMESTATS, ret);
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETEODSTAT));
 		return EOD_UNKNOWN;
 	}
@@ -3265,7 +3268,7 @@ int sg_ibmtape_get_eod_status(void *device, int part)
 	/* Parse Approximate used native capacity of partitions (0x203)*/
 	if (_parse_logPage(logdata, (uint16_t)VOLSTATS_PART_USED_CAP, &param_size, buf, sizeof(buf))
 		|| (param_size != sizeof(buf) ) ) {
-		ltfsmsg(LTFS_WARN, "30238W");
+		ltfsmsg(LTFS_WARN, 30238W);
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETEODSTAT));
 		return EOD_UNKNOWN;
 	}
@@ -3284,7 +3287,7 @@ int sg_ibmtape_get_eod_status(void *device, int part)
 				((uint32_t) buf[i + 6] << 8) +
 				(uint32_t) buf[i + 7];
 		} else
-			ltfsmsg(LTFS_WARN, "30239W", i, part_buf, len);
+			ltfsmsg(LTFS_WARN, 30239W, i, part_buf, len);
 
 		i += (len + 1);
 	}
@@ -3328,7 +3331,7 @@ int sg_ibmtape_get_device_list(struct tc_drive_info *buf, int count)
 
 	dp = opendir("/dev");
 	if (!dp) {
-		ltfsmsg(LTFS_INFO, "30240I");
+		ltfsmsg(LTFS_INFO, 30240I);
 		return -EDEV_DEVICE_UNOPENABLE;
 	}
 
@@ -3387,7 +3390,7 @@ int sg_ibmtape_get_device_list(struct tc_drive_info *buf, int count)
 
 void sg_ibmtape_help_message(void)
 {
-	ltfsresult("30399I", default_device);
+	ltfsresult(30399I, default_device);
 }
 
 int sg_ibmtape_parse_opts(void *device, void *opt_args)
@@ -3408,7 +3411,7 @@ int sg_ibmtape_parse_opts(void *device, void *opt_args)
 		else if (strcasecmp(global_data.str_crc_checking, "off") == 0)
 			global_data.crc_checking = 0;
 		else {
-			ltfsmsg(LTFS_ERR, "30241E", global_data.str_crc_checking);
+			ltfsmsg(LTFS_ERR, 30241E, global_data.str_crc_checking);
 			return -EDEV_INTERNAL_ERROR;
 		}
 	} else
@@ -3447,7 +3450,7 @@ static int _cdb_spin(void *device, const uint16_t sps, unsigned char **buffer, s
 
 	*buffer = calloc(len, sizeof(unsigned char));
 	if (! *buffer) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -EDEV_NO_MEMORY;
 	}
 
@@ -3543,7 +3546,7 @@ static void ltfsmsg_keyalias(const char * const title, const unsigned char * con
 	else
 		sprintf(s, "keyalias: NULL");
 
-	ltfsmsg(LTFS_DEBUG, "30392D", title, s);
+	ltfsmsg(LTFS_DEBUG, 30392D, title, s);
 }
 
 static bool is_ame(void *device)
@@ -3554,7 +3557,7 @@ static bool is_ame(void *device)
 	if (ret != 0) {
 		char message[100] = {0};
 		sprintf(message, "failed to get MP %02Xh (%d)", TC_MP_READ_WRITE_CTRL, ret);
-		ltfsmsg(LTFS_DEBUG, "30392D", __FUNCTION__, message);
+		ltfsmsg(LTFS_DEBUG, 30392D, __FUNCTION__, message);
 
 		return false; /* Consider that the encryption method is not AME */
 	} else {
@@ -3588,10 +3591,10 @@ static bool is_ame(void *device)
 				break;
 		}
 		sprintf(message, "Encryption Method is %s (0x%02X)", method, encryption_method);
-		ltfsmsg(LTFS_DEBUG, "30392D", __FUNCTION__, message);
+		ltfsmsg(LTFS_DEBUG, 30392D, __FUNCTION__, message);
 
 		if (encryption_method != 0x50) {
-			ltfsmsg(LTFS_ERR, "30242E", method, encryption_method);
+			ltfsmsg(LTFS_ERR, 30242E, method, encryption_method);
 		}
 		return encryption_method == 0x50;
 	}
@@ -3602,7 +3605,7 @@ static int is_encryption_capable(void *device)
 	struct sg_ibmtape_data *priv = (struct sg_ibmtape_data*)device;
 
 	if (IS_LTO(priv->drive_type)) {
-		ltfsmsg(LTFS_ERR, "30243E", priv->drive_type);
+		ltfsmsg(LTFS_ERR, 30243E, priv->drive_type);
 		return -EDEV_INTERNAL_ERROR;
 	}
 
@@ -3634,7 +3637,7 @@ int sg_ibmtape_set_key(void *device, const unsigned char *keyalias, const unsign
 	const size_t size = keyalias ? 20 + DK_LENGTH + 4 + DKI_LENGTH : 20;
 	uint8_t *buffer = calloc(size, sizeof(uint8_t));
 	if (! buffer) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		ret = -EDEV_NO_MEMORY;
 		goto out;
 	}
@@ -3733,7 +3736,7 @@ static void show_hex_dump(const char * const title, const uint8_t * const buf, c
 		p += sprintf(p, "%c", isprint(buf[i-j]) ? buf[i-j] : '.');
 	}
 
-	ltfsmsg(LTFS_DEBUG, "30392D", title, s);
+	ltfsmsg(LTFS_DEBUG, 30392D, title, s);
 }
 
 int sg_ibmtape_get_keyalias(void *device, unsigned char **keyalias)
@@ -3874,7 +3877,7 @@ int sg_ibmtape_get_serialnumber(void *device, char **result)
 
 	*result = strdup((const char *) priv->drive_serial);
 	if (! *result) {
-		ltfsmsg(LTFS_ERR, "10001E", "sg_ibmtape_get_serialnumber: result");
+		ltfsmsg(LTFS_ERR, 10001E, "sg_ibmtape_get_serialnumber: result");
 		ltfs_profiler_add_entry(priv->profiler, NULL, CHANGER_REQ_EXIT(REQ_TC_GETSER));
 		return -EDEV_NO_MEMORY;
 	}
@@ -3903,7 +3906,7 @@ int sg_ibmtape_set_profiler(void *device, char *work_dir, bool enable)
 		rc = asprintf(&path, "%s/%s%s%s", work_dir, DRIVER_PROFILER_BASE,
 					  "DUMMY", PROFILER_EXTENSION);
 		if (rc < 0) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -EDEV_NO_MEMORY;
 		}
 
@@ -3975,8 +3978,8 @@ int sg_ibmtape_get_block_in_buffer(void *device, uint32_t *block)
 	if (ret == DEVICE_GOOD) {
 		*block = (buf[5] << 16) + (buf[6] << 8) + (int)buf[7];
 
-		ltfsmsg(LTFS_DEBUG, "30398D", "blocks-in-buffer",
-				(unsigned long long) *block, 0, 0, priv->drive_serial);
+		ltfsmsg(LTFS_DEBUG, 30398D, "blocks-in-buffer",
+				(unsigned long long)*block, (unsigned long long)0, (unsigned long long)0, priv->drive_serial);
 	} else {
 		_process_errors(device, ret, msg, cmd_desc, true);
 	}

--- a/src/tape_drivers/linux/sg-ibmtape/sg_scsi_tape.c
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_scsi_tape.c
@@ -151,7 +151,7 @@ int sg_issue_cdb_command(struct sg_tape *device, sg_io_hdr_t *req, char **msg)
 
 	ret = ioctl(device->fd, SG_IO, req);
 	if (ret < 0) {
-		ltfsmsg(LTFS_INFO, "30200I", *req->cmdp, errno);
+		ltfsmsg(LTFS_INFO, 30200I, *req->cmdp, errno);
 		return -EDEV_INTERNAL_ERROR;
 	}
 
@@ -162,28 +162,28 @@ int sg_issue_cdb_command(struct sg_tape *device, sg_io_hdr_t *req, char **msg)
 		case SCSI_CHECK_CONDITION:
 			if (req->sb_len_wr) {
 				ret = sg_sense2errno(req, &sense, msg);
-				ltfsmsg(LTFS_DEBUG, "30201D", sense, *msg);
+				ltfsmsg(LTFS_DEBUG, 30201D, sense, *msg);
 			} else {
 				ret = -EDEV_NO_SENSE;
-				ltfsmsg(LTFS_DEBUG, "30202D", "nosense");
+				ltfsmsg(LTFS_DEBUG, 30202D, "nosense");
 			}
 			break;
 		case SCSI_BUSY:
-			ltfsmsg(LTFS_DEBUG, "30202D", "busy");
+			ltfsmsg(LTFS_DEBUG, 30202D, "busy");
 			ret = -EDEV_DEVICE_BUSY;
 			if (msg) {
 				*msg = "Drive busy";
 			}
 			break;
 		case SCSI_RESERVATION_CONFLICT:
-			ltfsmsg(LTFS_DEBUG, "30202D", "reservation conflict");
+			ltfsmsg(LTFS_DEBUG, 30202D, "reservation conflict");
 			ret = -EDEV_RESERVATION_CONFLICT;
 			if (msg) {
 				*msg = "Drive reservation conflict";
 			}
 			break;
 		default:
-			ltfsmsg(LTFS_INFO, "30203I", req->masked_status, req->host_status, req->driver_status);
+			ltfsmsg(LTFS_INFO, 30203I, req->masked_status, req->host_status, req->driver_status);
 			if (req->host_status) {
 				ret = -EDEV_HOST_ERROR;
 				if (msg) {
@@ -205,9 +205,9 @@ int sg_issue_cdb_command(struct sg_tape *device, sg_io_hdr_t *req, char **msg)
 
 	if (ret != DEVICE_GOOD) {
 		if (is_expected_error(device, req->cmdp, ret)) {
-			ltfsmsg(LTFS_DEBUG, "30204D", (char *)req->usr_ptr, req->cmdp[0], ret);
+			ltfsmsg(LTFS_DEBUG, 30204D, (char *)req->usr_ptr, req->cmdp[0], ret);
 		} else {
-			ltfsmsg(LTFS_INFO, "30205I", (char *)req->usr_ptr, req->cmdp[0], ret);
+			ltfsmsg(LTFS_INFO, 30205I, (char *)req->usr_ptr, req->cmdp[0], ret);
 		}
 	}
 
@@ -265,7 +265,7 @@ int sg_get_drive_identifier(struct sg_tape *device, scsi_device_identifier *id_d
 
 	ret = _inquiry_low(device, 0, inquiry_buf, MAX_INQ_LEN);
 	if( ret < 0 ) {
-		ltfsmsg(LTFS_INFO, "30206I", ret);
+		ltfsmsg(LTFS_INFO, 30206I, ret);
 		return ret;
 	}
 
@@ -282,7 +282,7 @@ int sg_get_drive_identifier(struct sg_tape *device, scsi_device_identifier *id_d
 
 	ret = _inquiry_low(device, 0x80, inquiry_buf, MAX_INQ_LEN);
 	if( ret < 0 ) {
-		ltfsmsg(LTFS_INFO, "30206I", ret);
+		ltfsmsg(LTFS_INFO, 30206I, ret);
 		return ret;
 	}
 

--- a/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
+++ b/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
@@ -196,8 +196,8 @@ static int _set_lbp(void *device, bool enable)
 		lbp_method = REED_SOLOMON_CRC;
 
 	/* set logical block protection */
-	ltfsmsg(LTFS_DEBUG, "30993D", "LBP Enable", enable, "");
-	ltfsmsg(LTFS_DEBUG, "30993D", "LBP Method", lbp_method, "");
+	ltfsmsg(LTFS_DEBUG, 30993D, "LBP Enable", enable, "");
+	ltfsmsg(LTFS_DEBUG, 30993D, "LBP Method", lbp_method, "");
 	ret = iokit_ibmtape_modesense(device, TC_MP_CTRL, TC_MP_PC_CURRENT,
 								  TC_MP_SUB_DP_CTRL, buf, sizeof(buf));
 	if (ret < 0)
@@ -233,11 +233,11 @@ static int _set_lbp(void *device, bool enable)
 					priv->f_crc_check = NULL;
 					break;
 			}
-			ltfsmsg(LTFS_INFO, "30853I");
+			ltfsmsg(LTFS_INFO, 30853I);
 		} else {
 			priv->f_crc_enc   = NULL;
 			priv->f_crc_check = NULL;
-			ltfsmsg(LTFS_INFO, "30854I");
+			ltfsmsg(LTFS_INFO, 30854I);
 		}
 	}
 
@@ -276,13 +276,13 @@ static int _get_dump(struct iokit_ibmtape_data *priv, char *fname)
 	unsigned char           *dump_buf;
 	int                     buf_id;
 
-	ltfsmsg(LTFS_INFO, "30855I", fname);
+	ltfsmsg(LTFS_INFO, 30855I, fname);
 
 	/* Set transfer size */
 	transfer_size = DUMP_TRANSFER_SIZE;
 	dump_buf = calloc(1, DUMP_TRANSFER_SIZE);
 	if(!dump_buf){
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -EDEV_NO_MEMORY;
 	}
 
@@ -300,7 +300,7 @@ static int _get_dump(struct iokit_ibmtape_data *priv, char *fname)
 	/* Open dump file for write only*/
 	dumpfd = open(fname, O_WRONLY|O_CREAT|O_TRUNC, 0666);
 	if(dumpfd < 0){
-		ltfsmsg(LTFS_WARN, "30856W", errno);
+		ltfsmsg(LTFS_WARN, 30856W, errno);
 		free(dump_buf);
 		return -2;
 	}
@@ -312,13 +312,13 @@ static int _get_dump(struct iokit_ibmtape_data *priv, char *fname)
 		num_transfers += 1;
 
 	/* Total dump data length is %lld. Total number of transfers is %d. */
-	ltfsmsg(LTFS_DEBUG, "30857D", data_length);
-	ltfsmsg(LTFS_DEBUG, "30858D", num_transfers);
+	ltfsmsg(LTFS_DEBUG, 30857D, data_length);
+	ltfsmsg(LTFS_DEBUG, 30858D, num_transfers);
 
 	/* start to transfer data */
 	buf_offset = 0;
 	i = 0;
-	ltfsmsg(LTFS_DEBUG, "30859D");
+	ltfsmsg(LTFS_DEBUG, 30859D);
 	while(num_transfers)
 	{
 		int length;
@@ -333,7 +333,7 @@ static int _get_dump(struct iokit_ibmtape_data *priv, char *fname)
 
 		ret = _cdb_read_buffer(priv, buf_id, dump_buf, buf_offset, length, 0x02);
 		if (ret) {
-			ltfsmsg(LTFS_WARN, "30860W", ret);
+			ltfsmsg(LTFS_WARN, 30860W, ret);
 			free(dump_buf);
 			close(dumpfd);
 			return ret;
@@ -343,7 +343,7 @@ static int _get_dump(struct iokit_ibmtape_data *priv, char *fname)
 		bytes = write(dumpfd, dump_buf, length);
 		if(bytes == -1)
 		{
-			ltfsmsg(LTFS_WARN, "30861W", ret);
+			ltfsmsg(LTFS_WARN, 30861W, ret);
 			free(dump_buf);
 			close(dumpfd);
 			return -1;
@@ -351,7 +351,7 @@ static int _get_dump(struct iokit_ibmtape_data *priv, char *fname)
 
 		if(bytes != length)
 		{
-			ltfsmsg(LTFS_WARN, "30862W", bytes, length);
+			ltfsmsg(LTFS_WARN, 30862W, bytes, length);
 			free(dump_buf);
 			close(dumpfd);
 			return -2;
@@ -390,13 +390,13 @@ static int _take_dump(struct iokit_ibmtape_data *priv, bool capture_unforced)
 			, tm_now->tm_sec);
 
 	if (capture_unforced) {
-		ltfsmsg(LTFS_INFO, "30863I");
+		ltfsmsg(LTFS_INFO, 30863I);
 		strcpy(fname, fname_base);
 		strcat(fname, ".dmp");
 		_get_dump(priv, fname);
 	}
 
-	ltfsmsg(LTFS_INFO, "30864I");
+	ltfsmsg(LTFS_INFO, 30864I);
 	_cdb_force_dump(priv);
 	strcpy(fname, fname_base);
 	strcat(fname, "_f.dmp");
@@ -412,9 +412,9 @@ static void _process_errors(struct iokit_ibmtape_data *priv, int ret, char *msg,
 	bool unforced_dump;
 
 	if (msg != NULL) {
-		ltfsmsg(LTFS_INFO, "30865I", cmd, msg, ret, priv->devname);
+		ltfsmsg(LTFS_INFO, 30865I, cmd, msg, ret, priv->devname);
 	} else {
-		ltfsmsg(LTFS_ERR, "30866E", cmd, ret, priv->devname);
+		ltfsmsg(LTFS_ERR, 30866E, cmd, ret, priv->devname);
 	}
 
 	if (priv) {
@@ -436,7 +436,7 @@ static int _cdb_read_buffer(void *device, int id, unsigned char *buf, size_t off
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "READ_BUFFER";
 	char *msg;
 
-	ltfsmsg(LTFS_DEBUG, "30993D", "read buffer", id, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30993D, "read buffer", id, priv->drive_serial);
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -488,7 +488,7 @@ static int _cdb_force_dump(struct iokit_ibmtape_data *priv)
 
 	unsigned char buf[SENDDIAG_BUF_LEN];
 
-	ltfsmsg(LTFS_DEBUG, "30993D", "force dump", 0, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30993D, "force dump", 0, priv->drive_serial);
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -587,7 +587,7 @@ static int _fetch_reservation_key(void *device, struct reservation_info *r)
 start:
 	buf = calloc(1, bufsize);
 	if (!buf) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -EDEV_NO_MEMORY;
 	}
 
@@ -682,13 +682,13 @@ static int _cdb_pro(void *device,
 			memset(&r_info, 0x00, sizeof(r_info));
 			f_ret = _fetch_reservation_key(device, &r_info);
 			if (!f_ret) {
-				ltfsmsg(LTFS_WARN, "30869W", r_info.hint, priv->drive_serial);
-				ltfsmsg(LTFS_WARN, "30867W",
+				ltfsmsg(LTFS_WARN, 30869W, r_info.hint, priv->drive_serial);
+				ltfsmsg(LTFS_WARN, 30867W,
 						r_info.wwid[0], r_info.wwid[1], r_info.wwid[2], r_info.wwid[3],
 						r_info.wwid[6], r_info.wwid[5], r_info.wwid[6], r_info.wwid[7],
 						priv->drive_serial);
 			} else {
-				ltfsmsg(LTFS_WARN, "30869W", "unknown host (reserve command)", priv->drive_serial);
+				ltfsmsg(LTFS_WARN, 30869W, "unknown host (reserve command)", priv->drive_serial);
 			}
 		} else {
 			_process_errors(device, ret, msg, cmd_desc, true);
@@ -725,17 +725,17 @@ int iokit_ibmtape_open(const char *devname, void **handle)
 	struct iokit_ibmtape_data *priv;
 	scsi_device_identifier id_data;
 
-	ltfsmsg(LTFS_INFO, "30810I", devname);
+	ltfsmsg(LTFS_INFO, 30810I, devname);
 
 	priv = calloc(1, sizeof(struct iokit_ibmtape_data));
 	if(!priv) {
-		ltfsmsg(LTFS_ERR, "10001E", "iokit_ibmtape_open: private data");
+		ltfsmsg(LTFS_ERR, 10001E, "iokit_ibmtape_open: private data");
 		return -EDEV_NO_MEMORY;
 	}
 
 	priv->devname = strdup(devname);
 	if (!priv->devname) {
-		ltfsmsg(LTFS_ERR, "10001E", "iokit_ibmtape_open: devname");
+		ltfsmsg(LTFS_ERR, 10001E, "iokit_ibmtape_open: devname");
 		free(priv);
 		return -EDEV_NO_MEMORY;
 	}
@@ -745,7 +745,7 @@ int iokit_ibmtape_open(const char *devname, void **handle)
 	errno = 0;
 	drive_number = strtoul(devname, &end, 10);
 	if(errno || (*end != '\0')) {
-		ltfsmsg(LTFS_INFO, "30811I", devname);
+		ltfsmsg(LTFS_INFO, 30811I, devname);
 		ret = -EDEV_DEVICE_UNOPENABLE;
 		goto free;
 	}
@@ -762,7 +762,7 @@ int iokit_ibmtape_open(const char *devname, void **handle)
 
 	ret = iokit_get_drive_identifier(&priv->dev, &id_data);
 	if(ret < 0) {
-		ltfsmsg(LTFS_INFO, "30812I", devname);
+		ltfsmsg(LTFS_INFO, 30812I, devname);
 		goto free;
 	}
 	strncpy(priv->drive_serial, id_data.unit_serial, UNIT_SERIAL_LENGTH - 1);
@@ -786,16 +786,16 @@ int iokit_ibmtape_open(const char *devname, void **handle)
 		} else
 			priv->drive_type = drive_type;
 	} else {
-		ltfsmsg(LTFS_INFO, "30813I", id_data.product_id);
+		ltfsmsg(LTFS_INFO, 30813I, id_data.product_id);
 		iokit_release_exclusive_access(&priv->dev);
 		ret = -EDEV_DEVICE_UNSUPPORTABLE; /* Unsupported device */
 		goto free;
 	}
 
-	ltfsmsg(LTFS_INFO, "30814I", id_data.vendor_id);
-	ltfsmsg(LTFS_INFO, "30815I", id_data.product_id);
-	ltfsmsg(LTFS_INFO, "30816I", id_data.product_rev);
-	ltfsmsg(LTFS_INFO, "30817I", priv->drive_serial);
+	ltfsmsg(LTFS_INFO, 30814I, id_data.vendor_id);
+	ltfsmsg(LTFS_INFO, 30815I, id_data.product_id);
+	ltfsmsg(LTFS_INFO, 30816I, id_data.product_rev);
+	ltfsmsg(LTFS_INFO, 30817I, priv->drive_serial);
 
 	/* Setup IBM tape specific parameters */
 	standard_table = standard_tape_errors;
@@ -834,12 +834,12 @@ int iokit_ibmtape_reopen(const char *devname, void *device)
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_REOPEN));
 
-	ltfsmsg(LTFS_INFO, "30818I", devname);
+	ltfsmsg(LTFS_INFO, 30818I, devname);
 
 	errno = 0;
 	drive_number = strtoul(devname, &end, 10);
 	if(errno || (*end != '\0')) {
-		ltfsmsg(LTFS_INFO, "30811I", devname);
+		ltfsmsg(LTFS_INFO, 30811I, devname);
 		ret = -EDEV_DEVICE_UNOPENABLE;
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REOPEN));
 		return ret;
@@ -883,7 +883,7 @@ int iokit_ibmtape_reopen(const char *devname, void *device)
 		} else
 			priv->drive_type = drive_type;
 	} else {
-		ltfsmsg(LTFS_INFO, "30813I", id_data.product_id);
+		ltfsmsg(LTFS_INFO, 30813I, id_data.product_id);
 		iokit_release_exclusive_access(&priv->dev);
 		ret = -EDEV_DEVICE_UNSUPPORTABLE; /* Unsupported device */
 	}
@@ -961,7 +961,7 @@ int iokit_ibmtape_inquiry_page(void *device, unsigned char page, struct tc_inq_p
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_INQUIRYPAGE));
-	ltfsmsg(LTFS_DEBUG, "30993D", "inquiry", page, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30993D, "inquiry", page, priv->drive_serial);
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -1040,7 +1040,7 @@ int iokit_ibmtape_test_unit_ready(void *device)
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_TUR));
-	ltfsmsg(LTFS_DEBUG3, "30992D", "test unit ready", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG3, 30992D, "test unit ready", priv->drive_serial);
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -1154,40 +1154,40 @@ static int _cdb_read(void *device, char *buf, size_t size, boolean_t sili)
 						 * In this case, LTFS will trust SCSI sense.
 						 */
 						if (diff_len < 0) {
-							ltfsmsg(LTFS_INFO, "30820I", diff_len, size - diff_len); // "Detect overrun condition"
+							ltfsmsg(LTFS_INFO, 30820I, diff_len, size - diff_len); // "Detect overrun condition"
 							ret = -EDEV_OVERRUN;
 						} else {
-							ltfsmsg(LTFS_DEBUG, "30821D", diff_len, size - diff_len); // "Detect underrun condition"
+							ltfsmsg(LTFS_DEBUG, 30821D, diff_len, size - diff_len); // "Detect underrun condition"
 							length = size - diff_len;
 							ret = DEVICE_GOOD;
 						}
 #else
-						ltfsmsg(LTFS_WARN, "30819W", req.actual_xfered, req.resid, diff_len);
+						ltfsmsg(LTFS_WARN, 30819W, req.actual_xfered, req.resid, diff_len);
 						return -EDEV_LENGTH_MISMATCH;
 #endif
 					} else {
 						if (diff_len < 0) {
-							ltfsmsg(LTFS_INFO, "30820I", diff_len, size - diff_len); // "Detect overrun condition"
+							ltfsmsg(LTFS_INFO, 30820I, diff_len, size - diff_len); // "Detect overrun condition"
 							ret = -EDEV_OVERRUN;
 						} else {
-							ltfsmsg(LTFS_DEBUG, "30821D", diff_len, size - diff_len); // "Detect underrun condition"
+							ltfsmsg(LTFS_DEBUG, 30821D, diff_len, size - diff_len); // "Detect underrun condition"
 							length = size - diff_len;
 							ret = DEVICE_GOOD;
 						}
 					}
 				} else if (sense_data->SENSE_KEY & kSENSE_FILEMARK_Set) {
-					ltfsmsg(LTFS_DEBUG, "30822D");
+					ltfsmsg(LTFS_DEBUG, 30822D);
 					ret = -EDEV_FILEMARK_DETECTED;
 					length = -EDEV_FILEMARK_DETECTED;
 				}
 				break;
 			case -EDEV_FILEMARK_DETECTED:
-				ltfsmsg(LTFS_DEBUG, "30822D");
+				ltfsmsg(LTFS_DEBUG, 30822D);
 				ret = -EDEV_FILEMARK_DETECTED;
 				length = -EDEV_FILEMARK_DETECTED;
 				break;
 			case -EDEV_CLEANING_REQUIRED:
-				ltfsmsg(LTFS_INFO, "30823I");
+				ltfsmsg(LTFS_INFO, 30823I);
 				length = 0;
 				ret = DEVICE_GOOD;
 				break;
@@ -1215,7 +1215,7 @@ int iokit_ibmtape_read(void *device, char *buf, size_t size,
 	struct tc_position pos_retry = {0, 0};
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_READ));
-	ltfsmsg(LTFS_DEBUG3, "30995D", "read", size, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG3, 30995D, "read", size, priv->drive_serial);
 
 	if (global_data.crc_checking) {
 		datacount = size + 4;
@@ -1272,7 +1272,7 @@ read_retry:
 			if (priv->f_crc_check)
 				ret = priv->f_crc_check(buf, ret - 4);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "30824E");
+				ltfsmsg(LTFS_ERR, 30824E);
 				_take_dump(priv, false);
 				ret = -EDEV_LBP_READ_ERROR;
 			}
@@ -1326,18 +1326,18 @@ static int _cdb_write(void *device, uint8_t *buf, size_t size, bool *ew, bool *p
 	if (ret < 0){
 		switch (ret) {
 			case -EDEV_EARLY_WARNING:
-				ltfsmsg(LTFS_WARN, "30825W", "write");
+				ltfsmsg(LTFS_WARN, 30825W, "write");
 				*ew = true;
 				*pew = true;
 				ret = DEVICE_GOOD;
 				break;
 			case -EDEV_PROG_EARLY_WARNING:
-				ltfsmsg(LTFS_WARN, "30826W", "write");
+				ltfsmsg(LTFS_WARN, 30826W, "write");
 				*pew = true;
 				ret = DEVICE_GOOD;
 				break;
 			case -EDEV_CLEANING_REQUIRED:
-				ltfsmsg(LTFS_INFO, "30823I");
+				ltfsmsg(LTFS_INFO, 30823I);
 				ret = DEVICE_GOOD;
 				break;
 			default:
@@ -1361,7 +1361,7 @@ int iokit_ibmtape_write(void *device, const char *buf, size_t count, struct tc_p
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_WRITE));
 
-	ltfsmsg(LTFS_DEBUG3, "30995D", "write", count, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG3, 30995D, "write", count, priv->drive_serial);
 
 	if(global_data.crc_checking) {
 		if (priv->f_crc_enc)
@@ -1395,7 +1395,7 @@ int iokit_ibmtape_writefm(void *device, size_t count, struct tc_position *pos, b
 	bool ew = false, pew = false;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_WRITEFM));
-	ltfsmsg(LTFS_DEBUG, "30994D", "write file marks", count, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30994D, "write file marks", count, priv->drive_serial);
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -1425,18 +1425,18 @@ int iokit_ibmtape_writefm(void *device, size_t count, struct tc_position *pos, b
 	if (ret < 0){
 		switch (ret) {
 			case -EDEV_EARLY_WARNING:
-				ltfsmsg(LTFS_WARN, "30825W", "write filemarks");
+				ltfsmsg(LTFS_WARN, 30825W, "write filemarks");
 				ew = true;
 				pew = true;
 				ret = DEVICE_GOOD;
 				break;
 			case -EDEV_PROG_EARLY_WARNING:
-				ltfsmsg(LTFS_WARN, "30826W", "write filemarks");
+				ltfsmsg(LTFS_WARN, 30826W, "write filemarks");
 				pew = true;
 				ret = DEVICE_GOOD;
 				break;
 			case -EDEV_CLEANING_REQUIRED:
-				ltfsmsg(LTFS_INFO, "30823I");
+				ltfsmsg(LTFS_INFO, 30823I);
 				ret = DEVICE_GOOD;
 				break;
 			default:
@@ -1475,7 +1475,7 @@ int iokit_ibmtape_rewind(void *device, struct tc_position *pos)
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_REWIND));
-	ltfsmsg(LTFS_DEBUG, "30997D", "rewind", 0, 0, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30997D, "rewind", 0, 0, priv->drive_serial);
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -1506,9 +1506,9 @@ int iokit_ibmtape_rewind(void *device, struct tc_position *pos)
 
 		if(ret == DEVICE_GOOD) {
 			if(pos->early_warning)
-				ltfsmsg(LTFS_WARN, "30825W", "rewind");
+				ltfsmsg(LTFS_WARN, 30825W, "rewind");
 			else if(pos->programmable_early_warning)
-				ltfsmsg(LTFS_WARN, "30826W", "rewind");
+				ltfsmsg(LTFS_WARN, 30826W, "rewind");
 		}
 	}
 
@@ -1529,7 +1529,7 @@ int iokit_ibmtape_locate(void *device, struct tc_position dest, struct tc_positi
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOCATE));
-	ltfsmsg(LTFS_DEBUG, "30997D", "locate", dest.partition, dest.block, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30997D, "locate", dest.partition, dest.block, priv->drive_serial);
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -1556,7 +1556,7 @@ int iokit_ibmtape_locate(void *device, struct tc_position dest, struct tc_positi
 	ret = iokit_issue_cdb_command(&priv->dev, &req, &msg);
 	if (ret < 0){
 		if (dest.block == TAPE_BLOCK_MAX && ret == -EDEV_EOD_DETECTED) {
-			ltfsmsg(LTFS_DEBUG, "30827D", "Locate");
+			ltfsmsg(LTFS_DEBUG, 30827D, "Locate");
 			ret = DEVICE_GOOD;
 		} else {
 			_process_errors(device, ret, msg, cmd_desc, true);
@@ -1567,9 +1567,9 @@ int iokit_ibmtape_locate(void *device, struct tc_position dest, struct tc_positi
 
 	if(ret == DEVICE_GOOD) {
 		if(pos->early_warning)
-			ltfsmsg(LTFS_WARN, "30825W", "locate");
+			ltfsmsg(LTFS_WARN, 30825W, "locate");
 		else if(pos->programmable_early_warning)
-			ltfsmsg(LTFS_WARN, "30826W", "locate");
+			ltfsmsg(LTFS_WARN, 30826W, "locate");
 	}
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOCATE));
@@ -1598,23 +1598,23 @@ int iokit_ibmtape_space(void *device, size_t count, TC_SPACE_TYPE type, struct t
 	cdb[0] = SPACE16;
 	switch(type) {
 		case TC_SPACE_EOD:
-			ltfsmsg(LTFS_DEBUG, "30992D", "space to EOD", priv->drive_serial);
+			ltfsmsg(LTFS_DEBUG, 30992D, "space to EOD", priv->drive_serial);
 			cdb[1] = 0x03;
 			break;
 		case TC_SPACE_FM_F:
-			ltfsmsg(LTFS_DEBUG, "30996D", "space forward file marks", (unsigned long long)count,
+			ltfsmsg(LTFS_DEBUG, 30996D, "space forward file marks", (unsigned long long)count,
 					priv->drive_serial);
 			cdb[1] = 0x01;
 			ltfs_u64tobe(cdb + 4, count);
 			break;
 		case TC_SPACE_FM_B:
-			ltfsmsg(LTFS_DEBUG, "30996D", "space back file marks", (unsigned long long)count,
+			ltfsmsg(LTFS_DEBUG, 30996D, "space back file marks", (unsigned long long)count,
 					priv->drive_serial);
 			cdb[1] = 0x01;
 			ltfs_u64tobe(cdb + 4, -count);
 			break;
 		case TC_SPACE_F:
-			ltfsmsg(LTFS_DEBUG, "30996D", "space forward records", (unsigned long long)count,
+			ltfsmsg(LTFS_DEBUG, 30996D, "space forward records", (unsigned long long)count,
 					priv->drive_serial);
 			cdb[1] = 0x00;
 			ltfs_u64tobe(cdb + 4, count);
@@ -1625,7 +1625,7 @@ int iokit_ibmtape_space(void *device, size_t count, TC_SPACE_TYPE type, struct t
 			break;
 		default:
 			/* unexpected space type */
-			ltfsmsg(LTFS_INFO, "30828I");
+			ltfsmsg(LTFS_INFO, 30828I);
 			ret = -EDEV_INVALID_ARG;
 			break;
 	}
@@ -1653,9 +1653,9 @@ int iokit_ibmtape_space(void *device, size_t count, TC_SPACE_TYPE type, struct t
 
 	if(ret == DEVICE_GOOD) {
 		if(pos->early_warning)
-			ltfsmsg(LTFS_WARN, "30825W", "space");
+			ltfsmsg(LTFS_WARN, 30825W, "space");
 		else if(pos->programmable_early_warning)
-			ltfsmsg(LTFS_WARN, "30826W", "space");
+			ltfsmsg(LTFS_WARN, 30826W, "space");
 	}
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SPACE));
@@ -1718,9 +1718,9 @@ int iokit_ibmtape_erase(void *device, struct tc_position *pos, bool long_erase)
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_ERASE));
 	if (long_erase)
-		ltfsmsg(LTFS_DEBUG, "30992D", "long erase", priv->drive_serial);
+		ltfsmsg(LTFS_DEBUG, 30992D, "long erase", priv->drive_serial);
 	else
-		ltfsmsg(LTFS_DEBUG, "30992D", "short erase", priv->drive_serial);
+		ltfsmsg(LTFS_DEBUG, 30992D, "short erase", priv->drive_serial);
 
 	get_current_timespec(&ts_start);
 
@@ -1767,11 +1767,11 @@ int iokit_ibmtape_erase(void *device, struct tc_position *pos, bool long_erase)
 
 			if (IS_ENTERPRISE(priv->drive_type)) {
 				get_current_timespec(&ts_now);
-				ltfsmsg(LTFS_INFO, "30829I", (ts_now.tv_sec - ts_start.tv_sec)/60);
+				ltfsmsg(LTFS_INFO, 30829I, (ts_now.tv_sec - ts_start.tv_sec)/60);
 			} else {
 				progress = ((uint32_t) sense_buf[16] & 0xFF) << 8;
 				progress += ((uint32_t) sense_buf[17] & 0xFF);
-				ltfsmsg(LTFS_INFO, "30830I", (progress*100/0xFFFF));
+				ltfsmsg(LTFS_INFO, 30830I, (progress*100/0xFFFF));
 			}
 
 			sleep(60);
@@ -1834,7 +1834,7 @@ int iokit_ibmtape_load(void *device, struct tc_position *pos)
 	unsigned char buf[TC_MP_SUPPORTEDPAGE_SIZE];
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOAD));
-	ltfsmsg(LTFS_DEBUG, "30992D", "load", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30992D, "load", priv->drive_serial);
 
 	ret = _cdb_load_unload(device, true);
 	iokit_ibmtape_readpos(device, pos);
@@ -1844,9 +1844,9 @@ int iokit_ibmtape_load(void *device, struct tc_position *pos)
 	} else {
 		if(ret == DEVICE_GOOD) {
 			if(pos->early_warning)
-				ltfsmsg(LTFS_WARN, "30825W", "load");
+				ltfsmsg(LTFS_WARN, 30825W, "load");
 			else if(pos->programmable_early_warning)
-				ltfsmsg(LTFS_WARN, "30826W", "load");
+				ltfsmsg(LTFS_WARN, 30826W, "load");
 		}
 	}
 
@@ -1864,7 +1864,7 @@ int iokit_ibmtape_load(void *device, struct tc_position *pos)
 
 	ret = ibmtape_is_supported_tape(priv->cart_type, priv->density_code, &(priv->is_worm));
 	if(ret == -LTFS_UNSUPPORTED_MEDIUM)
-		ltfsmsg(LTFS_INFO, "30831I", priv->cart_type, priv->density_code);
+		ltfsmsg(LTFS_INFO, 30831I, priv->cart_type, priv->density_code);
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOAD));
 
@@ -1877,7 +1877,7 @@ int iokit_ibmtape_unload(void *device, struct tc_position *pos)
 	struct iokit_ibmtape_data *priv = (struct iokit_ibmtape_data*)device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_UNLOAD));
-	ltfsmsg(LTFS_DEBUG, "30992D", "unload", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30992D, "unload", priv->drive_serial);
 
 	ret = _cdb_load_unload(device, false);
 	if (ret < 0) {
@@ -1939,7 +1939,7 @@ int iokit_ibmtape_readpos(void *device, struct tc_position *pos)
 		pos->early_warning = buf[0] & 0x40;
 		pos->programmable_early_warning = buf[0] & 0x01;
 
-		ltfsmsg(LTFS_DEBUG, "30998D", "readpos", (unsigned long long)pos->partition,
+		ltfsmsg(LTFS_DEBUG, 30998D, "readpos", (unsigned long long)pos->partition,
 				(unsigned long long)pos->block, (unsigned long long)pos->filemarks,
 				priv->drive_serial);
 	} else {
@@ -1963,7 +1963,7 @@ int iokit_ibmtape_setcap(void *device, uint16_t proportion)
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_SETCAP));
-	ltfsmsg(LTFS_DEBUG, "30993D", "setcap", proportion, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30993D, "setcap", proportion, priv->drive_serial);
 
 	if (IS_ENTERPRISE(priv->drive_type)) {
 		unsigned char buf[TC_MP_MEDIUM_SENSE_SIZE];
@@ -2032,7 +2032,7 @@ int iokit_ibmtape_format(void *device, TC_FORMAT_TYPE format)
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_FORMAT));
-	ltfsmsg(LTFS_DEBUG, "30992D", "format", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30992D, "format", priv->drive_serial);
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -2092,7 +2092,7 @@ int iokit_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 		ret = iokit_ibmtape_logsense(device, (uint8_t)LOG_TAPECAPACITY, (void *)buffer, LOGSENSEPAGE);
 		if(ret < 0)
 		{
-			ltfsmsg(LTFS_INFO, "30832I", LOG_VOLUMESTATS, ret);
+			ltfsmsg(LTFS_INFO, 30832I, LOG_VOLUMESTATS, ret);
 			goto out;
 		}
 
@@ -2101,7 +2101,7 @@ int iokit_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 			ret = _parse_logPage(buffer, (uint16_t)i, &param_size, buf, sizeof(buf));
 			if(ret < 0 || param_size != sizeof(uint32_t))
 			{
-				ltfsmsg(LTFS_INFO, "30833I", i, param_size);
+				ltfsmsg(LTFS_INFO, 30833I, i, param_size);
 				ret = -EDEV_INTERNAL_ERROR;
 				goto out;
 			}
@@ -2123,7 +2123,7 @@ int iokit_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 					cap->max_p1 = logcap;
 					break;
 				default:
-					ltfsmsg(LTFS_INFO, "30834I", i);
+					ltfsmsg(LTFS_INFO, 30834I, i);
 					ret = -EDEV_INTERNAL_ERROR;
 					goto out;
 					break;
@@ -2135,14 +2135,14 @@ int iokit_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 		ret = iokit_ibmtape_logsense(device, LOG_VOLUMESTATS, (void *)buffer, LOGSENSEPAGE);
 		if(ret < 0)
 		{
-			ltfsmsg(LTFS_INFO, "30832I", LOG_VOLUMESTATS, ret);
+			ltfsmsg(LTFS_INFO, 30832I, LOG_VOLUMESTATS, ret);
 			goto out;
 		}
 
 		/* Capture Total Cap */
 		ret = _parse_logPage(buffer, (uint16_t)VOLSTATS_PARTITION_CAP, &param_size, buf, sizeof(buf));
 		if (ret < 0) {
-			ltfsmsg(LTFS_INFO, "30835I");
+			ltfsmsg(LTFS_INFO, 30835I);
 			goto out;
 		}
 
@@ -2159,7 +2159,7 @@ int iokit_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 		/* Capture Remaining Cap  */
 		ret = _parse_logPage(buffer, (uint16_t)VOLSTATS_PART_REMAIN_CAP, &param_size, buf, sizeof(buf));
 		if (ret < 0) {
-			ltfsmsg(LTFS_INFO, "30835I");
+			ltfsmsg(LTFS_INFO, 30835I);
 			goto out;
 		}
 
@@ -2180,9 +2180,9 @@ int iokit_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 		ret = DEVICE_GOOD;
 	}
 
-	ltfsmsg(LTFS_DEBUG3, "30997D", "capacity part0", (unsigned long long)cap->remaining_p0,
+	ltfsmsg(LTFS_DEBUG3, 30997D, "capacity part0", (unsigned long long)cap->remaining_p0,
 			(unsigned long long)cap->max_p0, priv->drive_serial);
-	ltfsmsg(LTFS_DEBUG3, "30997D", "capacity part1", (unsigned long long)cap->remaining_p1,
+	ltfsmsg(LTFS_DEBUG3, 30997D, "capacity part1", (unsigned long long)cap->remaining_p1,
 			(unsigned long long)cap->max_p1, priv->drive_serial);
 
 out:
@@ -2243,7 +2243,7 @@ int iokit_ibmtape_logsense(void *device, const unsigned char page, unsigned char
 {
 	int ret = -EDEV_UNKNOWN;
 
-	ltfsmsg(LTFS_DEBUG3, "30993D", "logsense", page, "");
+	ltfsmsg(LTFS_DEBUG3, 30993D, "logsense", page, "");
 	ret = _cdb_logsense(device, page, 0x00, buf, size);
 
 	return ret;
@@ -2262,7 +2262,7 @@ int iokit_ibmtape_modesense(void *device, const unsigned char page, const TC_MP_
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_MODESENSE));
-	ltfsmsg(LTFS_DEBUG3, "30993D", "modesense", page, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG3, 30993D, "modesense", page, priv->drive_serial);
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -2311,7 +2311,7 @@ int iokit_ibmtape_modeselect(void *device, unsigned char *buf, const size_t size
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_MODESELECT));
-	ltfsmsg(LTFS_DEBUG3, "30992D", "modeselect", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG3, 30992D, "modeselect", priv->drive_serial);
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -2359,7 +2359,7 @@ int iokit_ibmtape_reserve(void *device)
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_RESERVEUNIT));
-	ltfsmsg(LTFS_DEBUG, "30992D", "reserve unit (6)", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30992D, "reserve unit (6)", priv->drive_serial);
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -2393,7 +2393,7 @@ int iokit_ibmtape_reserve(void *device)
 	int count = 0;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_RESERVEUNIT));
-	ltfsmsg(LTFS_DEBUG, "30392D", "reserve (PRO)", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30392D, "reserve (PRO)", priv->drive_serial);
 
 start:
 	ret = _cdb_pro(device, PRO_ACT_RESERVE, PRO_TYPE_EXCLUSIVE,
@@ -2405,7 +2405,7 @@ start:
 		   ret == -EDEV_REGISTRATION_PREEMPTED ||
 		   ret == -EDEV_RESERVATION_CONFLICT)
 		) {
-		ltfsmsg(LTFS_INFO, "30868I", priv->drive_serial);
+		ltfsmsg(LTFS_INFO, 30868I, priv->drive_serial);
 		_register_key(device, priv->key);
 		count++;
 		goto start;
@@ -2431,7 +2431,7 @@ int iokit_ibmtape_release(void *device)
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_RELEASEUNIT));
-	ltfsmsg(LTFS_DEBUG, "30992D", "release unit (6)", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30992D, "release unit (6)", priv->drive_serial);
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -2463,7 +2463,7 @@ int iokit_ibmtape_release(void *device)
 #else /* Use persistent reserve */
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_RELEASEUNIT));
-	ltfsmsg(LTFS_DEBUG, "30392D", "release (PRO)", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30392D, "release (PRO)", priv->drive_serial);
 
 	ret = _cdb_pro(device, PRO_ACT_RELEASE, PRO_TYPE_EXCLUSIVE,
 				   priv->key, NULL);
@@ -2521,7 +2521,7 @@ int iokit_ibmtape_prevent_medium_removal(void *device)
 	struct iokit_ibmtape_data *priv = (struct iokit_ibmtape_data*)device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_PREVENTM));
-	ltfsmsg(LTFS_DEBUG, "30992D", "prevent medium removal", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30992D, "prevent medium removal", priv->drive_serial);
 	ret = _cdb_prevent_allow_medium_removal(device, true);
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_PREVENTM));
 
@@ -2534,7 +2534,7 @@ int iokit_ibmtape_allow_medium_removal(void *device)
 	struct iokit_ibmtape_data *priv = (struct iokit_ibmtape_data*)device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_ALLOWMREM));
-	ltfsmsg(LTFS_DEBUG, "30992D", "allow medium removal", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30992D, "allow medium removal", priv->drive_serial);
 	ret = _cdb_prevent_allow_medium_removal(device, false);
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_ALLOWMREM));
 
@@ -2554,14 +2554,14 @@ int iokit_ibmtape_write_attribute(void *device, const tape_partition_t part,
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_WRITEATTR));
-	ltfsmsg(LTFS_DEBUG3, "30996D", "writeattr", (unsigned long long)part,
+	ltfsmsg(LTFS_DEBUG3, 30996D, "writeattr", (unsigned long long)part,
 			priv->drive_serial);
 
 	/* Prepare the buffer to transfer */
 	uint32_t len = size + 4;
 	unsigned char *buffer = calloc(1, len);
 	if (!buffer) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -EDEV_NO_MEMORY;
 	}
 
@@ -2620,13 +2620,13 @@ int iokit_ibmtape_read_attribute(void *device, const tape_partition_t part,
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_READATTR));
-	ltfsmsg(LTFS_DEBUG3, "30997D", "readattr", (unsigned long)part, id, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG3, 30997D, "readattr", (unsigned long)part, id, priv->drive_serial);
 
 	/* Prepare the buffer to transfer */
 	uint32_t len = size + 4;
 	unsigned char *buffer = calloc(1, len);
 	if (!buffer) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -EDEV_NO_MEMORY;
 	}
 
@@ -2673,7 +2673,7 @@ int iokit_ibmtape_read_attribute(void *device, const tape_partition_t part,
 			id != TC_MAM_TEXT_LOCALIZATION_IDENTIFIER &&
 			id != TC_MAM_BARCODE &&
 			id != TC_MAM_APP_FORMAT_VERSION)
-			ltfsmsg(LTFS_INFO, "30836I", ret);
+			ltfsmsg(LTFS_INFO, 30836I, ret);
 	} else {
 		memcpy(buf, buffer + 4, size);
 	}
@@ -2696,7 +2696,7 @@ int iokit_ibmtape_allow_overwrite(void *device, const struct tc_position pos)
 	char *msg;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_ALLOWOVERW));
-	ltfsmsg(LTFS_DEBUG, "30997D", "allow overwrite", pos.partition, pos.block, priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30997D, "allow overwrite", pos.partition, pos.block, priv->drive_serial);
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -2723,7 +2723,7 @@ int iokit_ibmtape_allow_overwrite(void *device, const struct tc_position pos)
 	ret = iokit_issue_cdb_command(&priv->dev, &req, &msg);
 	if (ret < 0){
 		if (pos.block == TAPE_BLOCK_MAX && ret == -EDEV_EOD_DETECTED) {
-			ltfsmsg(LTFS_DEBUG, "30827D", "Allow Overwrite");
+			ltfsmsg(LTFS_DEBUG, 30827D, "Allow Overwrite");
 			ret = DEVICE_GOOD;
 		} else {
 			_process_errors(device, ret, msg, cmd_desc, true);
@@ -2776,7 +2776,7 @@ int iokit_ibmtape_set_default(void *device)
 	/* Disable Read across EOD on the enterprise drive */
 	if (IS_ENTERPRISE(priv->drive_type)) {
 		unsigned char buf[TC_MP_READ_WRITE_CTRL_SIZE];
-		ltfsmsg(LTFS_DEBUG, "30992D", __FUNCTION__, "Disabling read across EOD");
+		ltfsmsg(LTFS_DEBUG, 30992D, __FUNCTION__, "Disabling read across EOD");
 		ret = iokit_ibmtape_modesense(device, TC_MP_READ_WRITE_CTRL, TC_MP_PC_CURRENT, 0, buf, sizeof(buf));
 		if (ret < 0) {
 			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETDEFAULT));
@@ -2796,10 +2796,10 @@ int iokit_ibmtape_set_default(void *device)
 
 	/* set logical block protection */
 	if (global_data.crc_checking) {
-		ltfsmsg(LTFS_DEBUG, "30992D", __FUNCTION__, "Setting LBP");
+		ltfsmsg(LTFS_DEBUG, 30992D, __FUNCTION__, "Setting LBP");
 		ret = _set_lbp(device, true);
 	} else {
-		ltfsmsg(LTFS_DEBUG, "30992D", __FUNCTION__, "Resetting LBP");
+		ltfsmsg(LTFS_DEBUG, 30992D, __FUNCTION__, "Resetting LBP");
 		ret = _set_lbp(device, false);
 	}
 
@@ -2861,11 +2861,11 @@ int iokit_ibmtape_get_cartridge_health(void *device, struct tc_cartridge_health 
 	cart_health->tape_efficiency  = UNSUPPORTED_CARTRIDGE_HEALTH;
 	ret = iokit_ibmtape_logsense(device, LOG_PERFORMANCE, logdata, LOGSENSEPAGE);
 	if (ret)
-		ltfsmsg(LTFS_INFO, "30837I", LOG_PERFORMANCE, ret, "get cart health");
+		ltfsmsg(LTFS_INFO, 30837I, LOG_PERFORMANCE, ret, "get cart health");
 	else {
 		for(i = 0; i < (int)((sizeof(perfstats)/sizeof(perfstats[0]))); i++) {
 			if (_parse_logPage(logdata, perfstats[i], &param_size, buf, 16)) {
-				ltfsmsg(LTFS_INFO, "30838I", LOG_PERFORMANCE, "get cart health");
+				ltfsmsg(LTFS_INFO, 30838I, LOG_PERFORMANCE, "get cart health");
 			} else {
 				switch(param_size) {
 					case sizeof(uint8_t):
@@ -2916,11 +2916,11 @@ int iokit_ibmtape_get_cartridge_health(void *device, struct tc_cartridge_health 
 	cart_health->passes_middle    = UNSUPPORTED_CARTRIDGE_HEALTH;
 	ret = iokit_ibmtape_logsense(device, LOG_VOLUMESTATS, logdata, LOGSENSEPAGE);
 	if (ret < 0)
-		ltfsmsg(LTFS_INFO, "30837I", LOG_VOLUMESTATS, ret, "get cart health");
+		ltfsmsg(LTFS_INFO, 30837I, LOG_VOLUMESTATS, ret, "get cart health");
 	else {
 		for(i = 0; i < (int)((sizeof(volstats)/sizeof(volstats[0]))); i++) {
 			if (_parse_logPage(logdata, volstats[i], &param_size, buf, 16)) {
-				ltfsmsg(LTFS_INFO, "30838I", LOG_VOLUMESTATS, "get cart health");
+				ltfsmsg(LTFS_INFO, 30838I, LOG_VOLUMESTATS, "get cart health");
 			} else {
 				switch(param_size) {
 					case sizeof(uint8_t):
@@ -3012,12 +3012,12 @@ int iokit_ibmtape_get_tape_alert(void *device, uint64_t *tape_alert)
 	ta = 0;
 	ret = iokit_ibmtape_logsense(device, LOG_TAPE_ALERT, logdata, LOGSENSEPAGE);
 	if (ret < 0)
-		ltfsmsg(LTFS_INFO, "30837I", LOG_TAPE_ALERT, ret, "get tape alert");
+		ltfsmsg(LTFS_INFO, 30837I, LOG_TAPE_ALERT, ret, "get tape alert");
 	else {
 		for(i = 1; i <= 64; i++) {
 			if (_parse_logPage(logdata, (uint16_t) i, &param_size, buf, 16)
 				|| param_size != sizeof(uint8_t)) {
-				ltfsmsg(LTFS_INFO, "30838I", LOG_VOLUMESTATS, "get tape alert");
+				ltfsmsg(LTFS_INFO, 30838I, LOG_VOLUMESTATS, "get tape alert");
 				ta = 0;
 			}
 
@@ -3069,10 +3069,10 @@ int iokit_ibmtape_get_xattr(void *device, const char *name, char **buf)
 			ret = _cdb_logsense(device, LOG_PERFORMANCE, LOG_PERFORMANCE_CAPACITY_SUB, logdata, LOGSENSEPAGE);
 
 			if (ret < 0) {
-				ltfsmsg(LTFS_INFO, "30837I", LOG_PERFORMANCE, ret, "get xattr");
+				ltfsmsg(LTFS_INFO, 30837I, LOG_PERFORMANCE, ret, "get xattr");
 			} else {
 				if (_parse_logPage(logdata, PERF_ACTIVE_CQ_LOSS_W, &param_size, logbuf, 16)) {
-					ltfsmsg(LTFS_INFO, "30838I", LOG_PERFORMANCE,  "get xattr");
+					ltfsmsg(LTFS_INFO, 30838I, LOG_PERFORMANCE,  "get xattr");
 					ret = -LTFS_NO_XATTR;
 				}
 				else {
@@ -3084,7 +3084,7 @@ int iokit_ibmtape_get_xattr(void *device, const char *name, char **buf)
 							priv->dirty_acq_loss_w = false;
 							break;
 						default:
-							ltfsmsg(LTFS_INFO, "30839I", param_size);
+							ltfsmsg(LTFS_INFO, 30839I, param_size);
 							ret = -LTFS_NO_XATTR;
 							break;
 					}
@@ -3097,7 +3097,7 @@ int iokit_ibmtape_get_xattr(void *device, const char *name, char **buf)
 		/* The buf allocated here shall be freed in xattr_get_virtual() */
 		ret = asprintf(buf, "%2.2f", priv->acq_loss_w);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "10001E", "getting active CQ loss write");
+			ltfsmsg(LTFS_ERR, 10001E, "getting active CQ loss write");
 			ret = -EDEV_NO_MEMORY;
 		} else {
 			ret = DEVICE_GOOD;
@@ -3133,7 +3133,7 @@ static int _cdb_read_block_limits(void *device) {
 
 	unsigned char buf[BLOCKLEN_DATA_SIZE];
 
-	ltfsmsg(LTFS_DEBUG, "30992D", "read block limits", priv->drive_serial);
+	ltfsmsg(LTFS_DEBUG, 30992D, "read block limits", priv->drive_serial);
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -3262,7 +3262,7 @@ int iokit_ibmtape_get_eod_status(void *device, int part)
 	/* Issue LogPage 0x17 */
 	ret = iokit_ibmtape_logsense(device, LOG_VOLUMESTATS, logdata, LOGSENSEPAGE);
 	if (ret) {
-		ltfsmsg(LTFS_WARN, "30840W", LOG_VOLUMESTATS, ret);
+		ltfsmsg(LTFS_WARN, 30840W, LOG_VOLUMESTATS, ret);
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETEODSTAT));
 		return EOD_UNKNOWN;
 	}
@@ -3270,7 +3270,7 @@ int iokit_ibmtape_get_eod_status(void *device, int part)
 	/* Parse Approximate used native capacity of partitions (0x203)*/
 	if (_parse_logPage(logdata, (uint16_t)VOLSTATS_PART_USED_CAP, &param_size, buf, sizeof(buf))
 		|| (param_size != sizeof(buf) ) ) {
-		ltfsmsg(LTFS_WARN, "30841W");
+		ltfsmsg(LTFS_WARN, 30841W);
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETEODSTAT));
 		return EOD_UNKNOWN;
 	}
@@ -3289,7 +3289,7 @@ int iokit_ibmtape_get_eod_status(void *device, int part)
 				((uint32_t) buf[i + 6] << 8) +
 				(uint32_t) buf[i + 7];
 		} else
-			ltfsmsg(LTFS_WARN, "30842W", i, part_buf, len);
+			ltfsmsg(LTFS_WARN, 30842W, i, part_buf, len);
 
 		i += (len + 1);
 	}
@@ -3331,7 +3331,7 @@ int iokit_ibmtape_get_device_list(struct tc_drive_info *buf, int count)
 
 	iokit_device = malloc(sizeof(struct iokit_device));
 	if(iokit_device == NULL) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -EDEV_NO_MEMORY;
 	}
 
@@ -3385,7 +3385,7 @@ int iokit_ibmtape_parse_opts(void *device, void *opt_args)
 		else if (strcasecmp(global_data.str_crc_checking, "off") == 0)
 			global_data.crc_checking = 0;
 		else {
-			ltfsmsg(LTFS_ERR, "30843E", global_data.str_crc_checking);
+			ltfsmsg(LTFS_ERR, 30843E, global_data.str_crc_checking);
 			return -EDEV_INTERNAL_ERROR;
 		}
 	} else
@@ -3419,7 +3419,7 @@ static int _cdb_spin(void *device, const uint16_t sps, unsigned char **buffer, s
 
 	*buffer = calloc(len, sizeof(unsigned char));
 	if (! *buffer) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -EDEV_NO_MEMORY;
 	}
 
@@ -3510,7 +3510,7 @@ static void ltfsmsg_keyalias(const char * const title, const unsigned char * con
 	else
 		sprintf(s, "keyalias: NULL");
 
-	ltfsmsg(LTFS_DEBUG, "30992D", title, s);
+	ltfsmsg(LTFS_DEBUG, 30992D, title, s);
 }
 
 static bool is_ame(void *device)
@@ -3521,7 +3521,7 @@ static bool is_ame(void *device)
 	if (ret != 0) {
 		char message[100] = {0};
 		sprintf(message, "failed to get MP %02Xh (%d)", TC_MP_READ_WRITE_CTRL, ret);
-		ltfsmsg(LTFS_DEBUG, "30992D", __FUNCTION__, message);
+		ltfsmsg(LTFS_DEBUG, 30992D, __FUNCTION__, message);
 
 		return false; /* Consider that the encryption method is not AME */
 	} else {
@@ -3555,10 +3555,10 @@ static bool is_ame(void *device)
 				break;
 		}
 		sprintf(message, "Encryption Method is %s (0x%02X)", method, encryption_method);
-		ltfsmsg(LTFS_DEBUG, "30992D", __FUNCTION__, message);
+		ltfsmsg(LTFS_DEBUG, 30992D, __FUNCTION__, message);
 
 		if (encryption_method != 0x50) {
-			ltfsmsg(LTFS_ERR, "30844E", method, encryption_method);
+			ltfsmsg(LTFS_ERR, 30844E, method, encryption_method);
 		}
 		return encryption_method == 0x50;
 	}
@@ -3569,7 +3569,7 @@ static int is_encryption_capable(void *device)
 	struct iokit_ibmtape_data *priv = (struct iokit_ibmtape_data*)device;
 
 	if (IS_LTO(priv->drive_type)) {
-		ltfsmsg(LTFS_ERR, "30845E", priv->drive_type);
+		ltfsmsg(LTFS_ERR, 30845E, priv->drive_type);
 		return -EDEV_INTERNAL_ERROR;
 	}
 
@@ -3601,7 +3601,7 @@ int iokit_ibmtape_set_key(void *device, const unsigned char *keyalias, const uns
 	const size_t size = keyalias ? 20 + DK_LENGTH + 4 + DKI_LENGTH : 20;
 	uint8_t *buffer = calloc(size, sizeof(uint8_t));
 	if (! buffer) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		ret = -EDEV_NO_MEMORY;
 		goto out;
 	}
@@ -3700,7 +3700,7 @@ static void show_hex_dump(const char * const title, const uint8_t * const buf, c
 		p += sprintf(p, "%c", isprint(buf[i-j]) ? buf[i-j] : '.');
 	}
 
-	ltfsmsg(LTFS_DEBUG, "30992D", title, s);
+	ltfsmsg(LTFS_DEBUG, 30992D, title, s);
 }
 
 int iokit_ibmtape_get_keyalias(void *device, unsigned char **keyalias)
@@ -3843,7 +3843,7 @@ int iokit_ibmtape_get_serialnumber(void *device, char **result)
 
 	*result = strdup((const char *) priv->drive_serial);
 	if (! *result) {
-		ltfsmsg(LTFS_ERR, "10001E", "iokit_ibmtape_get_serialnumber: result");
+		ltfsmsg(LTFS_ERR, 10001E, "iokit_ibmtape_get_serialnumber: result");
 		ltfs_profiler_add_entry(priv->profiler, NULL, CHANGER_REQ_EXIT(REQ_TC_GETSER));
 		return -EDEV_NO_MEMORY;
 	}
@@ -3872,7 +3872,7 @@ int iokit_ibmtape_set_profiler(void *device, char *work_dir, bool enable)
 		rc = asprintf(&path, "%s/%s%s%s", work_dir, DRIVER_PROFILER_BASE,
 					  "DUMMY", PROFILER_EXTENSION);
 		if (rc < 0) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -EDEV_NO_MEMORY;
 		}
 
@@ -3938,7 +3938,7 @@ int iokit_ibmtape_get_block_in_buffer(void *device, uint32_t *block)
 	if (ret == DEVICE_GOOD) {
 		*block = (buf[5] << 16) + (buf[6] << 8) + (int)buf[7];
 
-		ltfsmsg(LTFS_DEBUG, "30998D", "blocks-in-buffer",
+		ltfsmsg(LTFS_DEBUG, 30998D, "blocks-in-buffer",
 				(unsigned long long) *block, 0, 0, priv->drive_serial);
 	} else {
 		_process_errors(device, ret, msg, cmd_desc, true);

--- a/src/tape_drivers/osx/iokit-ibmtape/iokit_scsi.c
+++ b/src/tape_drivers/osx/iokit-ibmtape/iokit_scsi.c
@@ -174,7 +174,7 @@ int iokit_issue_cdb_command(struct iokit_device *device,
 		// we would allocate more than 1 IOVirtualRange.
 		range = (IOVirtualRange *) malloc(sizeof(IOVirtualRange));
 		if (range == NULL) {
-			ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			ret = -EDEV_NO_MEMORY;
 			goto free;
 		}
@@ -187,7 +187,7 @@ int iokit_issue_cdb_command(struct iokit_device *device,
 		kernelReturn = (*device->task)->SetScatterGatherEntries(device->task, range, 1,
 																req->dxfer_len, req->dxfer_direction);
 		if (kernelReturn != kIOReturnSuccess) {
-			ltfsmsg(LTFS_INFO, "30800I", *req->cmdp, kernelReturn);
+			ltfsmsg(LTFS_INFO, 30800I, *req->cmdp, kernelReturn);
 			ret = -EDEV_INTERNAL_ERROR;
 			goto free;
 		}
@@ -196,7 +196,7 @@ int iokit_issue_cdb_command(struct iokit_device *device,
 	// Set the actual cdb in the task.
 	kernelReturn = (*device->task)->SetCommandDescriptorBlock(device->task, req->cmdp, req->cmd_len);
 	if (kernelReturn != kIOReturnSuccess) {
-		ltfsmsg(LTFS_INFO, "30801I", *req->cmdp, kernelReturn);
+		ltfsmsg(LTFS_INFO, 30801I, *req->cmdp, kernelReturn);
 		ret = -EDEV_INTERNAL_ERROR;
 		goto free;
 	}
@@ -204,7 +204,7 @@ int iokit_issue_cdb_command(struct iokit_device *device,
 	// Set the timeout in the task
 	kernelReturn = (*device->task)->SetTimeoutDuration(device->task, req->timeout);
 	if (kernelReturn != kIOReturnSuccess) {
-		ltfsmsg(LTFS_INFO, "30802I", *req->cmdp, kernelReturn);
+		ltfsmsg(LTFS_INFO, 30802I, *req->cmdp, kernelReturn);
 		ret = -EDEV_INTERNAL_ERROR;
 		goto free;
 	}
@@ -212,7 +212,7 @@ int iokit_issue_cdb_command(struct iokit_device *device,
 	kernelReturn = (*device->task)->ExecuteTaskSync(device->task, &req->sense_buffer,
 													&req->status, &transfer_count);
 	if (kernelReturn != kIOReturnSuccess) {
-		ltfsmsg(LTFS_INFO, "30803I", *req->cmdp, kernelReturn);
+		ltfsmsg(LTFS_INFO, 30803I, *req->cmdp, kernelReturn);
 		ret = -EDEV_INTERNAL_ERROR;
 		goto free;
 	}
@@ -226,17 +226,17 @@ int iokit_issue_cdb_command(struct iokit_device *device,
 			break;
 		case kSCSITaskStatus_CHECK_CONDITION:
 			ret = iokit_sense2errno(req, &sense, msg);
-			ltfsmsg(LTFS_DEBUG, "30804D", sense, *msg);
+			ltfsmsg(LTFS_DEBUG, 30804D, sense, *msg);
 			break;
 		case kSCSITaskStatus_BUSY:
-			ltfsmsg(LTFS_DEBUG, "30805D", "busy");
+			ltfsmsg(LTFS_DEBUG, 30805D, "busy");
 			ret = -EDEV_DEVICE_BUSY;
 			if (msg) {
 				*msg = "Drive busy";
 			}
 			break;
 		case kSCSITaskStatus_RESERVATION_CONFLICT:
-			ltfsmsg(LTFS_DEBUG, "30805D", "reservation conflict");
+			ltfsmsg(LTFS_DEBUG, 30805D, "reservation conflict");
 			ret = -EDEV_RESERVATION_CONFLICT;
 			if (msg) {
 				*msg = "Drive reservation conflict";
@@ -244,7 +244,7 @@ int iokit_issue_cdb_command(struct iokit_device *device,
 			break;
 		default:
 			ret = -EDEV_DRIVER_ERROR;
-			ltfsmsg(LTFS_INFO, "30806I", req->status);
+			ltfsmsg(LTFS_INFO, 30806I, req->status);
 			if (msg) {
 				*msg = "CDB command returned with unexpected status";
 			}
@@ -254,9 +254,9 @@ int iokit_issue_cdb_command(struct iokit_device *device,
 free:
 	if (ret != DEVICE_GOOD) {
 		if (is_expected_error(device, req->cmdp, ret)) {
-			ltfsmsg(LTFS_DEBUG, "30807D", req->desc, req->cmdp[0], ret);
+			ltfsmsg(LTFS_DEBUG, 30807D, req->desc, req->cmdp[0], ret);
 		} else {
-			ltfsmsg(LTFS_INFO, "30808I", req->desc, req->cmdp[0], ret);
+			ltfsmsg(LTFS_INFO, 30808I, req->desc, req->cmdp[0], ret);
 		}
 	}
 
@@ -319,7 +319,7 @@ int iokit_get_drive_identifier(struct iokit_device *device,
 
 	ret = _inquiry_low(device, 0, inquiry_buf, MAX_INQ_LEN);
 	if( ret < 0 ) {
-		ltfsmsg(LTFS_INFO, "30809I", ret);
+		ltfsmsg(LTFS_INFO, 30809I, ret);
 		return ret;
 	}
 
@@ -331,7 +331,7 @@ int iokit_get_drive_identifier(struct iokit_device *device,
 
 	ret = _inquiry_low(device, 0x80, inquiry_buf, MAX_INQ_LEN);
 	if( ret < 0 ) {
-		ltfsmsg(LTFS_INFO, "30809I", ret);
+		ltfsmsg(LTFS_INFO, 30809I, ret);
 		return ret;
 	}
 

--- a/src/tape_drivers/reed_solomon_crc.c
+++ b/src/tape_drivers/reed_solomon_crc.c
@@ -127,7 +127,7 @@ void *memcpy_rs_gf256_enc(void *dest, const void *src, size_t n)
 
 	/* Inject CRC value to the end of the destination buffer */
 	ltfs_u32tobe(dest_cur, reg);
-	ltfsmsg(LTFS_DEBUG, "39804D", "encode", n, reg);
+	ltfsmsg(LTFS_DEBUG, 39804D, "encode", (int)n, reg);
 
 	return dest;
 }
@@ -147,7 +147,7 @@ void rs_gf256_enc(void *buf, size_t n)
 
 	/* Inject CRC value */
 	ltfs_u32tobe(reg_cur, reg);
-	ltfsmsg(LTFS_DEBUG, "39804D", "encode", n, reg);
+	ltfsmsg(LTFS_DEBUG, 39804D, "encode", (int)n, reg);
 
 	return;
 }
@@ -173,10 +173,10 @@ int memcpy_rs_gf256_check(void *dest, const void *src, size_t n)
 	/* Check CRC value in the end of the source buffer */
 	crc = ltfs_betou32(src_cur);
 	if(crc != reg) {
-		ltfsmsg(LTFS_ERR, "39803E", n, reg, crc);
+		ltfsmsg(LTFS_ERR, 39803E, (int)n, reg, crc);
 		return -1;
 	}
-	ltfsmsg(LTFS_DEBUG, "39804D", "check", n, crc);
+	ltfsmsg(LTFS_DEBUG, 39804D, "check", (int)n, crc);
 
 	return n;
 }
@@ -196,10 +196,10 @@ int rs_gf256_check(void *buf, size_t n)
 	/* Check CRC value in the end of the buffer */
 	crc = ltfs_betou32(buf_cur);
 	if(crc != reg) {
-		ltfsmsg(LTFS_ERR, "39803E", n, reg, crc);
+		ltfsmsg(LTFS_ERR, 39803E, (int)n, reg, crc);
 		return -1;
 	}
-	ltfsmsg(LTFS_DEBUG, "39804D", "check", n, crc);
+	ltfsmsg(LTFS_DEBUG, 39804D, "check", (int)n, crc);
 
 	return n;
 }

--- a/src/utils/ltfsck.c
+++ b/src/utils/ltfsck.c
@@ -189,34 +189,34 @@ static struct option long_options[] = {
 
 void show_usage(char *appname, struct config_file *config, bool full)
 {
-	ltfsresult("16400I", appname); /* Usage: %s [options] filesys */
+	ltfsresult(16400I, appname); /* Usage: %s [options] filesys */
 	fprintf(stderr, "\n");
-	ltfsresult("16401I"); /* filesys   Device file for the tape drive */
+	ltfsresult(16401I); /* filesys   Device file for the tape drive */
 	fprintf(stderr, "\n");
-	ltfsresult("16402I"); /* Available options are: */
-	ltfsresult("16403I"); /* -g, --generation */
-	ltfsresult("16404I"); /* -r, --rollback */
-	ltfsresult("16405I"); /* -n, --no-rollback */
-	ltfsresult("16406I", LTFS_LOSTANDFOUND_DIR); /* -f, --full-recovery */
-	ltfsresult("16421I"); /* -z --deep-recovery */
-	ltfsresult("16407I"); /* -l, --list-rollback-points */
-	ltfsresult("16422I"); /* -m, --full-index-info */
-	ltfsresult("16420I"); /* -v, --traverse */
-	ltfsresult("16408I"); /* -j, --erase-history */
-	ltfsresult("16409I"); /* -k, --keep-history */
-	ltfsresult("16410I"); /* -q, --quiet */
-	ltfsresult("16411I"); /* -t, --trace */
-	ltfsresult("16425I"); /* --syslogtrace */
-	ltfsresult("16426I"); /* -V --version */
-	ltfsresult("16412I"); /* -h, --help */
-	ltfsresult("16413I"); /* -p, --advanced-help */
+	ltfsresult(16402I); /* Available options are: */
+	ltfsresult(16403I); /* -g, --generation */
+	ltfsresult(16404I); /* -r, --rollback */
+	ltfsresult(16405I); /* -n, --no-rollback */
+	ltfsresult(16406I, LTFS_LOSTANDFOUND_DIR); /* -f, --full-recovery */
+	ltfsresult(16421I); /* -z --deep-recovery */
+	ltfsresult(16407I); /* -l, --list-rollback-points */
+	ltfsresult(16422I); /* -m, --full-index-info */
+	ltfsresult(16420I); /* -v, --traverse */
+	ltfsresult(16408I); /* -j, --erase-history */
+	ltfsresult(16409I); /* -k, --keep-history */
+	ltfsresult(16410I); /* -q, --quiet */
+	ltfsresult(16411I); /* -t, --trace */
+	ltfsresult(16425I); /* --syslogtrace */
+	ltfsresult(16426I); /* -V --version */
+	ltfsresult(16412I); /* -h, --help */
+	ltfsresult(16413I); /* -p, --advanced-help */
 	if (full) {
-		ltfsresult("16414I", LTFS_CONFIG_FILE); /* -i, --config=<file> */
-		ltfsresult("16415I");                   /* -e, --backend=<name> */
-		ltfsresult("16423I");                   /*     --kmi-backend=<name> */
-		ltfsresult("16416I");                   /* -x, --fulltrace */
-		ltfsresult("16424I");                   /*     --capture-index */
-		ltfsresult("16427I");                   /*     --salvage-rollback-points */
+		ltfsresult(16414I, LTFS_CONFIG_FILE); /* -i, --config=<file> */
+		ltfsresult(16415I);                   /* -e, --backend=<name> */
+		ltfsresult(16423I);                   /*     --kmi-backend=<name> */
+		ltfsresult(16416I);                   /* -x, --fulltrace */
+		ltfsresult(16424I);                   /*     --capture-index */
+		ltfsresult(16427I);                   /*     --salvage-rollback-points */
 		fprintf(stderr, "\n");
 		plugin_usage("driver", config);
 		fprintf(stderr, "\n");
@@ -264,21 +264,21 @@ int main(int argc, char **argv)
 #endif
 	ret = ltfs_init(LTFS_INFO, true, false);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10000E", ret);
+		ltfsmsg(LTFS_ERR, 10000E, ret);
 		return LTFSCK_OPERATIONAL_ERROR;
 	}
 
 	/*  Setup signal handler to terminate cleanly */
 	ret = ltfs_set_signal_handlers();
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10013E");
+		ltfsmsg(LTFS_ERR, 10013E);
 		return LTFSCK_OPERATIONAL_ERROR;
 	}
 
 	/* Register messages with libltfs */
 	ret = ltfsprintf_load_plugin("bin_ltfsck", bin_ltfsck_dat, &message_handle);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10012E", ret);
+		ltfsmsg(LTFS_ERR, 10012E, ret);
 		return LTFSCK_OPERATIONAL_ERROR;
 	}
 
@@ -305,7 +305,7 @@ int main(int argc, char **argv)
 	/* Load configuration file */
 	ret = config_file_load(config_file, &opt.config);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10008E", ret);
+		ltfsmsg(LTFS_ERR, 10008E, ret);
 		return LTFSCK_OPERATIONAL_ERROR;
 	}
 
@@ -399,8 +399,8 @@ int main(int argc, char **argv)
 				++num_of_o;
 				break;
 			case 'V':
-				ltfsresult("16108I", "ltfsck", PACKAGE_VERSION);
-				ltfsresult("16108I", "LTFS Format Specification", LTFS_INDEX_VERSION_STR);
+				ltfsresult(16108I, "ltfsck", PACKAGE_VERSION);
+				ltfsresult(16108I, "LTFS Format Specification", LTFS_INDEX_VERSION_STR);
 				return 0;
 			case '?':
 			default:
@@ -413,7 +413,7 @@ int main(int argc, char **argv)
 	if (! opt.backend_path) {
 		const char *default_backend = config_file_get_default_plugin("tape", opt.config);
 		if (! default_backend) {
-			ltfsmsg(LTFS_ERR, "10009E");
+			ltfsmsg(LTFS_ERR, 10009E);
 			return LTFSCK_OPERATIONAL_ERROR;
 		}
 		opt.backend_path = strdup(default_backend);
@@ -430,7 +430,7 @@ int main(int argc, char **argv)
 
 	/* Set the logging level */
 	if (opt.quiet && (opt.trace || opt.fulltrace)) {
-		ltfsmsg(LTFS_ERR, "9013E");
+		ltfsmsg(LTFS_ERR, 9013E);
 		show_usage(argv[0], opt.config, false);
 		return LTFSCK_OPERATIONAL_ERROR;
 	} else if (opt.quiet) {
@@ -453,7 +453,7 @@ int main(int argc, char **argv)
 	ltfs_set_syslog_level(log_level);
 
 	/* Starting ltfsck */
-	ltfsmsg(LTFS_INFO, "16000I", PACKAGE_NAME, PACKAGE_VERSION, log_level);
+	ltfsmsg(LTFS_INFO, 16000I, PACKAGE_NAME, PACKAGE_VERSION, log_level);
 
 	/* Show command line arguments */
 	for (i = 0, cmd_args_len = 0 ; i < argc; i++) {
@@ -462,7 +462,7 @@ int main(int argc, char **argv)
 	cmd_args = calloc(1, cmd_args_len + 1);
 	if (!cmd_args) {
 		/* Memory allocation failed */
-		ltfsmsg(LTFS_ERR, "10001E", "ltfsck (arguments)");
+		ltfsmsg(LTFS_ERR, 10001E, "ltfsck (arguments)");
 		return LTFSCK_OPERATIONAL_ERROR;
 	}
 	strcat(cmd_args, argv[0]);
@@ -470,12 +470,12 @@ int main(int argc, char **argv)
 		strcat(cmd_args, " ");
 		strcat(cmd_args, argv[i]);
 	}
-	ltfsmsg(LTFS_INFO, "16088I", cmd_args);
+	ltfsmsg(LTFS_INFO, 16088I, cmd_args);
 	free(cmd_args);
 
 	/* Show build time information */
-	ltfsmsg(LTFS_INFO, "16089I", BUILD_SYS_FOR);
-	ltfsmsg(LTFS_INFO, "16090I", BUILD_SYS_GCC);
+	ltfsmsg(LTFS_INFO, 16089I, BUILD_SYS_FOR);
+	ltfsmsg(LTFS_INFO, 16090I, BUILD_SYS_GCC);
 
 	/* Show run time information */
 	show_runtime_system_info();
@@ -483,7 +483,7 @@ int main(int argc, char **argv)
 	/* Actually mkltfs logic starts here */
 	ret = ltfs_volume_alloc("ltfsck", &vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "16001E");
+		ltfsmsg(LTFS_ERR, 16001E);
 		return LTFSCK_OPERATIONAL_ERROR;
 	}
 
@@ -493,7 +493,7 @@ int main(int argc, char **argv)
 	opt.prg_name = strdup(argv[0]);
 
 	if (_ltfsck_validate_options(&opt)) {
-		ltfsmsg(LTFS_ERR, "16002E");
+		ltfsmsg(LTFS_ERR, 16002E);
 		show_usage(argv[0], opt.config, false);
 		return LTFSCK_USAGE_SYNTAX_ERROR;
 	}
@@ -523,37 +523,37 @@ int ltfsck(struct ltfs_volume *vol, struct other_check_opts *opt, void *args)
 	/* load the backend, open the tape device, and load a tape */
 	ret = plugin_load(&backend, "tape", opt->backend_path, opt->config);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "16010E", opt->backend_path, ret);
+		ltfsmsg(LTFS_ERR, 16010E, opt->backend_path, ret);
 		return LTFSCK_OPERATIONAL_ERROR;
 	}
 	if (opt->kmi_backend_name) {
 		ret = plugin_load(&kmi, "kmi", opt->kmi_backend_name, opt->config);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "16102E", opt->kmi_backend_name);
+			ltfsmsg(LTFS_ERR, 16102E, opt->kmi_backend_name);
 			return LTFSCK_OPERATIONAL_ERROR;
 		}
 	}
 
 	ret = LTFSCK_OPERATIONAL_ERROR;
 	if (ltfs_device_open(opt->devname, backend.ops, vol) < 0) {
-		ltfsmsg(LTFS_ERR, "16011E", opt->devname);
+		ltfsmsg(LTFS_ERR, 16011E, opt->devname);
 		goto out_unload_backend;
 	}
 	ret = ltfs_parse_tape_backend_opts(args, vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "16106E");
+		ltfsmsg(LTFS_ERR, 16106E);
 		goto out_unload_backend;
 	}
 	if (opt->kmi_backend_name) {
 		ret = kmi_init(&kmi, vol);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "16104E", opt->devname, ret);
+			ltfsmsg(LTFS_ERR, 16104E, opt->devname, ret);
 			goto out_unload_backend;
 		}
 
 		ret = ltfs_parse_kmi_backend_opts(args, vol);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "16105E");
+			ltfsmsg(LTFS_ERR, 16105E);
 			goto out_unload_backend;
 		}
 
@@ -567,7 +567,7 @@ int ltfsck(struct ltfs_volume *vol, struct other_check_opts *opt, void *args)
 
 		for (i = 0; i < a->argc && a->argv[i]; ++i) {
 			if (!strcmp(a->argv[i], "-o")) {
-				ltfsmsg(LTFS_ERR, "16107E", a->argv[i], a->argv[i + 1] ? a->argv[i + 1] : "");
+				ltfsmsg(LTFS_ERR, 16107E, a->argv[i], a->argv[i + 1] ? a->argv[i + 1] : "");
 				ret = LTFSCK_USAGE_SYNTAX_ERROR;
 				goto out_unload_backend;
 			}
@@ -579,36 +579,36 @@ int ltfsck(struct ltfs_volume *vol, struct other_check_opts *opt, void *args)
 	ltfs_load_tape(vol);
 	ret = ltfs_wait_device_ready(vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "16092E", opt->devname);
+		ltfsmsg(LTFS_ERR, 16092E, opt->devname);
 		goto out_close;
 	}
 
 	if (ltfs_setup_device(vol)) {
-		ltfsmsg(LTFS_ERR, "16092E", opt->devname);
+		ltfsmsg(LTFS_ERR, 16092E, opt->devname);
 		goto out_close;
 	}
 
 	switch (opt->op_mode) {
 	case MODE_CHECK:
-		ltfsmsg(LTFS_INFO, "16014I", opt->devname);
+		ltfsmsg(LTFS_INFO, 16014I, opt->devname);
 		opt->full_index_info = false;
 		ret = check_ltfs_volume(vol, opt);
 		break;
 	case MODE_ROLLBACK:
-		ltfsmsg(LTFS_INFO, "16015I", opt->devname);
+		ltfsmsg(LTFS_INFO, 16015I, opt->devname);
 		opt->full_index_info = false;
 		switch(opt->search_mode) {
 		case SEARCH_BY_GEN:
 			ret = rollback(vol, opt);
 			break;
 		default:
-			ltfsmsg(LTFS_ERR, "16016E");
+			ltfsmsg(LTFS_ERR, 16016E);
 			ret = LTFSCK_USAGE_SYNTAX_ERROR;
 			break;
 		}
 		break;
 	case MODE_VERIFY:
-		ltfsmsg(LTFS_INFO, "16017I", opt->devname);
+		ltfsmsg(LTFS_INFO, 16017I, opt->devname);
 		opt->full_index_info = false;
 		switch(opt->search_mode) {
 		case SEARCH_BY_GEN:
@@ -617,18 +617,18 @@ int ltfsck(struct ltfs_volume *vol, struct other_check_opts *opt, void *args)
 				ret = LTFSCK_NO_ERRORS;
 			break;
 		default:
-			ltfsmsg(LTFS_ERR, "16016E");
+			ltfsmsg(LTFS_ERR, 16016E);
 			show_usage(opt->prg_name, opt->config, false);
 			ret = LTFSCK_USAGE_SYNTAX_ERROR;
 			break;
 		}
 		break;
 	case MODE_LIST_POINT:
-		ltfsmsg(LTFS_INFO, "16018I", opt->devname);
+		ltfsmsg(LTFS_INFO, 16018I, opt->devname);
 		ret = list_rollback_points(vol, opt);
 		break;
 	default:
-		ltfsmsg(LTFS_ERR, "16019E");
+		ltfsmsg(LTFS_ERR, 16019E);
 		ret = LTFSCK_USAGE_SYNTAX_ERROR;
 		break;
 	}
@@ -641,13 +641,13 @@ out_close:
 out_unload_backend:
 	ret_close = plugin_unload(&backend);
 	if (ret == 0 && ret_close < 0) {
-		ltfsmsg(LTFS_WARN, "16020W", ret_close);
+		ltfsmsg(LTFS_WARN, 16020W, ret_close);
 		ret = LTFSCK_OPERATIONAL_ERROR;
 	}
 	if (opt->kmi_backend_name) {
 		ret_close = plugin_unload(&kmi);
 		if (ret == 0 && ret_close < 0) {
-			ltfsmsg(LTFS_WARN, "16103W");
+			ltfsmsg(LTFS_WARN, 16103W);
 			ret = LTFSCK_OPERATIONAL_ERROR;
 		}
 	}
@@ -663,13 +663,13 @@ int check_ltfs_volume(struct ltfs_volume *vol, struct other_check_opts *opt)
 	/* Load tape and read labels */
 	ret = load_tape(vol);
 	if (ret != LTFSCK_NO_ERRORS) {
-		ltfsmsg(LTFS_ERR, "16080E", ret);
+		ltfsmsg(LTFS_ERR, 16080E, ret);
 		return LTFSCK_UNCORRECTED;
 	}
 
 	ret = tape_get_cart_volume_lock_status(vol->device, &vollock);
 	if (vollock != VOLUME_UNLOCKED) {
-		ltfsmsg(LTFS_INFO, "16111I", vollock);
+		ltfsmsg(LTFS_INFO, 16111I, vollock);
 	} else if (opt->deep_recovery) {
 		/* Performe EOD recovery, if deep_recovery option is set */
 		bool is_worm;
@@ -679,7 +679,7 @@ int check_ltfs_volume(struct ltfs_volume *vol, struct other_check_opts *opt)
 		}
 
 		if (is_worm && opt->deep_recovery) {
-			ltfsmsg(LTFS_ERR, "16109E", "Deep Recovery");
+			ltfsmsg(LTFS_ERR, 16109E, "Deep Recovery");
 			return LTFSCK_USAGE_SYNTAX_ERROR;
 		}
 
@@ -691,7 +691,7 @@ int check_ltfs_volume(struct ltfs_volume *vol, struct other_check_opts *opt)
 		 */
 		ret = ltfs_recover_eod(vol);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "16091E", ret);
+			ltfsmsg(LTFS_ERR, 16091E, ret);
 			return LTFSCK_UNCORRECTED;
 		}
 		vol->ignore_wrong_version = true;
@@ -701,18 +701,18 @@ int check_ltfs_volume(struct ltfs_volume *vol, struct other_check_opts *opt)
 	if (ret < 0) {
 		if(ret == -LTFS_BOTH_EOD_MISSING && opt->deep_recovery) {
 			/* CM corrupted? try -o force_mount_no_eod */
-			ltfsmsg(LTFS_ERR, "16093E");
-			ltfsmsg(LTFS_ERR, "16094E");
+			ltfsmsg(LTFS_ERR, 16093E);
+			ltfsmsg(LTFS_ERR, 16094E);
 		} else if (ret == -LTFS_UNSUPPORTED_INDEX_VERSION) {
-			ltfsmsg(LTFS_ERR, "16100E");
-			ltfsmsg(LTFS_ERR, "16101E");
+			ltfsmsg(LTFS_ERR, 16100E);
+			ltfsmsg(LTFS_ERR, 16101E);
 		} else /* Could not mount. Please format (mkltfs) or check (ltfsck). */
-			ltfsmsg(LTFS_ERR, "16021E");
+			ltfsmsg(LTFS_ERR, 16021E);
 		return LTFSCK_UNCORRECTED;
 	} else {
 		print_criteria_info(vol);
 		ltfs_unmount(SYNC_CHECK, vol);
-		ltfsmsg(LTFS_INFO, "16022I");
+		ltfsmsg(LTFS_INFO, 16022I);
 		return LTFSCK_CORRECTED;
 	}
 }
@@ -784,7 +784,7 @@ struct index_info * _make_new_index(struct ltfs_volume *vol)
 
 	new = calloc(1, sizeof(struct index_info));
 	if (!new) {
-		ltfsmsg(LTFS_ERR, "10001E", __FUNCTION__);
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return NULL;
 	}
 
@@ -979,22 +979,22 @@ void print_volume_info(struct ltfs_volume *vol)
 	struct ltfs_timespec format_time;
 	struct tm *t_st;
 
-	ltfsmsg(LTFS_INFO, "16023I");
-	ltfsmsg(LTFS_INFO, "16024I", ltfs_get_barcode(vol));
-	ltfsmsg(LTFS_INFO, "16025I", ltfs_get_volume_uuid(vol));
+	ltfsmsg(LTFS_INFO, 16023I);
+	ltfsmsg(LTFS_INFO, 16024I, ltfs_get_barcode(vol));
+	ltfsmsg(LTFS_INFO, 16025I, ltfs_get_volume_uuid(vol));
 
 	format_time = ltfs_get_format_time(vol);
 	t_st = get_localtime(&(format_time.tv_sec));
-	ltfsmsg(LTFS_INFO, "16026I",
+	ltfsmsg(LTFS_INFO, 16026I,
 			t_st->tm_year+1900, t_st->tm_mon+1, t_st->tm_mday,
 			t_st->tm_hour, t_st->tm_min, t_st->tm_sec, format_time.tv_nsec,
 			t_st->tm_zone);
 
-	ltfsmsg(LTFS_INFO, "16027I", ltfs_get_blocksize(vol));
-	ltfsmsg(LTFS_INFO, "16028I", ltfs_get_compression(vol) ? "Enabled" : "Disabled");
-	ltfsmsg(LTFS_INFO, "16029I",
+	ltfsmsg(LTFS_INFO, 16027I, ltfs_get_blocksize(vol));
+	ltfsmsg(LTFS_INFO, 16028I, ltfs_get_compression(vol) ? "Enabled" : "Disabled");
+	ltfsmsg(LTFS_INFO, 16029I,
 			   ltfs_ip_id(vol), ltfs_part_id2num(ltfs_ip_id(vol), vol));
-	ltfsmsg(LTFS_INFO, "16030I",
+	ltfsmsg(LTFS_INFO, 16030I,
 			   ltfs_dp_id(vol), ltfs_part_id2num(ltfs_dp_id(vol), vol));
 	if (ltfs_log_level >= LTFS_INFO)
 		fprintf(stderr, "\n");
@@ -1009,8 +1009,8 @@ void print_criteria_info(struct ltfs_volume *vol)
 	const struct index_criteria *ic = ltfs_get_index_criteria(vol);
 
 	if(ic->have_criteria) {
-		ltfsmsg(LTFS_INFO, "16031I");
-		ltfsmsg(LTFS_INFO, "16032I",
+		ltfsmsg(LTFS_INFO, 16031I);
+		ltfsmsg(LTFS_INFO, 16032I,
 			(unsigned long long)ic->max_filesize_criteria);
 
 		if(ic->glob_patterns) {
@@ -1018,12 +1018,12 @@ void print_criteria_info(struct ltfs_volume *vol)
 			while(1) {
 				if(ic->glob_patterns[i].name == NULL)
 					break;
-				ltfsmsg(LTFS_INFO, "16033I", ic->glob_patterns[i].name);
+				ltfsmsg(LTFS_INFO, 16033I, ic->glob_patterns[i].name);
 				i++;
 			}
 		}
 
-		ltfsmsg(LTFS_INFO, "16034I", update ? "Allowed" : "Not allowed");
+		ltfsmsg(LTFS_INFO, 16034I, update ? "Allowed" : "Not allowed");
 		if (ltfs_log_level >= LTFS_INFO)
 			fprintf(stderr, "\n");
 	}
@@ -1036,8 +1036,8 @@ int search_index_by_gen(struct ltfs_volume *vol, unsigned int target, void **lis
 	struct index_info *new;
 
 	if (vol->index->generation == (unsigned int)-1) {
-		ltfsmsg(LTFS_ERR, "16098E");
-		ltfsmsg(LTFS_ERR, "16099E");
+		ltfsmsg(LTFS_ERR, 16098E);
+		ltfsmsg(LTFS_ERR, 16099E);
 		return -LTFS_UNSUPPORTED_INDEX_VERSION;
 	}
 
@@ -1090,7 +1090,7 @@ int _erase_history(struct ltfs_volume *vol, struct other_check_opts *opt, struct
 	int ret;
 	struct tc_position pos;
 
-	ltfsmsg(LTFS_DEBUG, "16045D", position->partition, position->block);
+	ltfsmsg(LTFS_DEBUG, 16045D, (int)position->partition, (unsigned long long)position->block);
 
 	pos.partition = ltfs_part_id2num(position->partition, vol);
 	pos.block = position->block;
@@ -1099,23 +1099,23 @@ int _erase_history(struct ltfs_volume *vol, struct other_check_opts *opt, struct
 	if (ret < 0)
 		return LTFSCK_OPERATIONAL_ERROR;
 
-	ltfsmsg(LTFS_DEBUG, "16050D");
+	ltfsmsg(LTFS_DEBUG, 16050D);
 	ret = tape_spacefm(vol->device, 1);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "16051E", ret);
+		ltfsmsg(LTFS_ERR, 16051E, ret);
 		return LTFSCK_OPERATIONAL_ERROR;
 	}
 
-	ltfsmsg(LTFS_DEBUG, "16052D");
+	ltfsmsg(LTFS_DEBUG, 16052D);
 	ret = tape_spacefm(vol->device, -1);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "16053E", ret);
+		ltfsmsg(LTFS_ERR, 16053E, ret);
 		return LTFSCK_OPERATIONAL_ERROR;
 	}
 
 	ret = tape_write_filemark(vol->device, 1, true, true, false);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "16054E", ret);
+		ltfsmsg(LTFS_ERR, 16054E, ret);
 		return LTFSCK_OPERATIONAL_ERROR;
 	}
 
@@ -1127,16 +1127,16 @@ int _rollback_ip(struct ltfs_volume *vol, struct other_check_opts *opt, struct t
 	int ret;
 
 	if (position)
-		ltfsmsg(LTFS_DEBUG, "16046D", "IP", position->partition, position->block);
+		ltfsmsg(LTFS_DEBUG, 16046D, "IP", (int)position->partition, (unsigned long long)position->block);
 
 	if(opt->erase_history && position) {
 		ret = _erase_history(vol, opt, position);
 		if (ret != LTFSCK_NO_ERRORS)
-			ltfsmsg(LTFS_ERR, "16059E", ret);
+			ltfsmsg(LTFS_ERR, 16059E, ret);
 	} else {
 		ret = ltfs_write_index(ltfs_ip_id(vol), SYNC_ROLLBACK, vol);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "16060E", ret);
+			ltfsmsg(LTFS_ERR, 16060E, ret);
 			ret = LTFSCK_OPERATIONAL_ERROR;
 		}
 	}
@@ -1148,16 +1148,16 @@ int _rollback_dp(struct ltfs_volume *vol, struct other_check_opts *opt, struct t
 {
 	int ret;
 
-	ltfsmsg(LTFS_DEBUG, "16046D", "DP", position->partition, position->block);
+	ltfsmsg(LTFS_DEBUG, 16046D, "DP", (int)position->partition, (unsigned long long)position->block);
 
 	if(opt->erase_history && position) {
 		ret = _erase_history(vol, opt, position);
 		if (ret != LTFSCK_NO_ERRORS)
-			ltfsmsg(LTFS_ERR, "16055E", ret);
+			ltfsmsg(LTFS_ERR, 16055E, ret);
 	} else {
 		ret = ltfs_write_index(ltfs_dp_id(vol), SYNC_ROLLBACK, vol);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "16056E", ret);
+			ltfsmsg(LTFS_ERR, 16056E, ret);
 			ret = LTFSCK_OPERATIONAL_ERROR;
 		}
 	}
@@ -1172,7 +1172,7 @@ int _rollback(struct ltfs_volume *vol, struct other_check_opts *opt, struct roll
 	index_num = num_of_index(rb->target_info);
 
 	if (index_num == 1) {
-		ltfsmsg(LTFS_INFO, "16067I");
+		ltfsmsg(LTFS_INFO, 16067I);
 		print_index_array(vol, rb->target_info, opt);
 
 		if (opt->op_mode == MODE_ROLLBACK) {
@@ -1180,7 +1180,7 @@ int _rollback(struct ltfs_volume *vol, struct other_check_opts *opt, struct roll
 			if (! ret || ret == -LTFS_NO_SPACE || ret == -LTFS_LESS_SPACE)
 				ret = ltfs_get_partition_readonly(ltfs_dp_id(vol), vol);
 			if (ret < 0 && ret != -LTFS_NO_SPACE && ret != -LTFS_LESS_SPACE) { /* Try to roll back even in low space condition. */
-				ltfsmsg(LTFS_ERR, "16057E");
+				ltfsmsg(LTFS_ERR, 16057E);
 				return LTFSCK_OPERATIONAL_ERROR;
 			}
 
@@ -1194,13 +1194,13 @@ int _rollback(struct ltfs_volume *vol, struct other_check_opts *opt, struct roll
 			ret = tape_set_append_position(
 				vol->device, ltfs_part_id2num(ltfs_ip_id(vol), vol), rb->current_pos.block - 1);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "16079E", ret);
+				ltfsmsg(LTFS_ERR, 16079E, ret);
 				return LTFSCK_OPERATIONAL_ERROR;
 			}
 
 			if (rb->target_info->selfptr.partition == ltfs_ip_id(vol)) {
 				/* Recover from an index on index partition */
-				ltfsmsg(LTFS_INFO, "16058I");
+				ltfsmsg(LTFS_INFO, 16058I);
 				ret = _rollback_dp(vol, opt, &(rb->target->backptr));
 				if (ret != LTFSCK_NO_ERRORS)
 					return ret;
@@ -1209,7 +1209,7 @@ int _rollback(struct ltfs_volume *vol, struct other_check_opts *opt, struct roll
 					return ret;
 			} else if (rb->target_info->selfptr.partition == ltfs_dp_id(vol)) {
 				/* Recover from an index on data partition */
-				ltfsmsg(LTFS_INFO, "16062I");
+				ltfsmsg(LTFS_INFO, 16062I);
 				ret = _rollback_dp(vol, opt, &rb->target->selfptr);
 				if (ret != LTFSCK_NO_ERRORS)
 					return ret;
@@ -1217,12 +1217,12 @@ int _rollback(struct ltfs_volume *vol, struct other_check_opts *opt, struct roll
 				if (ret != LTFSCK_NO_ERRORS)
 					return ret;
 			} else {
-				ltfsmsg(LTFS_ERR, "16061E", rb->target->selfptr.partition);
+				ltfsmsg(LTFS_ERR, 16061E, rb->target->selfptr.partition);
 				return LTFSCK_OPERATIONAL_ERROR;
 			}
 		}
 	}  else {
-		ltfsmsg(LTFS_ERR, "16068E", index_num);
+		ltfsmsg(LTFS_ERR, 16068E, index_num);
 		print_index_array(vol, rb->target_info, opt);
 		return LTFSCK_OPERATIONAL_ERROR;
 	}
@@ -1241,7 +1241,7 @@ int rollback(struct ltfs_volume *vol, struct other_check_opts *opt)
 	/* Load tape and read labels */
 	ret = load_tape(vol);
 	if (ret !=  LTFSCK_NO_ERRORS) {
-		ltfsmsg(LTFS_ERR, "16070E", ret);
+		ltfsmsg(LTFS_ERR, 16070E, ret);
 		return ret;
 	}
 
@@ -1251,7 +1251,7 @@ int rollback(struct ltfs_volume *vol, struct other_check_opts *opt)
 	}
 
 	if (is_worm && opt->op_mode == MODE_ROLLBACK) {
-		ltfsmsg(LTFS_ERR, "16109E", "Rollback");
+		ltfsmsg(LTFS_ERR, 16109E, "Rollback");
 		return LTFSCK_USAGE_SYNTAX_ERROR;
 	}
 
@@ -1259,23 +1259,23 @@ int rollback(struct ltfs_volume *vol, struct other_check_opts *opt)
 	ret = ltfs_mount(false, false, false, false, 0, vol);
 	if (ret < 0) {
 		if(ret == -LTFS_BOTH_EOD_MISSING)
-			ltfsmsg(LTFS_ERR, "16097E");
+			ltfsmsg(LTFS_ERR, 16097E);
 		else
-			ltfsmsg(LTFS_ERR, "16087E");
+			ltfsmsg(LTFS_ERR, 16087E);
 		return LTFSCK_UNCORRECTED;
 	}
 	else {
 		r.current = vol->index;
 		r.current_pos = ltfs_get_index_selfpointer(vol);
-		ltfsmsg(LTFS_DEBUG, "16081D", ltfs_get_index_generation(vol),
-				r.current_pos.partition, r.current_pos.block);
+		ltfsmsg(LTFS_DEBUG, 16081D, ltfs_get_index_generation(vol),
+				(int)r.current_pos.partition, (unsigned long long)r.current_pos.block);
 		ltfs_unmount(SYNC_ROLLBACK, vol);
 		vol->index = NULL;
 	}
 
 	/* Cartridge is concistent and genaration is latest. No operation is needed */
 	if (opt->point_gen == r.current->generation) {
-		ltfsmsg(LTFS_INFO, "16063I");
+		ltfsmsg(LTFS_INFO, 16063I);
 		return LTFSCK_NO_ERRORS;
 	}
 
@@ -1287,22 +1287,22 @@ int rollback(struct ltfs_volume *vol, struct other_check_opts *opt)
 			ret = ltfs_traverse_index_forward(vol, ltfs_dp_id(vol), opt->point_gen,
 											  search_index_by_gen, (void *)(&(r.target_info)), (void *)opt);
 			if (ret == -LTFS_NO_INDEX) {
-				ltfsmsg(LTFS_ERR, "16072E", ret);
+				ltfsmsg(LTFS_ERR, 16072E, ret);
 				return LTFSCK_OPERATIONAL_ERROR;
 			} else if (ret < 0) {
-				ltfsmsg(LTFS_ERR, "16072E", ret);
+				ltfsmsg(LTFS_ERR, 16072E, ret);
 				return LTFSCK_OPERATIONAL_ERROR;;
 			}
 		} else {
 			ret = ltfs_traverse_index_backward(vol, ltfs_dp_id(vol), opt->point_gen,
 											   search_index_by_gen, (void *)(&(r.target_info)), (void *)opt);
 			if (ret !=  LTFSCK_NO_ERRORS) {
-				ltfsmsg(LTFS_ERR, "16072E", ret);
+				ltfsmsg(LTFS_ERR, 16072E, ret);
 				return LTFSCK_OPERATIONAL_ERROR;
 			}
 		}
 	} else if ( ret < 0) {
-		ltfsmsg(LTFS_ERR, "16071E", ret);
+		ltfsmsg(LTFS_ERR, 16071E, ret);
 		return ret;
 	}
 
@@ -1310,12 +1310,12 @@ int rollback(struct ltfs_volume *vol, struct other_check_opts *opt)
 	r.target = vol->index;
 	if (opt->op_mode == MODE_ROLLBACK && !opt->erase_history) {
 		struct tape_offset selfptr = ltfs_get_index_selfpointer(vol);
-		ltfsmsg(LTFS_INFO, "16082I");
+		ltfsmsg(LTFS_INFO, 16082I);
 		ret = ltfs_get_partition_readonly(ltfs_ip_id(vol), vol);
 		if (! ret || ret == -LTFS_NO_SPACE || ret == -LTFS_LESS_SPACE)
 			ret = ltfs_get_partition_readonly(ltfs_dp_id(vol), vol);
 		if (ret < 0 && ret != -LTFS_NO_SPACE && ret != -LTFS_LESS_SPACE) { /* Try to roll back even in low space condition. */
-			ltfsmsg(LTFS_ERR, "16057E");
+			ltfsmsg(LTFS_ERR, 16057E);
 			return LTFSCK_OPERATIONAL_ERROR;
 		}
 		vol->index = r.current;
@@ -1327,7 +1327,7 @@ int rollback(struct ltfs_volume *vol, struct other_check_opts *opt)
 	if (r.target_info)
 		ret = _rollback(vol, opt, &r);
 	else {
-		ltfsmsg(LTFS_ERR, "16073E");
+		ltfsmsg(LTFS_ERR, 16073E);
 		ret = LTFSCK_OPERATIONAL_ERROR;
 		goto out_destroy;
 	}
@@ -1336,11 +1336,11 @@ int rollback(struct ltfs_volume *vol, struct other_check_opts *opt)
 	if(ret == 0) {
 		ret = ltfs_mount(true, true, false, false, 0, vol);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "16021E");
+			ltfsmsg(LTFS_ERR, 16021E);
 			ret = LTFSCK_UNCORRECTED;
 			goto out_destroy;
 		}
-		ltfsmsg(LTFS_INFO, "16086I");
+		ltfsmsg(LTFS_INFO, 16086I);
 		ret = LTFSCK_CORRECTED;
 	}
 
@@ -1357,7 +1357,7 @@ int list_rollback_points_normal(struct ltfs_volume *vol, struct other_check_opts
 	/* Load tape and read labels */
 	ret = load_tape(vol);
 	if (ret !=  LTFSCK_NO_ERRORS) {
-		ltfsmsg(LTFS_ERR, "16074E", ret);
+		ltfsmsg(LTFS_ERR, 16074E, ret);
 		return ret;
 	}
 
@@ -1365,9 +1365,9 @@ int list_rollback_points_normal(struct ltfs_volume *vol, struct other_check_opts
 	ret = ltfs_mount(false, false, false, false, 0, vol);
 	if (ret < 0) {
 		if(ret == -LTFS_BOTH_EOD_MISSING)
-			ltfsmsg(LTFS_WARN, "16096W");
+			ltfsmsg(LTFS_WARN, 16096W);
 		else {
-			ltfsmsg(LTFS_ERR, "16087E");
+			ltfsmsg(LTFS_ERR, 16087E);
 			return LTFSCK_UNCORRECTED;
 		}
 	}
@@ -1382,7 +1382,7 @@ int list_rollback_points_normal(struct ltfs_volume *vol, struct other_check_opts
 		ret = ltfs_traverse_index_backward(vol, ltfs_ip_id(vol), opt->point_gen,
 										   print_a_index_noheader, NULL, (void *)opt);
 	if (ret !=  LTFSCK_NO_ERRORS) {
-		ltfsmsg(LTFS_ERR, "16075E", ret);
+		ltfsmsg(LTFS_ERR, 16075E, ret);
 		return ret;
 	}
 
@@ -1394,7 +1394,7 @@ int list_rollback_points_normal(struct ltfs_volume *vol, struct other_check_opts
 		ret = ltfs_traverse_index_backward(vol, ltfs_dp_id(vol), opt->point_gen,
 										   print_a_index_noheader, NULL, (void *)opt);
 	if (ret !=  LTFSCK_NO_ERRORS) {
-		ltfsmsg(LTFS_ERR, "16076E", ret);
+		ltfsmsg(LTFS_ERR, 16076E, ret);
 	}
 
 	return ret;
@@ -1408,20 +1408,20 @@ int list_rollback_points_no_eod(struct ltfs_volume *vol, struct other_check_opts
 	/* Load tape and read labels */
 	ret = load_tape(vol);
 	if (ret !=  LTFSCK_NO_ERRORS) {
-		ltfsmsg(LTFS_ERR, "16074E", ret);
+		ltfsmsg(LTFS_ERR, 16074E, ret);
 		return ret;
 	}
 
 	ret = tape_get_worm_status(vol->device, &is_worm);
 	if (ret < 0 || !is_worm) {
-		ltfsmsg(LTFS_ERR, "16109E", "Salvage Rollback Points");
+		ltfsmsg(LTFS_ERR, 16109E, "Salvage Rollback Points");
 		return LTFSCK_USAGE_SYNTAX_ERROR;
 	}
 
 	/* Check EOD status to reject normal tape. */
 	ret = ltfs_check_eod_status(vol);
 	if (ret == 0) {
-		ltfsmsg(LTFS_ERR, "16110E");
+		ltfsmsg(LTFS_ERR, 16110E);
 		return LTFSCK_USAGE_SYNTAX_ERROR;
 	}
 
@@ -1430,7 +1430,7 @@ int list_rollback_points_no_eod(struct ltfs_volume *vol, struct other_check_opts
 	ret = ltfs_traverse_index_no_eod(vol, ltfs_dp_id(vol), opt->point_gen,
 									  print_a_index_noheader, NULL, (void *)opt);
 	if (ret !=  LTFSCK_NO_ERRORS) {
-		ltfsmsg(LTFS_ERR, "16076E", ret);
+		ltfsmsg(LTFS_ERR, 16076E, ret);
 	}
 
 	return ret;
@@ -1454,22 +1454,22 @@ int _ltfsck_validate_options(struct other_check_opts *opt)
 {
 	if(opt->op_mode == MODE_VERIFY || opt->op_mode == MODE_ROLLBACK) {
 		if (!opt->str_gen) {
-			ltfsmsg(LTFS_ERR, "16003E");
+			ltfsmsg(LTFS_ERR, 16003E);
 			return LTFSCK_USAGE_SYNTAX_ERROR;
 		}
 
 		if (opt->search_mode == SEARCH_BY_GEN) {
 			if (!opt->str_gen) {
-				ltfsmsg(LTFS_ERR, "16004E");
+				ltfsmsg(LTFS_ERR, 16004E);
 				return LTFSCK_USAGE_SYNTAX_ERROR;
 			} else {
 				char *invalid_start;
 				errno = 0;
 				opt->point_gen = strtoul(opt->str_gen, &invalid_start, 0);
 				if( (*invalid_start == '\0') && opt->str_gen )
-					ltfsmsg(LTFS_INFO, "16006I", opt->point_gen);
+					ltfsmsg(LTFS_INFO, 16006I, opt->point_gen);
 				else {
-					ltfsmsg(LTFS_ERR, "16005E", opt->str_gen);
+					ltfsmsg(LTFS_ERR, 16005E, opt->str_gen);
 					return LTFSCK_USAGE_SYNTAX_ERROR;
 				}
 			}
@@ -1477,28 +1477,28 @@ int _ltfsck_validate_options(struct other_check_opts *opt)
 	}
 
 	if (opt->traverse_mode != TRAVERSE_FORWARD && opt->traverse_mode != TRAVERSE_BACKWARD) {
-		ltfsmsg(LTFS_ERR, "16085E");
+		ltfsmsg(LTFS_ERR, 16085E);
 		return LTFSCK_USAGE_SYNTAX_ERROR;
 	}
 
 	if(opt->op_mode == MODE_LIST_POINT) {
 		if ( opt->traverse_mode == TRAVERSE_FORWARD )
-			ltfsmsg(LTFS_INFO, "16083I");
+			ltfsmsg(LTFS_INFO, 16083I);
 		else if (opt->traverse_mode == TRAVERSE_BACKWARD)
-			ltfsmsg(LTFS_INFO, "16084I");
+			ltfsmsg(LTFS_INFO, 16084I);
 
 		if (opt->capture_index && opt->search_mode == SEARCH_BY_GEN) {
 			if (!opt->str_gen) {
-				ltfsmsg(LTFS_ERR, "16004E");
+				ltfsmsg(LTFS_ERR, 16004E);
 				return LTFSCK_USAGE_SYNTAX_ERROR;
 			} else {
 				char *invalid_start;
 				errno = 0;
 				opt->point_gen = strtoul(opt->str_gen, &invalid_start, 0);
 				if( (*invalid_start == '\0') && opt->str_gen )
-					ltfsmsg(LTFS_INFO, "16006I", opt->point_gen);
+					ltfsmsg(LTFS_INFO, 16006I, opt->point_gen);
 				else {
-					ltfsmsg(LTFS_ERR, "16005E", opt->str_gen);
+					ltfsmsg(LTFS_ERR, 16005E, opt->str_gen);
 					return LTFSCK_USAGE_SYNTAX_ERROR;
 				}
 				opt->op_mode = MODE_VERIFY;
@@ -1508,7 +1508,7 @@ int _ltfsck_validate_options(struct other_check_opts *opt)
 	}
 
 	if (!opt->devname) {
-		ltfsmsg(LTFS_ERR, "16009E");
+		ltfsmsg(LTFS_ERR, 16009E);
 		return LTFSCK_USAGE_SYNTAX_ERROR;
 	}
 

--- a/src/utils/mkltfs.c
+++ b/src/utils/mkltfs.c
@@ -157,31 +157,31 @@ void show_usage(char *appname, struct config_file *config, bool full)
 		devname = strdup("<devname>");
 
 	fprintf(stderr, "\n");
-	ltfsresult("15400I", appname);  /* Usage: %s <options> */
+	ltfsresult(15400I, appname);  /* Usage: %s <options> */
 	fprintf(stderr, "\n");
-	ltfsresult("15401I");           /* Available options are: */
-	ltfsresult("15402I");           /* -d, --device=<name> */
-	ltfsresult("15420I");           /* -f, --force */
-	ltfsresult("15403I");           /* -s, --tape-serial=<id> */
-	ltfsresult("15404I");           /* -n, --volume-name */
-	ltfsresult("15405I");           /* -r, --rules=<rule[,rule]> */
-	ltfsresult("15406I");           /*     --no-override */
-	ltfsresult("15418I");           /* -w, --wipe */
-	ltfsresult("15407I");           /* -q, --quiet */
-	ltfsresult("15408I");           /* -t, --trace */
-	ltfsresult("15422I");           /* --syslogtrace */
-	ltfsresult("15423I");			/* -V, --version */
-	ltfsresult("15409I");           /* -h, --help */
-	ltfsresult("15412I");           /* -p, --advanced-help */
+	ltfsresult(15401I);           /* Available options are: */
+	ltfsresult(15402I);           /* -d, --device=<name> */
+	ltfsresult(15420I);           /* -f, --force */
+	ltfsresult(15403I);           /* -s, --tape-serial=<id> */
+	ltfsresult(15404I);           /* -n, --volume-name */
+	ltfsresult(15405I);           /* -r, --rules=<rule[,rule]> */
+	ltfsresult(15406I);           /*     --no-override */
+	ltfsresult(15418I);           /* -w, --wipe */
+	ltfsresult(15407I);           /* -q, --quiet */
+	ltfsresult(15408I);           /* -t, --trace */
+	ltfsresult(15422I);           /* --syslogtrace */
+	ltfsresult(15423I);           /* -V, --version */
+	ltfsresult(15409I);           /* -h, --help */
+	ltfsresult(15412I);           /* -p, --advanced-help */
 	if (full) {
-		ltfsresult("15413I", LTFS_CONFIG_FILE);       /* -i, --config=<file> */
-		ltfsresult("15414I", default_backend);        /* -e, --backend */
-		ltfsresult("15421I", config_file_get_default_plugin("kmi", config)); /*     --kmi-backend */
-		ltfsresult("15415I", LTFS_DEFAULT_BLOCKSIZE); /* -b, --blocksize */
-		ltfsresult("15416I");                         /* -c, --no-compression */
-		ltfsresult("15419I");                         /* -k, --keep-capacity */
-		ltfsresult("15417I");                         /* -x, --fulltrace */
-		ltfsresult("15424I");                         /* --long-wipe */
+		ltfsresult(15413I, LTFS_CONFIG_FILE);       /* -i, --config=<file> */
+		ltfsresult(15414I, default_backend);        /* -e, --backend */
+		ltfsresult(15421I, config_file_get_default_plugin("kmi", config)); /* --kmi-backend */
+		ltfsresult(15415I, LTFS_DEFAULT_BLOCKSIZE); /* -b, --blocksize */
+		ltfsresult(15416I);                         /* -c, --no-compression */
+		ltfsresult(15419I);                         /* -k, --keep-capacity */
+		ltfsresult(15417I);                         /* -x, --fulltrace */
+		ltfsresult(15424I);                         /* --long-wipe */
 		fprintf(stderr, "\n");
 		plugin_usage("driver", config);
 		fprintf(stderr, "\n");
@@ -189,10 +189,10 @@ void show_usage(char *appname, struct config_file *config, bool full)
 	}
 
 	fprintf(stderr, "\n");
-	ltfsresult("15410I"); /* Usage example: */
-	ltfsresult("15411I", appname, devname, "size=100K"); /* %s --device=%s --rules="%s" */
-	ltfsresult("15411I", appname, devname, "size=1M/name=*.jpg");
-	ltfsresult("15411I", appname, devname, "size=1M/name=*.jpg:*.png");
+	ltfsresult(15410I); /* Usage example: */
+	ltfsresult(15411I, appname, devname, "size=100K"); /* %s --device=%s --rules="%s" */
+	ltfsresult(15411I, appname, devname, "size=1M/name=*.jpg");
+	ltfsresult(15411I, appname, devname, "size=1M/name=*.jpg:*.png");
 
 	free(devname);
 }
@@ -238,21 +238,21 @@ int main(int argc, char **argv)
 #endif
 	ret = ltfs_init(LTFS_INFO, true, false);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10000E", ret);
+		ltfsmsg(LTFS_ERR, 10000E, ret);
 		return MKLTFS_OPERATIONAL_ERROR;
 	}
 
 	/*  Setup signal handler to terminate cleanly */
 	ret = ltfs_set_signal_handlers();
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10013E");
+		ltfsmsg(LTFS_ERR, 10013E);
 		return MKLTFS_OPERATIONAL_ERROR;
 	}
 
 	/* Register messages with libltfs */
 	ret = ltfsprintf_load_plugin("bin_mkltfs", bin_mkltfs_dat, &message_handle);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10012E", ret);
+		ltfsmsg(LTFS_ERR, 10012E, ret);
 		return MKLTFS_OPERATIONAL_ERROR;
 	}
 
@@ -281,7 +281,7 @@ int main(int argc, char **argv)
 	/* Load configuration file */
 	ret = config_file_load(config_file, &opt.config);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "10008E", ret);
+		ltfsmsg(LTFS_ERR, 10008E, ret);
 		return MKLTFS_OPERATIONAL_ERROR;
 	}
 
@@ -361,8 +361,8 @@ int main(int argc, char **argv)
 				show_usage(argv[0], opt.config, true);
 				return 0;
 			case 'V':
-				ltfsresult("15059I", "mkltfs", PACKAGE_VERSION);
-				ltfsresult("15059I", "LTFS Format Specification", LTFS_INDEX_VERSION_STR);
+				ltfsresult(15059I, "mkltfs", PACKAGE_VERSION);
+				ltfsresult(15059I, "LTFS Format Specification", LTFS_INDEX_VERSION_STR);
 				return 0;
 			case '?':
 			default:
@@ -380,7 +380,7 @@ int main(int argc, char **argv)
 	if (! opt.backend_path) {
 		const char *default_backend = config_file_get_default_plugin("tape", opt.config);
 		if (! default_backend) {
-			ltfsmsg(LTFS_ERR, "10009E");
+			ltfsmsg(LTFS_ERR, 10009E);
 			return MKLTFS_OPERATIONAL_ERROR;
 		}
 		opt.backend_path = strdup(default_backend);
@@ -397,7 +397,7 @@ int main(int argc, char **argv)
 
 	/* Set the logging level */
 	if (opt.quiet && (opt.trace || opt.fulltrace)) {
-		ltfsmsg(LTFS_ERR, "9012E");
+		ltfsmsg(LTFS_ERR, 9012E);
 		show_usage(argv[0], opt.config, false);
 		return 1;
 	} else if (opt.quiet) {
@@ -420,7 +420,7 @@ int main(int argc, char **argv)
 	ltfs_set_syslog_level(syslog_level);
 
 	/* Starting mkltfs */
-	ltfsmsg(LTFS_INFO, "15000I", PACKAGE_NAME, PACKAGE_VERSION, log_level);
+	ltfsmsg(LTFS_INFO, 15000I, PACKAGE_NAME, PACKAGE_VERSION, log_level);
 
 	/* Show command line arguments */
 	for (i = 0, cmd_args_len = 0 ; i < argc; i++) {
@@ -429,7 +429,7 @@ int main(int argc, char **argv)
 	cmd_args = calloc(1, cmd_args_len + 1);
 	if (!cmd_args) {
 		/* Memory allocation failed */
-		ltfsmsg(LTFS_ERR, "10001E", "mkltfs (arguments)");
+		ltfsmsg(LTFS_ERR, 10001E, "mkltfs (arguments)");
 		return MKLTFS_OPERATIONAL_ERROR;
 	}
 	strcat(cmd_args, argv[0]);
@@ -437,12 +437,12 @@ int main(int argc, char **argv)
 		strcat(cmd_args, " ");
 		strcat(cmd_args, argv[i]);
 	}
-	ltfsmsg(LTFS_INFO, "15041I", cmd_args);
+	ltfsmsg(LTFS_INFO, 15041I, cmd_args);
 	free(cmd_args);
 
 	/* Show build time information */
-	ltfsmsg(LTFS_INFO, "15042I", BUILD_SYS_FOR);
-	ltfsmsg(LTFS_INFO, "15043I", BUILD_SYS_GCC);
+	ltfsmsg(LTFS_INFO, 15042I, BUILD_SYS_FOR);
+	ltfsmsg(LTFS_INFO, 15043I, BUILD_SYS_GCC);
 
 	/* Show run time information */
 	show_runtime_system_info();
@@ -450,14 +450,14 @@ int main(int argc, char **argv)
 	/* Actually mkltfs logic starts here */
 	ret = ltfs_volume_alloc("mkltfs", &newvol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "15001E");
+		ltfsmsg(LTFS_ERR, 15001E);
 		return MKLTFS_OPERATIONAL_ERROR;
 	}
 
 	ret = ltfs_set_blocksize(opt.blocksize, newvol);
 	if (ret < 0) {
 		if (ret == -LTFS_SMALL_BLOCKSIZE)
-			ltfsmsg(LTFS_ERR, "15028E", LTFS_MIN_BLOCKSIZE);
+			ltfsmsg(LTFS_ERR, 15028E, LTFS_MIN_BLOCKSIZE);
 		show_usage(argv[0], opt.config, false);
 		return MKLTFS_OPERATIONAL_ERROR;
 	}
@@ -465,15 +465,15 @@ int main(int argc, char **argv)
 	ret = ltfs_set_barcode(opt.barcode, newvol);
 	if (ret < 0) {
 		if (ret == -LTFS_BARCODE_LENGTH)
-			ltfsmsg(LTFS_ERR, "15029E");
+			ltfsmsg(LTFS_ERR, 15029E);
 		else if (ret == -LTFS_BARCODE_INVALID)
-			ltfsmsg(LTFS_ERR, "15030E");
+			ltfsmsg(LTFS_ERR, 15030E);
 		show_usage(argv[0], opt.config, false);
 		return MKLTFS_USAGE_SYNTAX_ERROR;
 	}
 
 	if (_mkltfs_validate_options(argv[0], newvol, &opt)) {
-		ltfsmsg(LTFS_ERR, "15002E");
+		ltfsmsg(LTFS_ERR, 15002E);
 		show_usage(argv[0], opt.config, false);
 		return MKLTFS_USAGE_SYNTAX_ERROR;
 	}
@@ -482,9 +482,9 @@ int main(int argc, char **argv)
 	if (ret)
 		return LTFSCK_OPERATIONAL_ERROR;;
 
-	ltfsmsg(LTFS_INFO, "15003I", opt.devname);
-	ltfsmsg(LTFS_INFO, "15004I", opt.blocksize);
-	ltfsmsg(LTFS_INFO, "15005I", opt.filterrules ? opt.filterrules : "None");
+	ltfsmsg(LTFS_INFO, 15003I, opt.devname);
+	ltfsmsg(LTFS_INFO, 15004I, opt.blocksize);
+	ltfsmsg(LTFS_INFO, 15005I, opt.filterrules ? opt.filterrules : "None");
 	if (! opt.quiet)
 		fprintf(stderr, "\n");
 
@@ -521,40 +521,40 @@ int format_tape(struct ltfs_volume *vol, struct other_format_opts *opt, void *ar
 	}
 
 	/* load the backend, open the tape device, and load a tape */
-	ltfsmsg(LTFS_DEBUG, "15006D");
+	ltfsmsg(LTFS_DEBUG, 15006D);
 	ret = plugin_load(&backend, "tape", opt->backend_path, opt->config);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "15008E", opt->backend_path);
+		ltfsmsg(LTFS_ERR, 15008E, opt->backend_path);
 		return MKLTFS_OPERATIONAL_ERROR;
 	}
 	if (opt->kmi_backend_name) {
 		ret = plugin_load(&kmi, "kmi", opt->kmi_backend_name, opt->config);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "15050E", opt->kmi_backend_name);
+			ltfsmsg(LTFS_ERR, 15050E, opt->kmi_backend_name);
 			return MKLTFS_OPERATIONAL_ERROR;
 		}
 	}
 	ret = ltfs_device_open(opt->devname, backend.ops, vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "15009E", opt->devname, ret);
+		ltfsmsg(LTFS_ERR, 15009E, opt->devname, ret);
 		ret = MKLTFS_OPERATIONAL_ERROR;
 		goto out_unload_backend;
 	}
 	ret = ltfs_parse_tape_backend_opts(args, vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "15054E");
+		ltfsmsg(LTFS_ERR, 15054E);
 		goto out_unload_backend;
 	}
 	if (opt->kmi_backend_name) {
 		ret = kmi_init(&kmi, vol);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "15052E", opt->devname, ret);
+			ltfsmsg(LTFS_ERR, 15052E, opt->devname, ret);
 			goto out_unload_backend;
 		}
 
 		ret = ltfs_parse_kmi_backend_opts(args, vol);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "15053E");
+			ltfsmsg(LTFS_ERR, 15053E);
 			goto out_unload_backend;
 		}
 
@@ -569,7 +569,7 @@ int format_tape(struct ltfs_volume *vol, struct other_format_opts *opt, void *ar
 
 		for (i = 0; i < a->argc && a->argv[i]; ++i) {
 			if (!strcmp(a->argv[i], "-o")) {
-				ltfsmsg(LTFS_ERR, "15055E", a->argv[i], a->argv[i + 1] ? a->argv[i + 1] : "");
+				ltfsmsg(LTFS_ERR, 15055E, a->argv[i], a->argv[i + 1] ? a->argv[i + 1] : "");
 				ret = MKLTFS_USAGE_SYNTAX_ERROR;
 				goto out_unload_backend;
 			}
@@ -579,7 +579,7 @@ int format_tape(struct ltfs_volume *vol, struct other_format_opts *opt, void *ar
 	ltfs_load_tape(vol);
 	ret = ltfs_wait_device_ready(vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "15044E");
+		ltfsmsg(LTFS_ERR, 15044E);
 		ret = MKLTFS_OPERATIONAL_ERROR;
 		goto out_close;
 	}
@@ -588,17 +588,17 @@ int format_tape(struct ltfs_volume *vol, struct other_format_opts *opt, void *ar
 	vol->set_pew = false;
 	ret = ltfs_setup_device(vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "15044E");
+		ltfsmsg(LTFS_ERR, 15044E);
 		ret = MKLTFS_OPERATIONAL_ERROR;
 		goto out_close;
 	}
-	ltfsmsg(LTFS_DEBUG, "15007D");
+	ltfsmsg(LTFS_DEBUG, 15007D);
 
 	ltfs_set_partition_map(DATA_PART_ID, INDEX_PART_ID, DATA_PART_NUM, INDEX_PART_NUM, vol);
 
 	/* Check target medium state */
 	if (! opt->force) {
-		ltfsmsg(LTFS_INFO, "15049I", "mount");
+		ltfsmsg(LTFS_INFO, 15049I, "mount");
 		ret = ltfs_volume_alloc("mkltfs", &dummy_vol);
 		if (ret < 0) {
 			ret = MKLTFS_OPERATIONAL_ERROR;
@@ -611,12 +611,12 @@ int format_tape(struct ltfs_volume *vol, struct other_format_opts *opt, void *ar
 		dummy_vol->kmi_handle = NULL;
 		if (ret != -LTFS_NOT_PARTITIONED && ret != -LTFS_LABEL_INVALID && ret != -LTFS_LABEL_MISMATCH) {
 			if (ret == 0) {
-				ltfsmsg(LTFS_ERR, "15047E", ret);
-				ltfsmsg(LTFS_INFO, "15048I");
+				ltfsmsg(LTFS_ERR, 15047E, ret);
+				ltfsmsg(LTFS_INFO, 15048I);
 			}
 			else if (ret == -EDEV_KEY_REQUIRED) {
-				ltfsmsg(LTFS_ERR, "15056E");
-				ltfsmsg(LTFS_INFO, "15057I");
+				ltfsmsg(LTFS_ERR, 15056E);
+				ltfsmsg(LTFS_INFO, 15057I);
 			}
 			ret = MKLTFS_USAGE_SYNTAX_ERROR;
 			ltfs_volume_free(&dummy_vol);
@@ -625,13 +625,13 @@ int format_tape(struct ltfs_volume *vol, struct other_format_opts *opt, void *ar
 		ltfs_volume_free(&dummy_vol);
 	}
 	else {
-		ltfsmsg(LTFS_INFO, "15049I", "load");
+		ltfsmsg(LTFS_INFO, 15049I, "load");
 		ret = tape_load_tape(vol->device, vol->kmi_handle, false);
 		if (ret < 0) {
 			if (ret == -LTFS_UNSUPPORTED_MEDIUM)
-				ltfsmsg(LTFS_ERR, "11298E");
+				ltfsmsg(LTFS_ERR, 11298E);
 			else
-				ltfsmsg(LTFS_ERR, "11006E");
+				ltfsmsg(LTFS_ERR, 11006E);
 
 			ret = MKLTFS_OPERATIONAL_ERROR;
 			goto out_close;
@@ -646,39 +646,39 @@ int format_tape(struct ltfs_volume *vol, struct other_format_opts *opt, void *ar
 	/* Set up index data: filter rules */
 	ret = index_criteria_set_allow_update(is_worm? false : opt->allow_update, vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "15014E", ret);
+		ltfsmsg(LTFS_ERR, 15014E, ret);
 		ret = MKLTFS_OPERATIONAL_ERROR;
 		goto out_close;
 	}
 
 	if (opt->filterrules) {
 		if (is_worm) {
-			ltfsmsg(LTFS_ERR, "15060E");
+			ltfsmsg(LTFS_ERR, 15060E);
 			ret = MKLTFS_USAGE_SYNTAX_ERROR;
 			goto out_close;
 		}
 
 		ret = ltfs_override_policy(opt->filterrules, true, vol);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "15015E", ret);
+			ltfsmsg(LTFS_ERR, 15015E, ret);
 			ret = MKLTFS_OPERATIONAL_ERROR;
 			goto out_close;
 		}
 	}
 
 	/* Create partitions and write labels and indices to the tape */
-	ltfsmsg(LTFS_INFO, "15010I", DATA_PART_ID, DATA_PART_NUM);
-	ltfsmsg(LTFS_INFO, "15011I", INDEX_PART_ID, INDEX_PART_NUM);
+	ltfsmsg(LTFS_INFO, 15010I, DATA_PART_ID, DATA_PART_NUM);
+	ltfsmsg(LTFS_INFO, 15011I, INDEX_PART_ID, INDEX_PART_NUM);
 	ret = ltfs_format_tape(vol, 0);
 	if (ret < 0) {
 		if (ret == -LTFS_INTERRUPTED) {
-			ltfsmsg(LTFS_ERR, "15045E");
+			ltfsmsg(LTFS_ERR, 15045E);
 			ret = MKLTFS_CANCELED_BY_USER;
 		}else if (ret == -EDEV_WRITE_PROTECTED_WORM) {
-			ltfsmsg(LTFS_ERR, "15061E");
+			ltfsmsg(LTFS_ERR, 15061E);
 			ret = MKLTFS_USAGE_SYNTAX_ERROR;
 		}else {
-			ltfsmsg(LTFS_ERR, "15012E");
+			ltfsmsg(LTFS_ERR, 15012E);
 			if (ret == -LTFS_WRITE_PROTECT || ret == -LTFS_WRITE_ERROR)
 				ret = MKLTFS_USAGE_SYNTAX_ERROR;
 			else
@@ -686,20 +686,20 @@ int format_tape(struct ltfs_volume *vol, struct other_format_opts *opt, void *ar
 		}
 		goto out_close;
 	}
-	ltfsmsg(LTFS_INFO, "15013I", ltfs_get_volume_uuid(vol));
+	ltfsmsg(LTFS_INFO, 15013I, ltfs_get_volume_uuid(vol));
 	if (! opt->quiet)
 		fprintf(stderr, "\n");
 
 	/* Print volume capacity as GB (10^9 Bytes - SI) */
 	memset(&cap, 0, sizeof(cap));
 	ltfs_capacity_data(&cap, vol);
-	ltfsmsg(LTFS_INFO, "15019I", (unsigned long long)(((cap.total_dp * (opt->blocksize / 1048576.0)
+	ltfsmsg(LTFS_INFO, 15019I, (unsigned long long)(((cap.total_dp * (opt->blocksize / 1048576.0)
 														* (1024 * 1024)) + 500000000)
 													  / 1000 / 1000 / 1000));
 
 	vol->t_attr = (struct tape_attr *) calloc(1, sizeof(struct tape_attr));
 	if (! vol->t_attr) {
-		ltfsmsg(LTFS_ERR, "10001E", "format_tape: vol->t_attr");
+		ltfsmsg(LTFS_ERR, 10001E, "format_tape: vol->t_attr");
 		goto out_close;
 	}
 
@@ -709,29 +709,29 @@ int format_tape(struct ltfs_volume *vol, struct other_format_opts *opt, void *ar
 	ret = tape_format_attribute_to_cm(vol->device, vol->t_attr);
 	if (ret < 0) {
 		free(vol->t_attr);
-		ltfsmsg(LTFS_ERR, "15058E", "format_tape");
+		ltfsmsg(LTFS_ERR, 15058E, "format_tape");
 	}
 
 	ret = MKLTFS_NO_ERRORS;
 
 	/* close the tape device and unload the backend */
-	ltfsmsg(LTFS_DEBUG, "15020D");
+	ltfsmsg(LTFS_DEBUG, 15020D);
 
 out_close:
 	ltfs_device_close(vol);
 	ltfs_volume_free(&vol);
 	ltfs_unset_signal_handlers();
 	if (ret == MKLTFS_NO_ERRORS)
-		ltfsmsg(LTFS_DEBUG, "15022D");
+		ltfsmsg(LTFS_DEBUG, 15022D);
 out_unload_backend:
 	if (ret == MKLTFS_NO_ERRORS) {
 		ret = plugin_unload(&backend);
 		if (ret < 0)
-			ltfsmsg(LTFS_WARN, "15021W");
+			ltfsmsg(LTFS_WARN, 15021W);
 		if (opt->kmi_backend_name) {
 			ret = plugin_unload(&kmi);
 			if (ret < 0)
-				ltfsmsg(LTFS_WARN, "15051W");
+				ltfsmsg(LTFS_WARN, 15051W);
 		}
 		ret = MKLTFS_NO_ERRORS;
 	} else {
@@ -741,9 +741,9 @@ out_unload_backend:
 	}
 
 	if (ret == MKLTFS_NO_ERRORS)
-		ltfsmsg(LTFS_INFO, "15024I");
+		ltfsmsg(LTFS_INFO, 15024I);
 	else
-		ltfsmsg(LTFS_INFO, "15023I");
+		ltfsmsg(LTFS_INFO, 15023I);
 
 	return ret;
 }
@@ -755,35 +755,35 @@ int unformat_tape(struct ltfs_volume *vol, struct other_format_opts *opt, void *
 	struct libltfs_plugin kmi; /* key manager interface backend */
 
 	/* load the backend, open the tape device, and load a tape */
-	ltfsmsg(LTFS_DEBUG, "15006D");
+	ltfsmsg(LTFS_DEBUG, 15006D);
 	ret = plugin_load(&backend, "tape", opt->backend_path, opt->config);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "15008E", opt->backend_path);
+		ltfsmsg(LTFS_ERR, 15008E, opt->backend_path);
 		return MKLTFS_OPERATIONAL_ERROR;
 	}
 	if (opt->kmi_backend_name) {
 		ret = plugin_load(&kmi, "kmi", opt->kmi_backend_name, opt->config);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "15050E", opt->kmi_backend_name);
+			ltfsmsg(LTFS_ERR, 15050E, opt->kmi_backend_name);
 			return MKLTFS_OPERATIONAL_ERROR;
 		}
 	}
 	ret = ltfs_device_open(opt->devname, backend.ops, vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "15009E", opt->devname, ret);
+		ltfsmsg(LTFS_ERR, 15009E, opt->devname, ret);
 		ret = MKLTFS_OPERATIONAL_ERROR;
 		goto out_unload_backend;
 	}
 	if (opt->kmi_backend_name) {
 		ret = kmi_init(&kmi, vol);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "15052E", opt->devname, ret);
+			ltfsmsg(LTFS_ERR, 15052E, opt->devname, ret);
 			goto out_unload_backend;
 		}
 
 		ret = ltfs_parse_kmi_backend_opts(args, vol);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "15053E");
+			ltfsmsg(LTFS_ERR, 15053E);
 			goto out_unload_backend;
 		}
 
@@ -797,7 +797,7 @@ int unformat_tape(struct ltfs_volume *vol, struct other_format_opts *opt, void *
 
 		for (i = 0; i < a->argc && a->argv[i]; ++i) {
 			if (!strcmp(a->argv[i], "-o")) {
-				ltfsmsg(LTFS_ERR, "15055E", a->argv[i], a->argv[i + 1] ? a->argv[i + 1] : "");
+				ltfsmsg(LTFS_ERR, 15055E, a->argv[i], a->argv[i + 1] ? a->argv[i + 1] : "");
 				ret = MKLTFS_USAGE_SYNTAX_ERROR;
 				goto out_unload_backend;
 			}
@@ -807,23 +807,23 @@ int unformat_tape(struct ltfs_volume *vol, struct other_format_opts *opt, void *
 	vol->set_pew = false;
 	ret = ltfs_setup_device(vol);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, "15044E");
+		ltfsmsg(LTFS_ERR, 15044E);
 		ret = MKLTFS_OPERATIONAL_ERROR;
 		goto out_close;
 	}
-	ltfsmsg(LTFS_DEBUG, "15007D");
+	ltfsmsg(LTFS_DEBUG, 15007D);
 
 	/* Create 1 partition cartridge */
 	ret = ltfs_unformat_tape(vol, opt->long_wipe);
 	if (ret < 0) {
 		if (ret == -LTFS_INTERRUPTED) {
-			ltfsmsg(LTFS_ERR, "15046E");
+			ltfsmsg(LTFS_ERR, 15046E);
 			ret = MKLTFS_CANCELED_BY_USER;
 		}else if (ret == -EDEV_WRITE_PROTECTED_WORM) {
-			ltfsmsg(LTFS_ERR, "15062E");
+			ltfsmsg(LTFS_ERR, 15062E);
 			ret = MKLTFS_USAGE_SYNTAX_ERROR;
 		}else {
-			ltfsmsg(LTFS_ERR, "15038E");
+			ltfsmsg(LTFS_ERR, 15038E);
 			ret = MKLTFS_OPERATIONAL_ERROR;
 		}
 		goto out_close;
@@ -832,23 +832,23 @@ int unformat_tape(struct ltfs_volume *vol, struct other_format_opts *opt, void *
 	ret = MKLTFS_UNFORMATTED;
 
 	/* close the tape device and unload the backend */
-	ltfsmsg(LTFS_DEBUG, "15020D");
+	ltfsmsg(LTFS_DEBUG, 15020D);
 
 out_close:
 	ltfs_device_close(vol);
 	ltfs_volume_free(&vol);
 	ltfs_unset_signal_handlers();
 	if (ret == MKLTFS_UNFORMATTED)
-		ltfsmsg(LTFS_DEBUG, "15022D");
+		ltfsmsg(LTFS_DEBUG, 15022D);
 out_unload_backend:
 	if (ret == MKLTFS_UNFORMATTED) {
 		ret = plugin_unload(&backend);
 		if (ret < 0)
-			ltfsmsg(LTFS_WARN, "15021W");
+			ltfsmsg(LTFS_WARN, 15021W);
 		if (opt->kmi_backend_name) {
 			ret = plugin_unload(&kmi);
 			if (ret < 0)
-				ltfsmsg(LTFS_WARN, "15051W");
+				ltfsmsg(LTFS_WARN, 15051W);
 		}
 		ret = MKLTFS_UNFORMATTED;
 	} else {
@@ -858,9 +858,9 @@ out_unload_backend:
 	}
 
 	if (ret == MKLTFS_UNFORMATTED)
-		ltfsmsg(LTFS_INFO, "15040I");
+		ltfsmsg(LTFS_INFO, 15040I);
 	else
-		ltfsmsg(LTFS_INFO, "15039I");
+		ltfsmsg(LTFS_INFO, 15039I);
 
 	return ret;
 }
@@ -871,10 +871,10 @@ int _mkltfs_validate_options(char *prg_name, struct ltfs_volume *vol,
 	int ret;
 	char *tmp;
 
-	ltfsmsg(LTFS_DEBUG, "15025D");
+	ltfsmsg(LTFS_DEBUG, 15025D);
 
 	if (!opt->devname) {
-		ltfsmsg(LTFS_ERR, "15026E", "-d");
+		ltfsmsg(LTFS_ERR, 15026E, "-d");
 		return 1;
 	}
 
@@ -882,7 +882,7 @@ int _mkltfs_validate_options(char *prg_name, struct ltfs_volume *vol,
 	if (opt->volume_name) {
 		ret = pathname_format(opt->volume_name, &tmp, true, false);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "15031E");
+			ltfsmsg(LTFS_ERR, 15031E);
 			return 1;
 		}
 		free(opt->volume_name);
@@ -893,13 +893,13 @@ int _mkltfs_validate_options(char *prg_name, struct ltfs_volume *vol,
 	if (opt->filterrules) {
 		ret = pathname_format(opt->filterrules, &tmp, false, false);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, "15034E", ret);
+			ltfsmsg(LTFS_ERR, 15034E, ret);
 			return 1;
 		}
 		free(opt->filterrules);
 		opt->filterrules = tmp;
 	}
 
-	ltfsmsg(LTFS_DEBUG, "15037D");
+	ltfsmsg(LTFS_DEBUG, 15037D);
 	return 0;
 }


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Fix of issue #21
- Introduce massage checker that is specified by option of configure script
- Cleaning argument of messages that generates warning

# Description

Original problem is current code tries to print name of dentry. Because I changed name handling in issue #14. The name structure is changed from `char *` to `struct ltfs_name`. But message is not changed at all. So LTFS crashes when it tries to print `d->name` by `%s`. This change corrects all lines touch `struct ltfs_name` at logging. 

In addition to logging correction, I introduced message checking feature by compiler. 

Currently, message format text is fixed at run time because message bundle is stored as resource bundle of ICU. In this environment, there is no chance to check the format string of message is correct or not. 

If you run `configure` script with `--enable-message-checker`, `make` operation checks format of message. This code may not functional because this option defines special definition and creates message header from ICU bundle source file. All message is defined as `#define` directive and all text lateral is checked as a argument of `printf()`.

Fixes #21

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
