### PR TITLE
Tiny correction of message function.

### DIFF
--- a/src/libltfs/ltfslogging.h
+++ b/src/libltfs/ltfslogging.h
@@ -78,21 +78,15 @@ extern bool ltfs_print_thread_id;
 	} while (0)
 #endif
 
+/* CAUTION: ltfsmsg_buffer takes message ID as a text literal */
 /* Wrapper for ltfsmsg_internal. It only invokes the message print function if the requested
  * log level is not too verbose. */
-#ifdef MSG_CHECK
-#define ltfsmsg_buffer(level, id, ...)			\
-	do {										\
-		printf(LTFS ## id, ##__VA_ARGS__);		\
-	} while(0)
-#else
 #define ltfsmsg_buffer(level, id, buffer, ...)	\
 	do { \
 		*buffer = NULL; \
 		if (level <= ltfs_log_level) \
-			ltfsmsg_internal(true, level, buffer, #id, ##__VA_ARGS__);	\
+			ltfsmsg_internal(true, level, buffer, id, ##__VA_ARGS__);	\
 	} while (0)
-#endif
 
 /* Wrapper for ltfsmsg_internal that prints a message without the LTFSnnnnn prefix. It
  * always invokes the message print function, regardless of the message level. */


### PR DESCRIPTION
# Summary of changes

Make tiny correction against #22.

Revert ltfsmsg_buffer() not to support message checker.

At this time, we assume this function is used for messages with no arguments.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
