### PR TITLE
Handle M8 labeled tape correctly

### DIFF
--- a/src/tape_drivers/ibm_tape.c
+++ b/src/tape_drivers/ibm_tape.c
@@ -1074,7 +1074,7 @@ static inline int _is_mountable(const int drive_type,
 	}
 
 	if (IS_LTO(drive_type)) {
-		if (product == 'L' || product == 0x00) {
+		if (product == 'L' || product == 'M' || product == 0x00) {
 			if (strict) {
 				table = lto_drive_density_strict;
 				num_table = num_lto_drive_density_strict;


### PR DESCRIPTION
# Summary of changes

Currently barcode label `XXXXXXM8` is not supported correctly.

# Description

ibm tape drive backends should return mountable information correctly.

In this fix, ibm tape drive backends returns correct hint information for `XXXXXXM8`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
