### PR TITLE
Correct argument of ltfsresult() for message checker

### DIFF
--- a/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
+++ b/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
@@ -3363,7 +3363,7 @@ int iokit_ibmtape_get_device_list(struct tc_drive_info *buf, int count)
 
 void iokit_ibmtape_help_message(void)
 {
-	ltfsresult("30999I", default_device);
+	ltfsresult(30999I, default_device);
 }
 
 int iokit_ibmtape_parse_opts(void *device, void *opt_args)


### PR DESCRIPTION
# Summary of changes

Correction one message foe message checker.

- Fix the side effect of #22 

# Description

I forget to change one message in #22. 

Fixes #22

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
