### PR TITLE
Introduce path failover function in the sg-ibmtape backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ brew link --force icu4c
 brew link --force libxml2
 ```
 
-On OSX (macOS), snmp cannot be supported. Need to disable it on configure script.
+On OSX (macOS), snmp cannot be supported, you need to disable it on configure script. And may be, you need to specify LDFLAGS while running configure script to link some required frameworks, CoreFundation and IOKit.
 
 ```
 ./autogen.sh
-./configure --disable-snmp
+LDFLAGS="-framework CoreFoundation -framework IOKit" ./configure --disable-snmp
 make
 make install
 ```

--- a/messages/internal_error/root.txt
+++ b/messages/internal_error/root.txt
@@ -360,6 +360,11 @@ root:table {
 		D1716E:string{ "The actual transfer length and residual length do not match." }
 		D1717E:string{ "A buffer overrun is detected." }
 		D1718E:string{ "The number of drives are not correct." }
+		D1719E:string{ "Reservation Conflict." }
+		D1720E:string{ "Connection lost while executing a command." }
+		D1721E:string{ "No reservation holder." }
+		D1722E:string{ "Path switch happens, need to reissue the command." }
+		D1723E:string{ "Real power on reset is detected." }
 		D9998E:string{ "Unknown sense." }
 		D9999E:string{ "Vendor unique sense. ASC >= 0x80 or ASCQ >= 0x80." }
 	}

--- a/messages/libltfs/root.txt
+++ b/messages/libltfs/root.txt
@@ -568,7 +568,7 @@ root:table {
 		17022E:string { "XML parser: invalid block size %s." }
 		17023E:string { "XML parser: invalid generation number %s." }
 		17024E:string { "XML parser: invalid size criterion %s." }
-		17025E:string { "XML parser: failed to normalize value (%d)." }
+		//unused 17025E:string { "XML parser: failed to normalize value (%d)." }
 		17026E:string { "XML parser: file size is shorter than extent list." }
 		17027E:string { "XML parser: unsupported extended attribute type \'%s\'." }
 		17028E:string { "XML parser: base64 decoding failed." }
@@ -641,7 +641,7 @@ root:table {
 		17095W:string { "The index read from the tape uses an old version of the LTFS format. If this tape is modified, the index upgrades format version to %s from %d.%d.%d." }
 		17096W:string { "The index read from the tape uses a newer version of the LTFS format than the one supported by this software. Some functionality might be unavailable. If this tape is modified, the index downgrades format version to %s from %d.%d.%d." }
 		17097E:string { "XML parser: two extents overlap." }
-		17098E:string { "XML parser: invalid name pattern '%s\'." }
+		//unused 17098E:string { "XML parser: invalid name pattern '%s\'." }
 		17099E:string { "Failed to spawn the periodic sync thread (%d)." }
 
 		17100E:string { "XML parser: UID on the root directory must be 1." }

--- a/messages/tape_generic_file/root.txt
+++ b/messages/tape_generic_file/root.txt
@@ -128,7 +128,7 @@ root:table {
 		30084D:string { "Found a device (%s, %s, %s, %s)." }
 		30085I:string { "Cartridge is read-only (%d, %s)." }
 		30086I:string { "Cartridge is unsupported (%s, 0x%02x)." }
-		30087I:string { "Cartridge is unsupported (0x%x, 0x%02x)." }
+		//unused
 		30088I:string { "Unsupported density code (0x%x, 0x%02x)." }
 
 		30150E:string { "Cannot parse cartridge configuration file: start document (%d)." }

--- a/messages/tape_linux_sg_ibmtape/root.txt
+++ b/messages/tape_linux_sg_ibmtape/root.txt
@@ -42,7 +42,7 @@ root:table {
 		30200I:string { "Failed to execute SG_IO ioctl, opcode = %02x (%d)." }
 		30201D:string { "CDB check condition: sense = %06x, %s." }
 		30202D:string { "CDB %s." }
-		30203I:string { "CDB unexpected status: S = 0x%02x, H = 0x02%x, D = 0x%02x." }
+		30203I:string { "CDB unexpected status: S = 0x%02x, M = 0x02%x" }
 		30204D:string { "%s (0x%02x) expected error %d." }
 		30205I:string { "%s (0x%02x) returns %d." }
 		30206I:string { "Cannot open device: inquiry failed (%d)." }
@@ -83,12 +83,12 @@ root:table {
 		30241E:string { "Invalid scsi_lbprotect option: %s." }
 		30242E:string { "Encryption method of the drive is not AME but %s (0x%02X)." }
 		30243E:string { "Encryption feature is not supported on the drive: %d." }
-		//unused 30244
-		//unused 30245
-		//unused 30246
-		//unused 30247
-		//unused 30248
-		//unused (moved) 30249W:string { "Drive firmware must be upgraded to %s or later." }
+		30244I:string { "CDB unexpected status: H = 0x%02x, D = 0x02%x" }
+		30245D:string { "Tape device returns %d, ignore for buffered sense cleaning." }
+		30246I:string { "Connection down is detected, try to reconnect (%s)." }
+		30247I:string { "No alternate device is found for drive %s." }
+		30248I:string { "Drive serial is not matched. Actual: %s, Expected %s." }
+		30249I:string { "Opening another path for drive %s on %s." }
 		//unused (moved) 30250W:string { "Drive firmware level does not correctly detect the EOD status." }
 		30251I:string { "Logical block protection is enabled." }
 		30252I:string { "Logical block protection is disabled." }
@@ -105,9 +105,14 @@ root:table {
 		30263I:string { "%s returns %s (%d) %s." }
 		30264E:string { "%s returns msg = NULL (%d) %s." }
 		30265W:string { "Failed to get medium type code: medium type check is skipped." }
-		30266W:string { "The drive is already reserved: %s (%s)" }
-		30267W:string { "WWPID of reservation: x%02x%02x%02x%02x%02x%02x%02x%02x (%s)" }
-		30268I:string { "Retry to reserve from key registration (%s)" }
+		30266W:string { "The drive is already reserved: %s (%s)." }
+		30267W:string { "WWPID of reservation: x%02x%02x%02x%02x%02x%02x%02x%02x (%s)." }
+		30268I:string { "Retry to reserve from key registration (%s)." }
+		30269I:string { "Successfully reopen the drive %s with another path. Preempting reservation." }
+		30270I:string { "Power-On-Reset happened in the drive %s." }
+		30271I:string { "Successfully reopen the drive %s with same path." }
+		30272I:string { "Drive %s is reserved successfully." }
+		30273I:string { "Cannot %s device flag (%d)." }
 
 		30392D:string { "Backend %s %s." }
 		30393D:string { "Backend %s: %d %s." }

--- a/src/libltfs/arch/errormap.c
+++ b/src/libltfs/arch/errormap.c
@@ -392,6 +392,11 @@ static struct error_map fuse_error_list[] = {
 	{ EDEV_LENGTH_MISMATCH,          "D1716E", EINVAL},
 	{ EDEV_BUFFER_OVERFLOW,          "D1717E", EINVAL},
 	{ EDEV_DRIVES_MISMATCH,          "D1718E", EINVAL},
+	{ EDEV_RESERVATION_CONFLICT,     "D1719E", EIO},
+	{ EDEV_CONNECTION_LOST,          "D1720E", EIO},
+	{ EDEV_NO_RESERVATION_HOLDER,    "D1721E", EIO},
+	{ EDEV_NEED_FAILOVER,            "D1722E", EIO},
+	{ EDEV_REAL_POWER_ON_RESET,      "D1723E", EIO},
 	{ -1, NULL, 0 }
 };
 

--- a/src/libltfs/ltfs_error.h
+++ b/src/libltfs/ltfs_error.h
@@ -402,6 +402,10 @@
 #define EDEV_BUFFER_OVERFLOW         21717  /* Detect buffer overrun */
 #define EDEV_DRIVES_MISMATCH         21718  /* Number of drives are not correct */
 #define EDEV_RESERVATION_CONFLICT    21719  /* Reservation Conflict */
+#define EDEV_CONNECTION_LOST         21720  /* Connection lost while executing a command */
+#define EDEV_NO_RESERVATION_HOLDER   21721  /* No reservation holder */
+#define EDEV_NEED_FAILOVER           21722  /* Path switch happens, need to reissue the command */
+#define EDEV_REAL_POWER_ON_RESET     21723  /* Real power on reset is detected */
 
 /* Vendor Unique codes */
 #define EDEV_UNKNOWN                 29998  /* Unknown sense code */

--- a/src/libltfs/tape.h
+++ b/src/libltfs/tape.h
@@ -78,7 +78,9 @@ extern "C" {
 #define NEED_REVAL(ret) (ret == -EDEV_POR_OR_BUS_RESET	\
 						 || ret == -EDEV_MEDIUM_MAY_BE_CHANGED	\
 						 || ret == -EDEV_RESERVATION_PREEMPTED	\
-						 || ret == -EDEV_REGISTRATION_PREEMPTED)
+						 || ret == -EDEV_REGISTRATION_PREEMPTED \
+						 || ret == -EDEV_REAL_POWER_ON_RESET	\
+		                 || ret == -EDEV_NEED_FAILOVER)
 
 #define IS_UNEXPECTED_MOVE(ret) (ret == -EDEV_MEDIUM_REMOVAL_REQ)
 

--- a/src/tape_drivers/generic/file/filedebug_tc.c
+++ b/src/tape_drivers/generic/file/filedebug_tc.c
@@ -1443,7 +1443,7 @@ int filedebug_load(void *device, struct tc_position *pos)
 	}
 
 	/* Configure internal read_only flag */
-	ret = ibmtape_is_mountable( state->drive_type,
+	ret = ibm_tape_is_mountable( state->drive_type,
 								NULL,
 								state->conf.cart_type,
 								state->conf.density_code,
@@ -2527,7 +2527,7 @@ int filedebug_is_mountable(void *device, const char *barcode, const unsigned cha
 	int ret;
 	struct filedebug_data *state = (struct filedebug_data *)device;
 
-	ret = ibmtape_is_mountable( state->drive_type,
+	ret = ibm_tape_is_mountable( state->drive_type,
 								barcode,
 								cart_type,
 								density,
@@ -2541,7 +2541,7 @@ bool filedebug_is_readonly(void *device)
 	int ret;
 	struct filedebug_data *state = (struct filedebug_data *)device;
 
-	ret = ibmtape_is_mountable( state->drive_type,
+	ret = ibm_tape_is_mountable( state->drive_type,
 								NULL,
 								state->conf.cart_type,
 								state->conf.density_code,

--- a/src/tape_drivers/ibm_tape.c
+++ b/src/tape_drivers/ibm_tape.c
@@ -1125,7 +1125,7 @@ static inline int _is_mountable(const int drive_type,
 	return ret;
 }
 
-int ibmtape_is_mountable(const int drive_type,
+int ibm_tape_is_mountable(const int drive_type,
 						 const char *barcode,
 						 const unsigned char cart_type,
 						 const unsigned char density_code,
@@ -1157,7 +1157,7 @@ int ibmtape_is_mountable(const int drive_type,
 	return ret;
 }
 
-int ibmtape_is_supported_tape(unsigned char type, unsigned char density, bool *is_worm)
+int ibm_tape_is_supported_tape(unsigned char type, unsigned char density, bool *is_worm)
 {
 	int ret = -LTFS_UNSUPPORTED_MEDIUM, i;
 
@@ -1189,7 +1189,7 @@ int ibmtape_is_supported_tape(unsigned char type, unsigned char density, bool *i
 /**
  *  Generate a key for persistent reservation
  */
-int ibmtape_genkey(unsigned char *key)
+int ibm_tape_genkey(unsigned char *key)
 {
 #ifdef mingw_PLATFORM
 	memset(key, 0x00, KEYLEN);
@@ -1269,7 +1269,7 @@ int ibmtape_genkey(unsigned char *key)
 	return 0;
 }
 
-int ibmtape_parsekey(unsigned char *key, struct reservation_info *r)
+int ibm_tape_parsekey(unsigned char *key, struct reservation_info *r)
 {
 	r->key_type = key[0];
 	switch (r->key_type) {
@@ -1301,7 +1301,7 @@ int ibmtape_parsekey(unsigned char *key, struct reservation_info *r)
 	return 0;
 }
 
-bool ibmtape_is_supported_firmware(int drive_type, const unsigned char * const revision)
+bool ibm_tape_is_supported_firmware(int drive_type, const unsigned char * const revision)
 {
 	bool supported = true;
 	const uint32_t rev = ltfs_betou32(revision);

--- a/src/tape_drivers/ibm_tape.h
+++ b/src/tape_drivers/ibm_tape.h
@@ -209,6 +209,7 @@ enum {
 #define PRO_BUF_LEN                  (0x18)
 #define PRI_BUF_HEADER               (0x08) // Header of PRI
 #define PRI_BUF_LEN                  (0xF8) // Initial buffer size (Header + 5 x full info)
+#define PRI_FULL_LEN_BASE            (24)
 
 enum pro_type {
 	PRO_TYPE_NONE          = 0x00,
@@ -248,15 +249,13 @@ int  ibm_tape_init_timeout(struct timeout_tape **table, int type);
 void ibm_tape_destroy_timeout(struct timeout_tape **table);
 int  ibm_tape_get_timeout(struct timeout_tape *table, int op_code);
 
-int ibmtape_is_mountable(const int drive_type,
+int ibm_tape_is_mountable(const int drive_type,
 						 const char *barcode,
 						 const unsigned char cart_type,
 						 const unsigned char density_code,
 						 const bool strict);
 
-int ibmtape_is_supported_tape(unsigned char type, unsigned char density, bool *is_worm);
-
-#define PRI_FULL_LEN_BASE (24)
+int ibm_tape_is_supported_tape(unsigned char type, unsigned char density, bool *is_worm);
 
 #define KEYLEN (8)
 #define KEY_PREFIX_HOST (0x10)
@@ -270,9 +269,9 @@ struct reservation_info {
 	unsigned char wwid[8];     /* WWPN */
 };
 
-int ibmtape_genkey(unsigned char *key);
-int ibmtape_parsekey(unsigned char *key, struct reservation_info *r);
-bool ibmtape_is_supported_firmware(int drive_type, const unsigned char * const revision);
+int ibm_tape_genkey(unsigned char *key);
+int ibm_tape_parsekey(unsigned char *key, struct reservation_info *r);
+bool ibm_tape_is_supported_firmware(int drive_type, const unsigned char * const revision);
 
 extern struct supported_device *ibm_supported_drives[];
 extern struct supported_device *usb_supported_drives[];

--- a/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
+++ b/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
@@ -1065,7 +1065,7 @@ int lin_tape_ibmtape_open(const char *devname, void **handle)
 	}
 
 	ltfsmsg(LTFS_INFO, 30432I, inq_data.revision);
-	if (! ibmtape_is_supported_firmware(priv->drive_type, (unsigned char*)inq_data.revision)) {
+	if (! ibm_tape_is_supported_firmware(priv->drive_type, (unsigned char*)inq_data.revision)) {
 		ltfsmsg(LTFS_INFO, 30430I, "firmware");
 		close(priv->fd);
 		free(priv);
@@ -1940,7 +1940,7 @@ int lin_tape_ibmtape_load(void *device, struct tc_position *pos)
 		return 0;
 	}
 
-	rc = ibmtape_is_supported_tape(priv->cart_type, priv->density_code, &(priv->is_worm));
+	rc = ibm_tape_is_supported_tape(priv->cart_type, priv->density_code, &(priv->is_worm));
 	if(rc == -LTFS_UNSUPPORTED_MEDIUM)
 		ltfsmsg(LTFS_INFO, 30455I, priv->cart_type, priv->density_code);
 
@@ -3904,7 +3904,7 @@ int lin_tape_ibmtape_is_mountable(void *device, const char *barcode, const unsig
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_ISMOUNTABLE));
 
-	ret = ibmtape_is_mountable( priv->drive_type,
+	ret = ibm_tape_is_mountable( priv->drive_type,
 								barcode,
 								cart_type,
 								density,
@@ -3920,7 +3920,7 @@ bool lin_tape_ibmtape_is_readonly(void *device)
 	int ret;
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *)device;
 
-	ret = ibmtape_is_mountable( priv->drive_type,
+	ret = ibm_tape_is_mountable( priv->drive_type,
 								NULL,
 								priv->cart_type,
 								priv->density_code,

--- a/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.h
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.h
@@ -54,6 +54,9 @@ struct sg_ibmtape_data {
 	struct sg_tape       dev;                  /**< device structure of sg */
 	bool                 loaded;               /**< Is cartridge loaded? */
 	bool                 loadfailed;           /**< Is load/unload failed? */
+	bool                 is_reserved;          /**< Is reserved? */
+	bool                 is_tape_locked;       /**< Is medium removal prevented? */
+	bool                 is_reconnecting;      /**< Reconnecting, suppress nested reconnect */
 	char                 drive_serial[255];    /**< serial number of device */
 	long                 fetch_sec_acq_loss_w; /**< Sec to fetch Active CQs loss write */
 	bool                 dirty_acq_loss_w;     /**< Is Active CQs loss write dirty */

--- a/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
+++ b/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
@@ -619,7 +619,7 @@ start:
 	/* Print holder information here */
 	if (holder) {
 		memcpy(r->key, cur, KEYLEN);
-		ibmtape_parsekey(cur, r);
+		ibm_tape_parsekey(cur, r);
 	} else
 		ret = -EDEV_INTERNAL_ERROR;
 
@@ -803,7 +803,7 @@ int iokit_ibmtape_open(const char *devname, void **handle)
 	ibm_tape_init_timeout(&priv->timeouts, priv->drive_type);
 
 	/* Register reservation key */
-	ibmtape_genkey(priv->key);
+	ibm_tape_genkey(priv->key);
 	_register_key(priv, priv->key);
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_OPEN));

--- a/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
+++ b/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
@@ -434,7 +434,7 @@ static int _cdb_read_buffer(void *device, int id, unsigned char *buf, size_t off
 	unsigned char cdb[CDB10_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "READ_BUFFER";
-	char *msg;
+	char *msg = NULL;
 
 	ltfsmsg(LTFS_DEBUG, 30993D, "read buffer", id, priv->drive_serial);
 
@@ -484,7 +484,7 @@ static int _cdb_force_dump(struct iokit_ibmtape_data *priv)
 	unsigned char cdb[CDB6_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "FORCE_DUMP";
-	char *msg;
+	char *msg = NULL;
 
 	unsigned char buf[SENDDIAG_BUF_LEN];
 
@@ -539,7 +539,7 @@ static int _cdb_pri(void *device, unsigned char *buf, int size)
 	unsigned char cdb[CDB10_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "PRI";
-	char *msg;
+	char *msg = NULL;
 
 	memset(cdb, 0, sizeof(cdb));
 	memset(buf, 0, size);
@@ -640,7 +640,7 @@ static int _cdb_pro(void *device,
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "PRO";
 	unsigned char buf[PRO_BUF_LEN];
-	char *msg;
+	char *msg = NULL;
 
 	struct reservation_info r_info;
 
@@ -779,7 +779,7 @@ int iokit_ibmtape_open(const char *devname, void **handle)
 	}
 
 	if(drive_type > 0) {
-		if (!ibmtape_is_supported_firmware(drive_type, (unsigned char*)id_data.product_rev)) {
+		if (!ibm_tape_is_supported_firmware(drive_type, (unsigned char*)id_data.product_rev)) {
 			iokit_release_exclusive_access(&priv->dev);
 			ret = -EDEV_UNSUPPORTED_FIRMWARE;
 			goto free;
@@ -877,7 +877,7 @@ int iokit_ibmtape_reopen(const char *devname, void *device)
 	}
 
 	if(drive_type > 0) {
-		if (!ibmtape_is_supported_firmware(drive_type, (unsigned char*)id_data.product_rev)) {
+		if (!ibm_tape_is_supported_firmware(drive_type, (unsigned char*)id_data.product_rev)) {
 			iokit_release_exclusive_access(&priv->dev);
 			ret = -EDEV_UNSUPPORTED_FIRMWARE;
 		} else
@@ -958,7 +958,7 @@ int iokit_ibmtape_inquiry_page(void *device, unsigned char page, struct tc_inq_p
 	unsigned char cdb[CDB6_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "INQUIRY";
-	char *msg;
+	char *msg = NULL;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_INQUIRYPAGE));
 	ltfsmsg(LTFS_DEBUG, 30993D, "inquiry", page, priv->drive_serial);
@@ -1037,7 +1037,7 @@ int iokit_ibmtape_test_unit_ready(void *device)
 	unsigned char cdb[CDB6_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "TEST_UNIT_READY";
-	char *msg;
+	char *msg = NULL;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_TUR));
 	ltfsmsg(LTFS_DEBUG3, 30992D, "test unit ready", priv->drive_serial);
@@ -1103,7 +1103,7 @@ static int _cdb_read(void *device, char *buf, size_t size, boolean_t sili)
 	unsigned char cdb[CDB6_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "READ";
-	char *msg;
+	char *msg = NULL;
 	size_t length = -EDEV_UNKNOWN;
 
 	// Zero out the CDB and the result buffer
@@ -1292,7 +1292,7 @@ static int _cdb_write(void *device, uint8_t *buf, size_t size, bool *ew, bool *p
 	unsigned char cdb[CDB6_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "WRITE";
-	char *msg;
+	char *msg = NULL;
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -1390,7 +1390,7 @@ int iokit_ibmtape_writefm(void *device, size_t count, struct tc_position *pos, b
 	unsigned char cdb[CDB6_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "WRITEFM";
-	char *msg;
+	char *msg = NULL;
 
 	bool ew = false, pew = false;
 
@@ -1472,7 +1472,7 @@ int iokit_ibmtape_rewind(void *device, struct tc_position *pos)
 	unsigned char cdb[CDB6_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "REWIND";
-	char *msg;
+	char *msg = NULL;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_REWIND));
 	ltfsmsg(LTFS_DEBUG, 30997D, "rewind", 0, 0, priv->drive_serial);
@@ -1526,7 +1526,7 @@ int iokit_ibmtape_locate(void *device, struct tc_position dest, struct tc_positi
 	unsigned char cdb[CDB16_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "LOCATE";
-	char *msg;
+	char *msg = NULL;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOCATE));
 	ltfsmsg(LTFS_DEBUG, 30997D, "locate", dest.partition, dest.block, priv->drive_serial);
@@ -1586,7 +1586,7 @@ int iokit_ibmtape_space(void *device, size_t count, TC_SPACE_TYPE type, struct t
 	unsigned char cdb[CDB16_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "SPACE";
-	char *msg;
+	char *msg = NULL;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_SPACE));
 
@@ -1672,7 +1672,7 @@ static int _cdb_request_sense(void *device, unsigned char *buf, unsigned char si
 	unsigned char cdb[CDB6_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "REQUEST_SENSE";
-	char *msg;
+	char *msg = NULL;
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -1713,7 +1713,7 @@ int iokit_ibmtape_erase(void *device, struct tc_position *pos, bool long_erase)
 	unsigned char cdb[CDB6_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "ERASE";
-	char *msg;
+	char *msg = NULL;
 	struct ltfs_timespec ts_start, ts_now;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_ERASE));
@@ -1796,7 +1796,7 @@ static int _cdb_load_unload(void *device, bool load)
 	unsigned char cdb[CDB6_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "LOAD_UNLOAD";
-	char *msg;
+	char *msg = NULL;
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -1862,7 +1862,7 @@ int iokit_ibmtape_load(void *device, struct tc_position *pos)
 	priv->cart_type = buf[2];
 	priv->density_code = buf[8];
 
-	ret = ibmtape_is_supported_tape(priv->cart_type, priv->density_code, &(priv->is_worm));
+	ret = ibm_tape_is_supported_tape(priv->cart_type, priv->density_code, &(priv->is_worm));
 	if(ret == -LTFS_UNSUPPORTED_MEDIUM)
 		ltfsmsg(LTFS_INFO, 30831I, priv->cart_type, priv->density_code);
 
@@ -1904,7 +1904,7 @@ int iokit_ibmtape_readpos(void *device, struct tc_position *pos)
 	unsigned char cdb[CDB6_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "READPOS";
-	char *msg;
+	char *msg = NULL;
 	unsigned char buf[REDPOS_LONG_LEN];
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_READPOS));
@@ -1960,7 +1960,7 @@ int iokit_ibmtape_setcap(void *device, uint16_t proportion)
 	unsigned char cdb[CDB6_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "SETCAP";
-	char *msg;
+	char *msg = NULL;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_SETCAP));
 	ltfsmsg(LTFS_DEBUG, 30993D, "setcap", proportion, priv->drive_serial);
@@ -2029,7 +2029,7 @@ int iokit_ibmtape_format(void *device, TC_FORMAT_TYPE format)
 	unsigned char cdb[CDB6_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "FORMAT";
-	char *msg;
+	char *msg = NULL;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_FORMAT));
 	ltfsmsg(LTFS_DEBUG, 30992D, "format", priv->drive_serial);
@@ -2200,7 +2200,7 @@ static int _cdb_logsense(void *device, const unsigned char page, const unsigned 
 	unsigned char cdb[CDB10_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "LOGSENSE";
-	char *msg;
+	char *msg = NULL;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOGSENSE));
 
@@ -2259,7 +2259,7 @@ int iokit_ibmtape_modesense(void *device, const unsigned char page, const TC_MP_
 	unsigned char cdb[CDB10_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "MODESENSE";
-	char *msg;
+	char *msg = NULL;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_MODESENSE));
 	ltfsmsg(LTFS_DEBUG3, 30993D, "modesense", page, priv->drive_serial);
@@ -2308,7 +2308,7 @@ int iokit_ibmtape_modeselect(void *device, unsigned char *buf, const size_t size
 	unsigned char cdb[CDB10_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "MODESELECT";
-	char *msg;
+	char *msg = NULL;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_MODESELECT));
 	ltfsmsg(LTFS_DEBUG3, 30992D, "modeselect", priv->drive_serial);
@@ -2356,7 +2356,7 @@ int iokit_ibmtape_reserve(void *device)
 	unsigned char cdb[CDB6_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "RESERVE6";
-	char *msg;
+	char *msg = NULL;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_RESERVEUNIT));
 	ltfsmsg(LTFS_DEBUG, 30992D, "reserve unit (6)", priv->drive_serial);
@@ -2428,7 +2428,7 @@ int iokit_ibmtape_release(void *device)
 	unsigned char cdb[CDB6_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "RELEASE6";
-	char *msg;
+	char *msg = NULL;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_RELEASEUNIT));
 	ltfsmsg(LTFS_DEBUG, 30992D, "release unit (6)", priv->drive_serial);
@@ -2484,7 +2484,7 @@ static int _cdb_prevent_allow_medium_removal(void *device, bool prevent)
 	unsigned char cdb[CDB6_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "PREVENT/ALLOW_MEDIUM_REMOVAL";
-	char *msg;
+	char *msg = NULL;
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -2551,7 +2551,7 @@ int iokit_ibmtape_write_attribute(void *device, const tape_partition_t part,
 	unsigned char cdb[CDB16_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "WRITE_ATTR";
-	char *msg;
+	char *msg = NULL;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_WRITEATTR));
 	ltfsmsg(LTFS_DEBUG3, 30996D, "writeattr", (unsigned long long)part,
@@ -2617,7 +2617,7 @@ int iokit_ibmtape_read_attribute(void *device, const tape_partition_t part,
 	unsigned char cdb[CDB16_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "READ_ATTR";
-	char *msg;
+	char *msg = NULL;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_READATTR));
 	ltfsmsg(LTFS_DEBUG3, 30997D, "readattr", (unsigned long)part, id, priv->drive_serial);
@@ -2693,7 +2693,7 @@ int iokit_ibmtape_allow_overwrite(void *device, const struct tc_position pos)
 	unsigned char cdb[CDB16_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "ALLOWOVERW";
-	char *msg;
+	char *msg = NULL;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_ALLOWOVERW));
 	ltfsmsg(LTFS_DEBUG, 30997D, "allow overwrite", pos.partition, pos.block, priv->drive_serial);
@@ -3129,7 +3129,7 @@ static int _cdb_read_block_limits(void *device) {
 	unsigned char cdb[CDB6_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "READ_BLOCK_LIMITS";
-	char *msg;
+	char *msg = NULL;
 
 	unsigned char buf[BLOCKLEN_DATA_SIZE];
 
@@ -3410,7 +3410,7 @@ static int _cdb_spin(void *device, const uint16_t sps, unsigned char **buffer, s
 	unsigned char cdb[CDB12_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "SPIN";
-	char *msg;
+	char *msg = NULL;
 	size_t len = *size + 4;
 
 	// Zero out the CDB and the result buffer
@@ -3464,7 +3464,7 @@ int _cdb_spout(void *device, const uint16_t sps,
 	unsigned char cdb[CDB12_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "SPOUT";
-	char *msg;
+	char *msg = NULL;
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
@@ -3794,7 +3794,7 @@ int iokit_ibmtape_is_mountable(void *device, const char *barcode, const unsigned
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_ISMOUNTABLE));
 
-	ret = ibmtape_is_mountable( priv->drive_type,
+	ret = ibm_tape_is_mountable( priv->drive_type,
 								barcode,
 								cart_type,
 								density,
@@ -3810,7 +3810,7 @@ bool iokit_ibmtape_is_readonly(void *device)
 	int ret;
 	struct iokit_ibmtape_data *priv = (struct iokit_ibmtape_data*)device;
 
-	ret = ibmtape_is_mountable( priv->drive_type,
+	ret = ibm_tape_is_mountable( priv->drive_type,
 								NULL,
 								priv->cart_type,
 								priv->density_code,
@@ -3907,7 +3907,7 @@ int iokit_ibmtape_get_block_in_buffer(void *device, uint32_t *block)
 	unsigned char cdb[CDB6_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "READPOS";
-	char *msg;
+	char *msg = NULL;
 	unsigned char buf[REDPOS_EXT_LEN];
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_READPOS));


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Introduce path failover function in the sg-ibmtape backend

# Description

This is the first drop of path failover function (Linux sg-ibmtape only). The concept is

- The sg backend returns an error when path switch happened
- The libltfs execute "re-validation" operation when it receives a path
  switch related error

There is no command re-issue into the sg backend. The sg backend does following things.

- Detect connection loss from sg driver call
- Search new device when connection loss happens
- Recover drive reservation in the new path

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
