### PR TITLE
FreeBSD port

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,17 @@ These instructions will get you a copy of the project up and running on your loc
   * icu4c
   * gnu-sed
 
+- FreeBSD:
+  * FreeBSD 10.2 or 11.0 or later (for sa(4) driver changes)
+  * automake
+  * autoconf
+  * libtool
+  * fusefs-libs
+  * net-snmp
+  * e2fsprogs-libuuid
+  * libxml2
+  * icu
+
 ## Supported Tape Drives
 
   | Vendor | Drive Type | Minimum F/W Level |
@@ -83,6 +94,15 @@ make install
 ```
 
 `./configure --help` shows various options for build and install.
+
+### Build and install on FreeBSD
+
+```
+./autogen.sh
+./configure
+make
+make install
+```
 
 ## Contributing
 

--- a/conf/Makefile.am
+++ b/conf/Makefile.am
@@ -10,6 +10,10 @@ if PLATFORM_MAC
 PLAT_OPT += plugin tape iokit __LIBDIR__/ltfs/libtape-iokit-ibmtape.so
 endif
 
+if PLATFORM_FREEBSD
+PLAT_OPT += plugin tape camtape __LIBDIR__/ltfs/libtape-camtape-freebsd.so
+endif
+
 if ENABLE_LIN_TAPE
 PLAT_OPT += \\nplugin tape lin_tape __LIBDIR__/ltfs/libtape-lin_tape.so
 endif

--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,7 @@ dnl Detecting OS
 dnl
 host_linux=no
 host_mac=no
+host_freebsd=no
 
 case "${host_os}" in
 	linux*)
@@ -64,6 +65,9 @@ case "${host_os}" in
 		;;
 	darwin*)
 		host_mac=yes
+		;;
+	freebsd*)
+		host_freebsd=yes
 		;;
 	*)
 		AC_MSG_ERROR(["OS $host_os is not supported"])
@@ -157,6 +161,10 @@ then
 	then
 		DEFAULT_TAPE=iokit
 	fi
+	if test "x${host_freebsd}" = "xyes"
+	then
+		DEFAULT_TAPE=camtape
+	fi
 fi
 
 if test "x${DEFAULT_TAPE}" = "xlin_tape"
@@ -222,6 +230,27 @@ else
 	PKG_CHECK_MODULES([UUID_MODULE], [uuid >= 1.36])
 fi
 
+dnl
+dnl Check for pthreads and clock_gettime
+dnl
+AC_CHECK_LIB(pthread, pthread_create,,
+	[AC_MSG_ERROR([required library pthread missing])])
+AC_CHECK_LIB(rt, clock_gettime,,
+	[AC_MSG_ERROR([required library rt missing])])
+
+dnl
+dnl Check for libcam, libbsdxml (expat) and libmt on FreeBSD
+dnl
+if test "x${host_freebsd}" = "xyes"
+then
+    AC_CHECK_LIB(cam, cam_open_device,,
+	    [AC_MSG_ERROR([required library cam missing])])
+    AC_CHECK_LIB(bsdxml, XML_ParserCreate,,
+	    [AC_MSG_ERROR([required library bsdxml missing])])
+    AC_CHECK_LIB(mt, mt_status_free,,
+	    [AC_MSG_ERROR([required library mt missing])])
+
+fi
 dnl
 dnl Check for ICU
 dnl
@@ -310,6 +339,18 @@ if test "x$ac_cv_xml_huge" = "xyes"; then
    AC_DEFINE(HAVE_XML_PARSE_HUGE, [1], [Define to 1 if you have XML_PARSE_HUGE])
 fi
 
+AC_MSG_CHECKING([if compiling with clang])
+
+AC_COMPILE_IFELSE(
+[AC_LANG_PROGRAM([], [[
+#ifndef __clang__
+	not clang
+#endif
+]])],
+[CLANG=yes], [CLANG=no])
+
+AC_MSG_RESULT([$CLANG])
+
 dnl
 dnl Update flags
 dnl Sets CFLAGS to force optimization and debugging options, which isn't quite kosher
@@ -322,7 +363,10 @@ then
 	OPT_FLAGS="-D_FORTIFY_SOURCE=2 -O2 -g -fno-strict-aliasing"
 else
 	OPT_FLAGS="-D_FORTIFY_SOURCE=0 -O0 -ggdb"
-	AM_CFLAGS="${AM_CFLAGS} -fkeep-inline-functions -rdynamic"
+	if test "x$CLANG" = 'xno'
+	then
+		AM_CFLAGS="${AM_CFLAGS} -fkeep-inline-functions -rdynamic"
+	fi
 	if test "x$use_debug" = "xyes"
 	then
 		AM_CPPFLAGS="${AM_CPPFLAGS} -DDEBUG -DTRACE"
@@ -345,7 +389,7 @@ dnl
 AC_MSG_CHECKING([for SSE4.2])
 CRC_OPTIMIZE="-O2"
 
-if test "x$GCC" = 'xyes'
+if test "x$GCC" = 'xyes' -a "x$CLANG" = 'xno'
 then
 	GCC_VERSION=`$CC -dumpversion`
 	GCC_VERSION_MAJOR=$(echo $GCC_VERSION | cut -d'.' -f1)
@@ -360,7 +404,7 @@ then
 	if test "x${SSE42}" = "xyes"
 	then
 		case x"$target_cpu" in
-			xx86_64)
+			xx86_64 | xamd64)
 				AC_MSG_RESULT([yes, x86_64])
 				CRC_OPTIMIZE="-msse4.2 -O2 -D__SSE42__"
 				;;
@@ -375,6 +419,21 @@ then
 	else
 		AC_MSG_RESULT([no, gcc version])
 	fi
+elif test "x$CLANG" = 'xyes'
+then
+	case x"$target_cpu" in
+		xx86_64 | xamd64)
+			AC_MSG_RESULT([yes, x86_64])
+			CRC_OPTIMIZE="-msse4.2 -O2 -D__SSE42__"
+			;;
+		xi*86)
+			AC_MSG_RESULT([yes, x86])
+			CRC_OPTIMIZE="-msse4.2 -O2 -D__SSE42__"
+			;;
+		*)
+			AC_MSG_RESULT([no, unsupported cpu $target_cpu])
+			;;
+	esac
 else
 	AC_MSG_RESULT([no, non-gcc])
 fi
@@ -401,6 +460,7 @@ dnl
 AM_CONDITIONAL([PLATFORM_LINUX], [test "x${host_linux}" = "xyes"])
 AM_CONDITIONAL([ENABLE_LIN_TAPE], [test "x${lintape}" = "xyes"])
 AM_CONDITIONAL([PLATFORM_MAC], [test "x${host_mac}" = "xyes"])
+AM_CONDITIONAL([PLATFORM_FREEBSD], [test "x${host_freebsd}" = "xyes"])
 AM_CONDITIONAL([OSS], [true])
 AM_CONDITIONAL([CHK_MESSAGE], [test "x${use_msg_check}" = "xyes"])
 
@@ -427,6 +487,7 @@ AC_CONFIG_FILES([
 	src/tape_drivers/linux/lin_tape/Makefile
 	src/tape_drivers/linux/sg-ibmtape/Makefile
 	src/tape_drivers/osx/iokit-ibmtape/Makefile
+	src/tape_drivers/freebsd/cam/Makefile
 	src/iosched/Makefile
 	src/kmi/Makefile
 	src/utils/Makefile

--- a/messages/Makefile.am
+++ b/messages/Makefile.am
@@ -57,6 +57,7 @@ RESOURCES = \
 	tape_linux_lin_tape_dat.o \
 	tape_linux_sg_ibmtape_dat.o \
 	tape_iokit_ibmtape_dat.o \
+	tape_freebsd_camtape_dat.o \
 	iosched_fcfs_dat.o \
 	iosched_unified_dat.o \
 	libltfs_dat.o \

--- a/messages/make_message_src.sh
+++ b/messages/make_message_src.sh
@@ -15,6 +15,9 @@ if [ "$KERNEL_NAME" = "Darwin" ]; then
 		GENRB=genrb
 		PKGDATA=pkgdata
 	fi
+elif [ "$KERNEL_NAME" = "FreeBSD" ]; then
+	GENRB=genrb
+	PKGDATA=/usr/local/bin/pkgdata
 else
 	if [ -x /usr/bin/genrb ]; then
 		GENRB=/usr/bin/genrb
@@ -56,6 +59,14 @@ make_obj() {
 		MINGW32_NT*)
 			mv ${BASENAME}.dat ../../
 			;;
+		FreeBSD)
+			# pkgdata with -m static generates an ar(1) archive
+			# with several object files on FreeBSD.  To avoid
+			# reworking the makefiles for all OSes, just rename
+			# the archive to match the regular convention.  The
+			# linker handles it without a problem.
+			mv lib${BASENAME}.a ../../${BASENAME}_dat.o
+			;;
 		*)
 			mv ${BASENAME}_dat.o ../../
 			;;
@@ -68,7 +79,7 @@ make_obj() {
 
 # Check whether we need to do anything
 if [ -f "../$1" ]; then
-	for file in *; do
+	for file in *.txt; do
 		if [ "$file" -nt "../$1" ]; then
 			make_obj
 			exit 0

--- a/messages/tape_freebsd_camtape/en.txt
+++ b/messages/tape_freebsd_camtape/en.txt
@@ -1,0 +1,39 @@
+//
+//
+//  OO_Copyright_BEGIN
+//
+//
+//  Copyright 2010, 2018 IBM Corp. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//   modification, are permitted provided that the following conditions
+//  are met:
+//  1. Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//  documentation and/or other materials provided with the distribution.
+//  3. Neither the name of the copyright holder nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+//
+//
+//  OO_Copyright_END
+//
+ 
+en:table {
+	// This resource intentionally left blank.
+}
+

--- a/messages/tape_freebsd_camtape/en_US.txt
+++ b/messages/tape_freebsd_camtape/en_US.txt
@@ -1,0 +1,39 @@
+//
+//
+//  OO_Copyright_BEGIN
+//
+//
+//  Copyright 2010, 2018 IBM Corp. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//   modification, are permitted provided that the following conditions
+//  are met:
+//  1. Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//  documentation and/or other materials provided with the distribution.
+//  3. Neither the name of the copyright holder nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+//
+//
+//  OO_Copyright_END
+//
+ 
+en_US:table {
+	// This resource intentionally left blank.
+}
+

--- a/messages/tape_freebsd_camtape/root.txt
+++ b/messages/tape_freebsd_camtape/root.txt
@@ -1,0 +1,146 @@
+//
+//
+//  OO_Copyright_BEGIN
+//
+//
+//  Copyright 2010, 2018 IBM Corp. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//   modification, are permitted provided that the following conditions
+//  are met:
+//  1. Redistributions of source code must retain the above copyright
+//     notice, this list of conditions and the following disclaimer.
+//  2. Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//  documentation and/or other materials provided with the distribution.
+//  3. Neither the name of the copyright holder nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+//
+//
+//  OO_Copyright_END
+//
+
+// Messages for the FreeBSD camtape backend.
+// This backend shares IDs 12000-12999 with the file and iokit backends and the backend
+// interface functions, so be sure to make a note in messages/ltfs/root.txt whenever an
+// ID is allocated here.
+root:table {
+	messages:table {
+		start_id:int { 30400 }
+		end_id:int { 30599 }
+
+		30400I:string { "SIOC_PASS_THROUGH: command failed (%d) %s" }
+		30401D:string { "SIOC_PASS_THROUGH: no sense info: T%02x:M%02x:H%02x:D%02x %s" }
+		30402D:string { "SIOC_PASS_THROUGH: sense = %02x/%02x%02x" }
+		30403D:string { "SIOC_PASS_THROUGH: pos = 0x%02x%02x%02x%02x %s" }
+		30404I:string { "SIOC_PASS_THROUGH: cannot sense data from the drive" }
+		30405I:string { "SIOC_PASS_THROUGH: status info: T%02x:M%02x:H%02x:D%02x %s" }
+		30406D:string { "IOCTL: sense = %02x/%02x%02x" }
+		30407D:string { "IOCTL: pos = 0x%02x%02x%02x%02x %s" }
+		30408I:string { "IOCTL: %s %d returns %d (generic %d) %s" }
+		30409D:string { "IOCTL: no sense info" }
+		30410D:string { "IOCTL: %s %d expected error %d" }
+		30411D:string { "IOCTL: %s %d expected error %d. retry the operation."}
+		30412I:string { "Cannot get sense (%d)" }
+		30413I:string { "Error on %s: %s (%d) %s"}
+		30414E:string { "Error on %s: msg = NULL (%d) %s"}
+		30415W:string { "Cannot detect camtape version" }
+		30416I:string { "camtape version is %s" }
+		30417E:string { "Old camtape version is detected." }
+		30418I:string { "Parsing log page: buffer too small, copying %zu bytes from %lx" }
+		30419I:string { "Option parsing for the camtape backend failed (%d)" }
+		30420E:string { "Invalid scsi_lbprotect option: %s" }
+		30421W:string { "Drive firmware must be updated. Upgrading to %s or later is recommended." }
+		30422W:string { "Drive firmware level does not correctly detect the EOD status" }
+		30423I:string { "Opening a device through camtape driver (%s)" }
+		30424E:string { "%s: medium is already mounted or in use" }
+		30425I:string { "Cannot open device \'%s\' (%d)" }
+		30426W:string { "Device \'%s\' must be opened in read-only mode" }
+		30427I:string { "Cannot open device: inquiry failed (%d)" }
+		30428I:string { "Product ID is \'%s\'" }
+		30429I:string { "Vendor ID is %s" }
+		30430I:string { "Unsupported Drive \'%s\'" }
+		30431I:string { "Cannot open device: inquiry 0x%x failed (%d)" }
+		30432I:string { "Firmware revision is %s" }
+		30433I:string { "Drive serial is %s" }
+		30434I:string { "Pseudo-error on %s" }
+		30435I:string { "Pseudo-error on write. Good return code, but a record to emulate a write error did not get sent to the drive." }
+
+		30436D:string { "Read block: file mark detected" }
+		30437I:string { "Read block: overlength condition is detected. residual = %d, actual = %d" }
+		30438D:string { "Read block: underlength condition is detected. shortage = %d, actual = %d" }
+		30439E:string { "Logical block protection Error on read" }
+		30440W:string { "Detect ENOMEM in write() call. Wait 3 secs and retry (%d)"}
+		30441I:string { "Retrying write() call at (%u, %llu)"}
+		30442I:string { "Skip retrying write() call at (%u, %llu), because the record was already written"}
+		30443W:string { "Enexpected current position (%d). (%u, %llu), (%u, %llu) "}
+		30444W:string { "Position confirmation for write() call retry is failed (%d). (%u, %llu), (%u, %llu) "}
+		30445W:string { "Received low space warning (early warning) in %s" }
+		30446W:string { "Received low space warning (programmable early warning) in %s" }
+		30447E:string { "Logical block protection Error on write" }
+		30448D:string { "EOD detected (%s): ignore sense" }
+		30449I:string { "Unrecognized space type" }
+		30450I:string { "Cannot space: count value %d of the space command is too large" }
+		30451I:string { "A long data wipe is in progress. (%d minutes passed)" }
+		30452I:string { "A long data wipe is in progress. %d %%" }
+		30453W:string { "Failed to get medium type code: medium type check is skipped" }
+		// Reusable 30454
+		30455I:string { "Unsupported cartridge (0x%x, 0x%x)" }
+		30456I:string { "Invalid format mode (%d)" }
+		30457I:string { "Cannot get remaining capacity: get log page 0x%02x failed (%d)" }
+		30458I:string { "Cannot get remaining capacity: failed to parse the log page" }
+		30459I:string { "Cannot get remaining capacity: loop index error (%d)" }
+		30460I:string { "Cannot read attribute (%d)" }
+		30461I:string { "Cannot get log page 0x%02x (%d) in %s" }
+		30462I:string { "Cannot parse the log page 0x%02x in %s" }
+		30463E:string { "Failed to open file '%s' (%d)"}
+		30464W:string { "Cannot get EOD status: failed to get log page 0x%02x (%d)" }
+		30465W:string { "Cannot get EOD status: failed to parse the log page" }
+		30466W:string { "Cannot get EOD status: value length or partition number is wrong %d - (%d, %d)" }
+		30467I:string { "Unexpected parameter size for getting active CQ loss write (%d)" }
+		30468I:string { "Cannot allocate memory in %s" }
+		30469E:string { "Encryption method of the drive is not AME but %s (0x%02X)" }
+		30470E:string { "Encryption feature is not supported on the drive: %d" }
+		30471I:string { "Logical block protection is enabled" }
+		30472I:string { "Logical block protection is disabled" }
+
+		30478I:string { "Saving drive dump to %s" }
+		30479W:string { "Cannot retrieve drive dump: failed to create dump file (%d)" }
+		30480D:string { "Total dump data length is %lld." }
+		30481D:string { "Total number of transfers is %d." }
+		30482D:string { "Transferring dump data" }
+		30483W:string { "Cannot retrieve drive dump: failed to read buffer (%d)" }
+		30484W:string { "Cannot retrieve drive dump: failed to write to dump file (%d)" }
+		30485D:string { "Transfer %d: wrote %d bytes" }
+		30486W:string { "Cannot retrieve drive dump: wrote %d bytes out, expected %d" }
+		30487I:string { "Taking drive dump in buffer" }
+		30488I:string { "Forcing drive dump" }
+		30489I:string { "Failed to get cartridge status. The cartridge is not loaded."}
+
+		30592D:string { "Backend %s %s" }
+		30593D:string { "Backend %s: %d %s" }
+		30594D:string { "Backend %s: %llu %s" }
+		30595D:string { "Backend %s: %zu bytes %s" }
+		30596D:string { "Backend %s: %zu %s" }
+		30597D:string { "Backend %s: (%llu, %llu) %s" }
+		30598D:string { "Backend %s: (%llu, %llu) FM = %llu %s" }
+		30599I:string { "CAM backend options:\n"
+						"    -o devname=<dev>           tape device (default=%s)\n"
+						"    -o autodump                enable autodump (default)\n"
+						"    -o noautodump              disable autodump\n"
+						"    -o scsi_lbprotect=<on|off> enable drive logical block protection (default=off)\n" }
+	}
+}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -52,6 +52,10 @@ if PLATFORM_MAC
 PLAT_DRV += tape_drivers/osx/iokit-ibmtape
 endif
 
+if PLATFORM_FREEBSD
+PLAT_DRV += tape_drivers/freebsd/cam
+endif
+
 if ENABLE_LIN_TAPE
 PLAT_DRV += tape_drivers/linux/lin_tape
 endif

--- a/src/libltfs/arch/arch_info.c
+++ b/src/libltfs/arch/arch_info.c
@@ -133,7 +133,7 @@ void show_runtime_system_info(void)
 
 	return;
 }
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(__FreeBSD__)
 {
 	int mib[2];
 	size_t len;

--- a/src/libltfs/arch/arch_info.h
+++ b/src/libltfs/arch/arch_info.h
@@ -74,6 +74,11 @@
 #define BUILD_SYS_FOR "This binary is built for Mac OS X "
 #define BUILD_SYS_GCC __VERSION__
 
+#elif defined(__FreeBSD__)
+
+#define BUILD_SYS_FOR "This binary is built for FreeBSD"
+#define BUILD_SYS_GCC __VERSION__
+
 #elif defined(mingw_PLATFORM)
 
 #define BUILD_SYS_FOR "This binary is built for Windows"

--- a/src/libltfs/arch/errormap.c
+++ b/src/libltfs/arch/errormap.c
@@ -51,6 +51,10 @@
 #include "libltfs/arch/win/win_util.h"
 #endif
 
+#ifdef __FreeBSD__
+#include "libltfs/arch/freebsd/errno.h"
+#endif
+
 #include <stdlib.h>
 #include <errno.h>
 

--- a/src/libltfs/arch/freebsd/errno.h
+++ b/src/libltfs/arch/freebsd/errno.h
@@ -1,0 +1,6 @@
+#ifndef LIBLTFS_ARCH_FREEBSD_ERRNO_H
+#define LIBLTFS_ARCH_FREEBSD_ERRNO_H
+
+#define ENODATA EIO
+
+#endif

--- a/src/libltfs/arch/freebsd/freebsd_locking.h
+++ b/src/libltfs/arch/freebsd/freebsd_locking.h
@@ -1,0 +1,154 @@
+/*
+**
+**  OO_Copyright_BEGIN
+**
+**
+**  Copyright 2010, 2018 IBM Corp. All rights reserved.
+**  Copyright (c) 2014-2018 Spectra Logic Corporation. All rights reserved.
+**
+**  Redistribution and use in source and binary forms, with or without
+**   modification, are permitted provided that the following conditions
+**  are met:
+**  1. Redistributions of source code must retain the above copyright
+**     notice, this list of conditions and the following disclaimer.
+**  2. Redistributions in binary form must reproduce the above copyright
+**     notice, this list of conditions and the following disclaimer in the
+**  documentation and/or other materials provided with the distribution.
+**  3. Neither the name of the copyright holder nor the names of its
+**     contributors may be used to endorse or promote products derived from
+**     this software without specific prior written permission.
+**
+**  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+**  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+**  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+**  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+**  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+**  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+**  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+**  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+**  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+**  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+**  POSSIBILITY OF SUCH DAMAGE.
+**
+**
+**  OO_Copyright_END
+**
+*************************************************************************************
+**
+** COMPONENT NAME:  IBM Linear Tape File System
+**
+** FILE NAME:       freebsd_locking.h
+**
+** DESCRIPTION:     LTFS locking method imprementation
+**                  Multi-reader single-writer lock implementation for FreeBSD.
+**
+** AUTHORS:         Mark A. Smith
+**                  IBM Almaden Research Center
+**                  mark1smi@us.ibm.com
+**
+**                  Atsushi Abe
+**                  IBM Tokyo Lab., Japan
+**                  piste@jp.ibm.com
+**
+**                  Reid Linnemann
+**                  Spectra Logic Corporation
+**                  reidl@spectralogic.com
+*************************************************************************************
+*/
+#ifndef __FREEBSD_LOCKING_H__
+#define __FREEBSD_LOCKING_H__
+
+typedef pthread_rwlock_t MultiReaderSingleWriter;
+
+static inline int
+init_mrsw(MultiReaderSingleWriter *mrsw)
+{
+	return (pthread_rwlock_init(mrsw, NULL));
+}
+
+static inline void
+destroy_mrsw(MultiReaderSingleWriter *mrsw)
+{
+	pthread_rwlock_destroy(mrsw);
+}
+
+static inline bool
+try_acquirewrite_mrsw(MultiReaderSingleWriter *mrsw)
+{
+	int err;
+
+	err = pthread_rwlock_trywrlock(mrsw);
+	if (err)
+		return false;
+	else
+		return true;
+}
+
+static inline void
+acquirewrite_mrsw(MultiReaderSingleWriter *mrsw)
+{
+	pthread_rwlock_wrlock(mrsw);
+}
+
+static inline void
+acquirewrite_mrsw_long(MultiReaderSingleWriter *mrsw)
+{
+	/* XXX KDM long lock? */
+	pthread_rwlock_wrlock(mrsw);
+}
+
+static inline void
+releasewrite_mrsw(MultiReaderSingleWriter *mrsw)
+{
+	pthread_rwlock_unlock(mrsw);
+}
+
+static inline void
+acquireread_mrsw(MultiReaderSingleWriter *mrsw)
+{
+	pthread_rwlock_rdlock(mrsw);
+}
+
+static inline int
+acquireread_mrsw_short(MultiReaderSingleWriter *mrsw)
+{
+	int ret = 0;
+
+	ret = pthread_rwlock_rdlock(mrsw);
+	if (ret != 0)
+		return -1;
+	else
+		return 0;
+}
+
+static inline void
+releaseread_mrsw(MultiReaderSingleWriter *mrsw)
+{
+	pthread_rwlock_unlock(mrsw);
+}
+
+static inline void
+release_mrsw(MultiReaderSingleWriter *mrsw)
+{
+	pthread_rwlock_unlock(mrsw);
+}
+
+//downgrades a write lock to a read lock
+static inline void
+writetoread_mrsw(MultiReaderSingleWriter *mrsw)
+{
+	/*
+	 * The original intent of this function was to downgrade from write lock
+	 * to read lock with higher priority than incoming write
+	 * locks. pthread_rwlock doesn't provide this semantic,so we just
+	 * release the lock and reacquire a reader lock on it. This demotion is
+	 * only used by _ltfs_fsraw_write_data_unlocked() to release the write
+	 * lock before returning. If there are pending writers on the volume
+	 * lock at this point, they could prevent
+	 * _ltfs_fsraw_write_data_unlocked)_ from returning immediately.
+	 */
+	pthread_rwlock_unlock(mrsw);
+	pthread_rwlock_rdlock(mrsw);
+}
+
+#endif /* __FREEBSD_LOCKING_H__ */

--- a/src/libltfs/arch/freebsd/xattr.h
+++ b/src/libltfs/arch/freebsd/xattr.h
@@ -1,0 +1,12 @@
+#ifndef LIBLTFS_ARCH_FREEBSD_XATTR_H
+#define LIBLTFS_ARCH_FREEBSD_XATTR_H
+
+enum
+{
+  XATTR_CREATE = 1,     /* set value, fail if attr already exists.  */
+#define XATTR_CREATE    XATTR_CREATE
+  XATTR_REPLACE = 2     /* set value, fail if attr does not exist.  */
+#define XATTR_REPLACE   XATTR_REPLACE
+};
+
+#endif /* LIBLTFS_ARCH_FREEBSD_XATTR_H */

--- a/src/libltfs/arch/version.h
+++ b/src/libltfs/arch/version.h
@@ -61,6 +61,8 @@
     #define PLATFORM "Mac OS X"
 #elif mingw_PLATFORM
     #define PLATFORM "Windows"
+#elif __FreeBSD__
+    #define PLATFORM "FreeBSD"
 #else
     #define PLATFORM "Linux"
 #endif /* __APPLE__ */

--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -200,7 +200,11 @@ int ltfs_set_signal_handlers(void)
 }
 #else
 {
+#ifdef __FreeBSD__
+	sig_t ret;
+#else
 	sighandler_t ret;
+#endif
 
 	interrupted = false;
 
@@ -248,7 +252,11 @@ int ltfs_unset_signal_handlers(void)
 }
 #else
 {
+#ifdef __FreeBSD__
+	sig_t rc;
+#else
 	sighandler_t rc;
+#endif
 	int ret = 0;
 
 	rc = signal(SIGINT, SIG_DFL);

--- a/src/libltfs/ltfs.h
+++ b/src/libltfs/ltfs.h
@@ -89,7 +89,9 @@ extern "C" {
 #endif
 
 #ifndef mingw_PLATFORM
-#include <sys/xattr.h>
+  #ifndef __FreeBSD__
+    #include <sys/xattr.h>
+  #endif
 #endif
 
 #include "libltfs/arch/signal_internal.h"
@@ -264,8 +266,8 @@ struct dentry {
 	 * iosched_lock, contents_lock, meta_lock. If the tape device lock is needed, take it
 	 * before meta_lock. If locks are needed on a dentry's parent, take all parent locks before
 	 * any dentry locks. */
-	struct MultiReaderSingleWriter contents_lock;      /**< Lock for 'extentlist' and 'list' */
-	struct MultiReaderSingleWriter meta_lock;          /**< Lock for metadata */
+	MultiReaderSingleWriter contents_lock;      /**< Lock for 'extentlist' and 'list' */
+	MultiReaderSingleWriter meta_lock;          /**< Lock for metadata */
 	ltfs_mutex_t iosched_lock;                      /**< Lock for use by the I/O scheduler */
 
 	/* Immutable fields. No locks are needed to access these. */
@@ -368,7 +370,7 @@ enum volumelock_status {
 struct ltfs_volume {
 	/* acquire this lock for read before using the volume in any way. acquire it for write before
 	 * writing the index to tape or performing other exclusive operations. */
-	struct MultiReaderSingleWriter lock; /**< Controls access to volume metadata */
+	MultiReaderSingleWriter lock; /**< Controls access to volume metadata */
 
 	/* LTFS format data */
 	struct tc_coherency ip_coh;    /**< Index partition coherency info */
@@ -540,7 +542,7 @@ typedef enum {
 #define SYNC_DNO_SPACE       "Dcache no space"
 #define SYNC_UNMOUNT         "Unmount"
 #define SYNC_UNMOUNT_NOMEM   "Unmount - no memory"
-#define SYNC_MOVE            "Unmount - %"PRIu64
+#define SYNC_MOVE            "Unmount - %" PRIu64
 #define SYNC_CHECK           "Check"
 #define SYNC_ROLLBACK        "Rollback"
 #define SYNC_FORMAT          "Format"

--- a/src/libltfs/ltfs_locking.h
+++ b/src/libltfs/ltfs_locking.h
@@ -66,7 +66,8 @@ static inline void backtrace_info(void)
 }
 
 #include "arch/win/win_locking.h"
-#else
+
+#else /* ! mingw_PLATFORM */
 
 #include <pthread.h>
 #include <execinfo.h> /* For backtrace() */
@@ -148,7 +149,13 @@ static inline int ltfs_mutexattr_setpshared(ltfs_mutexattr_t *attr,
 {
 	return pthread_mutexattr_setpshared(attr, pshared);
 }
-#endif
+#endif /* ! mingw_PLATFORM */
+
+#ifdef __FreeBSD__
+
+#include "arch/freebsd/freebsd_locking.h"
+
+#else /* !__FreeBSD__ */
 
 typedef struct MultiReaderSingleWriter {
 	ltfs_mutex_t write_exclusive_mutex;
@@ -349,6 +356,8 @@ writetoread_mrsw(MultiReaderSingleWriter *mrsw)
 	//Release the write_exclusive_mutex, to allow others to write protect, and additional readers in.
 	ltfs_mutex_unlock(&mrsw->write_exclusive_mutex);
 }
+
+#endif /* ! __FreeBSD__ */
 
 #ifdef __cplusplus
 }

--- a/src/libltfs/ltfs_thread.c
+++ b/src/libltfs/ltfs_thread.c
@@ -61,4 +61,19 @@ uint32_t ltfs_get_thread_id(void)
 	return tid;
 }
 
+#elif defined(__FreeBSD__)
+
+#include <pthread.h>
+#include <pthread_np.h>
+
+uint32_t ltfs_get_thread_id(void)
+{
+	uint32_t tid;
+
+	tid = (uint32_t)pthread_getthreadid_np();
+
+	return tid;
+}
+
+
 #endif

--- a/src/libltfs/ltfs_thread.h
+++ b/src/libltfs/ltfs_thread.h
@@ -58,6 +58,14 @@ extern "C" {
 #include "arch/win/win_thread.h"
 #else
 
+/*
+ * restrict is a C99 extension, and isn't necessarily supported by C++
+ * compilers.
+ */
+#ifdef __cplusplus
+#define	restrict
+#endif
+
 #include <pthread.h>
 #include <sys/time.h>
 #include <sys/syscall.h>
@@ -200,14 +208,14 @@ static inline ltfs_thread_t ltfs_thread_self(void)
 
 static inline int ltfs_thread_yield(void)
 {
-#ifdef __APPLE__
+#if defined (__APPLE__) || defined(__FreeBSD__)
 	return sched_yield();
 #else
 	return pthread_yield();
 #endif
 }
 
-#ifdef __APPLE__
+#if defined(__APPLE__) || defined(__FreeBSD__)
 extern uint32_t ltfs_get_thread_id(void);
 #else
 static inline uint32_t ltfs_get_thread_id(void)

--- a/src/libltfs/ltfstrace.c
+++ b/src/libltfs/ltfstrace.c
@@ -162,7 +162,7 @@ struct function_entry {
 #define FS_FN_TRACE_ENTRIES    (FS_FN_TRACE_SIZE / FN_TRACE_ENTRY_SIZE)
 
 struct filesystem_function_trace {
-	struct MultiReaderSingleWriter trace_lock;      /**< Lock for trace data */
+	MultiReaderSingleWriter        trace_lock;      /**< Lock for trace data */
 	uint32_t                       max_index;
 	uint32_t                       cur_index;
 	struct function_entry          entries[FS_FN_TRACE_ENTRIES];
@@ -180,7 +180,7 @@ struct filesystem_trace_list {
 #define ADMIN_FN_TRACE_ENTRIES	256
 #define ADMIN_FN_TRACE_SIZE	(ADMIN_FN_TRACE_ENTRIES * FN_TRACE_ENTRY_SIZE)
 struct admin_function_trace {
-	struct MultiReaderSingleWriter trace_lock;      /**< Lock for trace data */
+	MultiReaderSingleWriter        trace_lock;      /**< Lock for trace data */
 	uint32_t                       max_index;
 	uint32_t                       cur_index;
 	struct function_entry          entries[ADMIN_FN_TRACE_ENTRIES];
@@ -200,7 +200,7 @@ struct admin_completed_function_trace {
 	TAILQ_ENTRY(admin_completed_function_trace) list;
 	uint32_t                       tid;
 	struct admin_function_trace    *fn_entry;
-	struct MultiReaderSingleWriter trace_lock;
+	MultiReaderSingleWriter        trace_lock;
 };
 
 /*

--- a/src/libltfs/plugin.c
+++ b/src/libltfs/plugin.c
@@ -199,7 +199,7 @@ static void print_help_message(void *ops, const char * const type)
 		if (ret < 0) {
 			ltfsmsg(LTFS_ERR, 11316E);
 		}
-	} else if (! strcmp(type, "driver"))
+	} else if (! strcmp(type, "tape"))
 		tape_print_help_message(ops);
 	else
 		ltfsmsg(LTFS_ERR, 11317E, type);

--- a/src/libltfs/xattr.h
+++ b/src/libltfs/xattr.h
@@ -58,6 +58,10 @@
 extern "C" {
 #endif
 
+#ifdef __FreeBSD__
+#include "libltfs/arch/freebsd/xattr.h"
+#endif
+
 #include "ltfs.h"
 
 #define LTFS_PRIVATE_PREFIX "ltfs."

--- a/src/tape_drivers/freebsd/cam/IBM_tape.h
+++ b/src/tape_drivers/freebsd/cam/IBM_tape.h
@@ -1,0 +1,1240 @@
+/*******************************************************************************
+ *   IBM_tape.h
+ *
+ *  Copyright 2001, 2017 IBM Corp.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *   modification, are permitted provided that the following conditions
+ *  are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *  documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the names of its
+ *     contributors may be used to endorse or promote products derived from
+ *     this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#ifndef IBM_TAPE_H
+#define IBM_TAPE_H
+
+/* tape device id */
+#define IBM_3580    1
+#define IBM_3590    2
+#define IBM_3592    3
+
+/* changer device id */
+#define IBM_3581    7
+#define IBM_3582    8
+#define IBM_3583    9
+#define IBM_3584   10
+#define BDT_3581   11
+#define IBM_3576   12
+#define IBM_3573   13
+#define IBM_3577   14
+#define IBM_3572   15
+
+/*******************************************************************************
+* IOCTL Structures                                                             *
+*******************************************************************************/
+#ifndef unchar
+#define unchar unsigned char
+#endif
+
+#ifndef boolean
+#define boolean unchar
+#endif
+
+#ifndef BYTE
+#define BYTE unchar
+#endif
+
+#ifndef ulong
+#define ulong unsigned long
+#endif
+
+/*******************************************************************************
+* SCSI_PASS_THROUGH pass through function                                      *
+*******************************************************************************/
+
+#define SCSI_PASS_THROUGH _IOWR('P',0x01,SCSIPassThrough) /* Pass Through  */
+
+typedef struct _SCSIPassThrough {
+	unchar   CDB[12];                           /* Command Data Block    */
+	unchar   CommandLength;                     /* Command Length        */
+	unchar * Buffer ;                           /* Command Buffer        */
+	ulong    BufferLength;                      /* Buffer Length         */
+	unchar   DataDirection;                     /* Transfer Direction    */
+	ushort   TimeOut;                           /* Time Out Value        */
+	unchar   TargetStatus;                      /* Target Status         */
+	unchar   MessageStatus;                     /* Msg from host adapter */
+	unchar   HostStatus;                        /* Host status           */
+	unchar   DriverStatus;                      /* Driver status         */
+	unchar   SenseDataValid;                    /* Sense Data Valid      */
+	unchar   ASC;                               /* ASC if SenseDataValid */
+	unchar   ASCQ;                              /* ASCQ if SenseDataVld  */
+	unchar   SenseKey;                          /* SK if SenseDataValid  */
+} SCSIPassThrough, *PSCSIPassThrough;
+
+#define SCSI_DATA_OUT  1
+#define SCSI_DATA_IN   2
+
+#ifndef SCSI_DATA_NONE
+#define SCSI_DATA_NONE 3
+#endif
+
+/*******************************************************************************
+* SCSI Tape Operations                                                         *
+* STOFFL, STREW, STERASE, STWEOF, STFSF, STRSF, STFSR and STRSR perform as     *
+* defined in the AIX manuals. For IBM tape products STRETEN is a NOP           *
+* since they automatically perform retension on their own.                     *
+*                                                                              *
+* STTUR issues a SCSI Test Unit Ready to device.                               *
+* STLOAD issues a SCSI LOAD command                                            *
+* STSEOD issues a space forward to EOD command. After this command the         *
+*   tape is positioned to begin writing.                                       *
+* STFSSF issues a forward space sequential filemarks. Count is equal to        *
+*   the number of contiguous fiemarks to search for.                           *
+* STRSSF issues a reverse space sequential filemarks. Count is equal to        *
+*   the number of contiguous fiemarks to search for.                           *
+* IMPORTANT NOTE:                                                              *
+* Any command that causes tape position to reverse. Will cause the close       *
+* entry point to not write file-marks. If you must position the tape           *
+* after writing data and before closing then you can manually write            *
+* file-marks with STWEOF.                                                      *
+*******************************************************************************/
+
+#define STIOCTOP    _IOWR('P',0x02, struct stop)          /* tape commands */
+
+struct stop {
+	short   st_op;                            /* operations defined below */
+	daddr_t st_count;                         /* Counter value            */
+};
+
+#define STOFFL  5                      /* rewind and unload tape              */
+#define STREW   6                      /* rewind                              */
+#define STERASE 7                      /* erase tape, leave at load point     */
+#define STRETEN 8                      /* retension tape, leave at load point */
+#define STWEOF  10                     /* write an end-of-file record         */
+#define STFSF   11                     /* forward space file                  */
+#define STRSF   12                     /* reverse space file                  */
+#define STFSR   13                     /* forward space record                */
+#define STRSR   14                     /* reverse space record                */
+#define STINSRT 15                     /* load the tape                       */
+#define STEJECT 16                     /* unload the tape                     */
+
+/* additional st_op's */
+#define STTUR   30                     /* test unit ready                     */
+#define STLOAD  31                     /* load tape                           */
+#define STSEOD  32                     /* space to end of data                */
+#define STFSSF  33                     /* forward space sequential file marks */
+#define STRSSF  34                     /* reverse space sequential file marks */
+
+#define STIOCHGP _IOW('P',0x03, struct stchgp)    /* change drive parameters  */
+struct  stchgp  {
+	unchar  st_ecc;                              /* reserved              */
+	int     st_blksize;                          /* change blocksize      */
+};
+
+/*******************************************************************************
+* QUERY_DRIVER_VERSION returns the IBMtape driver version                      *
+*******************************************************************************/
+
+#define QUERY_DRIVER_VERSION \
+	_IOR('P',0x04, struct QueryDriverVersion)  /* version */
+struct QueryDriverVersion {
+	uint MajorRelease;                            /* Major release number */
+	uint MinorRelease;                            /* Minor release number */
+	uint IncrementRelease;                        /* Incrs release num    */
+};
+
+/*******************************************************************************
+* STIOCSETP changes device driver parameters                                   *
+*   The structure "stchgp" is used to set the current values.                  *
+* STIOCQRYP queries device driver parameters                                   *
+*   The structure "stchgp" is filled in with the current values.               *
+*******************************************************************************/
+
+#define STIOCSETP _IOW('z',0x30,struct stchgp_s)         /* change parameters */
+#define STIOCQRYP _IOR('z',0x31,struct stchgp_s)         /* query  parameters */
+
+struct stchgp_s {
+	int blksize;                      /* new block size                   */
+	boolean trace;                    /* TRUE = message trace on          */
+	uint hkwrd;                       /* trace hook word                  */
+	int sync_count;                   /* obsolete - not used              */
+	boolean autoload;                 /* on/off autoload feature          */
+	boolean buffered_mode;            /* on/off buffered mode             */
+	boolean compression;              /* on/off compression               */
+	boolean trailer_labels;           /* on/off allow writing after EOM   */
+	boolean rewind_immediate;         /* on/off immediate rewinds         */
+	boolean bus_domination;           /* obsolete - not used              */
+	boolean logging;                  /* enable or disable volume logging */
+	boolean write_protect;            /* write_protected media            */
+	uint min_blksize;                 /* minimum block size               */
+	uint max_blksize;                 /* maximum block size               */
+	uint max_scsi_xfer;               /* maximum scsi tranfer len         */
+	char volid[16];                   /* volume id                        */
+	unchar acf_mode;                  /* automatic cartridge facility mode*/
+#define ACF_NONE             0
+#define ACF_MANUAL           1
+#define ACF_SYSTEM           2
+#define ACF_AUTOMATIC        3
+#define ACF_ACCUMULATE       4
+#define ACF_RANDOM           5
+	unchar record_space_mode;                     /* fsr/bsr space mode   */
+#define SCSI_SPACE_MODE      1
+#define AIX_SPACE_MODE       2
+	unchar logical_write_protect;                 /* logical write protect*/
+#define NO_PROTECT           0
+#define ASSOCIATED_PROTECT   1
+#define PERSISTENT_PROTECT   2
+#define WORM_PROTECT         3
+	unchar capacity_scaling;                      /* capacity scaling     */
+#define SCALE_100            0
+#define SCALE_75             1
+#define SCALE_50             2
+#define SCALE_25             3
+#define SCALE_VALUE          4
+	unchar retain_reservation;       /* retain reservation                */
+	unchar alt_pathing;              /* alternate pathing active          */
+	boolean emulate_autoloader;      /* emulate autoloader in random mode */
+	unchar medium_type;              /* tape medium type                  */
+	unchar density_code;             /* tape density code                 */
+	boolean disable_sim_logging;     /* disable sim/mim error logging     */
+	boolean read_sili_bit;           /* SILI bit setting for read commands*/
+	unchar read_past_filemark;       /* fixed block read pass the filemark*/
+	boolean disable_auto_drive_dump; /* disable auto drive dump logging   */
+	unchar capacity_scaling_value;   /* hex value of capacity scaling     */
+	boolean wfm_immediate;           /* buffer write file mark            */
+	boolean limit_read_recov;        /* limit read recovery to 5 seconds  */
+	boolean limit_write_recov;       /* limit write recovery to 5 seconds */
+	boolean data_safe_mode;          /* turn data safe mode on/off        */
+	unchar pews[2];                  /* programmable early warn zone size */
+	unchar busy_retry;			     /* if set a retry will be tried on busy */
+	unchar reserved[12];
+};
+
+/*******************************************************************************
+* This has no arguments. The tape buffers are flushed to tape.                 *
+*******************************************************************************/
+
+#define STIOCSYNC _IO('z',0x37)           /* synchronize buffers with tape */
+
+/*******************************************************************************
+* STIOCDM displays a message on the 3490 display.                              *
+*   dm_func is a flag that is built by oring the defines below.                *
+*******************************************************************************/
+
+#define STIOCDM _IOW('z',0x32,struct stdm_s)               /* display message */
+#define MAXMSGLEN     8
+
+struct stdm_s {
+	char dm_func;                                      /* function code   */
+
+/*Function Selection*/
+#define DMSTATUSMSG 0x00    /* General Status Msg                             */
+#define DMDVMSG     0x20    /* Demount/Verify Message                         */
+#define DMMIMMED    0x40    /* Mount With Immediate Action indicator          */
+#define DMDEMIMMED  0xE0    /* Demount/Mount With Immediate Action            */
+
+/*Message Control*/
+#define DMMSG0      0x00                /* display msg 0                      */
+#define DMMSG1      0x04                /* display msg 1                      */
+#define DMFLASHMSG0 0x08                /* Flash msg 0                        */
+#define DMFLASHMSG1 0x0C                /* flash msg 1                        */
+#define DMALTERNATE 0x10                /* alternate msg 0 and msg 1          */
+
+	char dm_msg0[MAXMSGLEN];        /* message 1                          */
+char dm_msg1[MAXMSGLEN];                /* message 2                          */
+};
+
+/*******************************************************************************
+* STIOCQRYPOS is used to query the position of the tape device on the tape.    *
+*   "block_type" indicates whether a logical position is wanted or             *
+*   whether a vendor specific position is wanted. The vendor specific          *
+*   position is a composite number that is fed into an STIOCSETPOS command     *
+*   to provide a much faster method of positioning. Unless a SETPOS            *
+*   operation is going to be used there is not much reason to use              *
+*   QP_PHYSICAL.                                                               *
+*   "eot" is true if the tape position is after early warning.                 *
+*   "curpos" is the position where the next write or read would take place.    *
+*   "lbot" is the number of the last block to be actually written from the     *
+*   buffer onto the tape. If no blocks have been written to tape, ie, all      *
+*   are still in the buffer then lbot=NONE                                     *
+*   NOTE: lbot is only valid immediately following a write command. Any        *
+*   tape positioning will cause this to become invalid.                        *
+* STIOCSETPOS is used to position the tape directly to a particular block.     *
+*   Only "block_type" and "curpos" are used. All other fields are undefined    *
+*******************************************************************************/
+
+#define STIOCQRYPOS _IOWR('z',0x33,struct stpos_s)     /* query tape position */
+#define STIOCSETPOS _IOWR('z',0x34,struct stpos_s)     /* set tape position   */
+typedef unsigned int blockid_t;
+struct stpos_s {
+	char block_type;                  /* format of block id information   */
+#define QP_LOGICAL  0                     /* scsi logical blockid format      */
+#define QP_PHYSICAL 1                     /* vendor specific blockid format   */
+	boolean eot;                      /* leading end of partition         */
+	blockid_t curpos;                 /* for qry/set pos                  */
+	blockid_t lbot;                   /* last block written to tape       */
+#define LBOT_NONE    0xFFFFFFFF           /* no blocks have been written      */
+#define LBOT_UNKNOWN 0xFFFFFFFE           /* unable to determine information  */
+	uint num_blocks;                  /* number of blocks in buffer       */
+	uint num_bytes;                   /* number of bytes in buffer        */
+	boolean bot;                      /* beginning of partition           */
+	unchar partition_number;          /* current partition number on tape */
+	unchar reserved1[2];
+	blockid_t tapepos;                /* next block to be transferred     */
+	unchar reserved2[48];
+};
+
+/*******************************************************************************
+* STIOCQRYSENSE returns raw sense data from device.                            *
+*******************************************************************************/
+
+#define MAXSENSE        255
+#define STIOCQRYSENSE _IOWR('z',0x35,struct stsense_s)   /* get sense data */
+
+struct stsense_s {
+	/*INPUT*/
+	char sense_type;        /* fresh(new sense) or error(last error) data */
+
+#define FRESH     1             /* initiate a new sense command               */
+#define LASTERROR 2             /* return sense from last scsi sense command  */
+
+	/*OUTPUT*/
+	unchar sense[MAXSENSE];  /* actual sense data                         */
+	int len;                 /* length of valid sense data returned       */
+	int residual_count;      /* residual count from last operation        */
+	unchar reserved[60];
+};
+
+#define MAX_INQ_LEN 255            /* max data xfer for inquiry page ioctl */
+
+/*******************************************************************************
+* STIOCINQUIRY returns raw inquiry data from device.                           *
+*******************************************************************************/
+
+#define STIOCQRYINQUIRY _IOWR('z',0x36,struct st_inquiry)   /* get inquiry */
+struct inq_data_s {
+	BYTE b0;
+/*macros for accessing fields of byte 0 */
+#define PERIPHERAL_QUALIFIER(x)   ((x->b0 & 0xE0)>>5)
+#define PERIPHERAL_CONNECTED          0x00
+#define PERIPHERAL_NOT_CONNECTED      0x01
+#define LUN_NOT_SUPPORTED             0x03
+#define PERIPHERAL_DEVICE_TYPE(x) (x->b0 & 0x1F)
+#define DIRECT_ACCESS                 0x00
+#define SEQUENTIAL_DEVICE             0x01
+#define PRINTER_DEVICE                0x02
+#define PROCESSOR_DEVICE              0x03
+#define CD_ROM_DEVICE                 0x05
+#define OPTICAL_MEMORY_DEVICE         0x07
+#define MEDIUM_CHANGER_DEVICE         0x08
+#define UNKNOWN                       0x1F
+
+	BYTE b1;
+/*macros for accessing fields of byte 1 */
+#define RMB(x) ((x->b1 & 0x80)>>7)                /*removable media bit  */
+#define FIXED     0
+#define REMOVABLE 1
+#define device_type_qualifier(x) (x->b1 & 0x7F)   /* vendor specific     */
+
+	BYTE b2;
+/*macros for accessing fields of byte 2 */
+#define ISO_Version(x)  ((x->b2 & 0xC0)>>6)
+#define ECMA_Version(x) ((x->b2 & 0x38)>>3)
+#define ANSI_Version(x) (x->b2 & 0x07)
+#define NONSTANDARD     0
+#define SCSI1           1
+#define SCSI2           2
+#define SCSI3           3
+
+	BYTE b3;
+/*macros for accessing fields of byte 3 */
+#define AENC(x)    ((x->b3 & 0x80)>>7) /*asynchronous event notification */
+#ifndef TRUE
+#define TRUE 1
+#endif
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+#define TrmIOP(x)  ((x->b3 & 0x40)>>6) /* support terminate I/O process?      */
+#define Response_Data_Format(x)  (x->b3 & 0x0F)
+#define SCSI1INQ      0          /* scsi1 standard inquiry data format        */
+#define CCSINQ        1          /* CCS standard inquiry data format          */
+#define SCSI2INQ      2          /* scsi2 standard inquiry data format        */
+
+	BYTE additional_length;  /* bytes following this field minus 4        */
+	BYTE res5;
+	BYTE b6;
+#define MChngr(x)    ((x->b6 & 0x08)>>3)
+
+	BYTE b7;
+/* macros for accessing fields of byte 7  */
+/* the following fields are true or false */
+#define RelAdr(x)    ((x->b7 & 0x80)>>7)
+#define WBus32(x)    ((x->b7 & 0x40)>>6)
+#define WBus16(x)    ((x->b7 & 0x20)>>5)
+#define Sync(x)      ((x->b7 & 0x10)>>4)
+#define Linked(x)    ((x->b7 & 0x08)>>3)
+#define CmdQue(x)    ((x->b7 & 0x02)>>1)
+#define SftRe(x)     (x->b7 & 0x01)
+
+	char vendor_identification[8];
+	char product_identification[16];
+	char product_revision_level[4];
+};
+
+struct st_inquiry {
+	struct inq_data_s standard;
+	BYTE vendor_specific[MAX_INQ_LEN - sizeof(struct inq_data_s)];
+};
+
+/*******************************************************************************
+* Log sense page ioctl data structure                                          *
+*******************************************************************************/
+
+#define LOGSENSEPAGE 1024        /* max data xfer for log sense page ioctl    */
+
+struct log_sense_page {
+	unchar page_code;
+	unsigned short len;       /* log_page_header size + parameter length  */
+	unsigned short parm_pointer;
+	char data[LOGSENSEPAGE];
+};
+
+struct log_sense10_page {
+	unchar page_code;
+	unchar subpage_code;
+	unchar reserved[2];
+	unsigned short len;     /* [IN] specific allocation length for the data */
+							/* [OUT] number of valid bytes in data          *
+							 * (log_page_header size + parameter length)    */
+	unsigned short parm_pointer;
+	char data[LOGSENSEPAGE];
+};
+
+#define SIOC_LOG_SENSE10_PAGE _IOR('z', 0x51, struct log_sense10_page)
+
+/*******************************************************************************
+* Mode sense page ioctl data structure                                         *
+*******************************************************************************/
+
+#define MAX_MDSNS_LEN 255       /* max data xfer for mode sense page ioctl */
+struct mode_sense_page {
+	unchar page_code;
+	char data[MAX_MDSNS_LEN];
+};
+
+struct mode_sense {
+	unchar page_code;
+	unchar subpage_code;
+	unchar reserved[6];
+	unchar cmd_code;
+	char data[MAX_MDSNS_LEN];
+};
+
+/*******************************************************************************
+* Inquiry page ioctl data structure                                            *
+*******************************************************************************/
+
+struct inquiry_page {
+	unchar page_code;
+	char data[MAX_INQ_LEN];
+};
+
+/*******************************************************************************
+* Report Density Support ioctl data structures and defines                     *
+*******************************************************************************/
+
+#define ALL_MEDIA_DENSITY      0
+#define CURRENT_MEDIA_DENSITY  1
+
+#define MAX_DENSITY_REPORTS    8
+
+struct density_report {
+	unchar  primary_density_code;  /* primary density code                */
+	unchar  secondary_density_code;/* secondary densuty code              */
+	uint   wrtok : 1,              /* write ok, dvc can write this format */
+		dup : 1,               /* zero if density only reported once  */
+		deflt : 1,             /* current density is default format   */
+		: 5;                   /* reserved                            */
+	char   reserved[2];            /* reserved                            */
+	uint   bits_per_mm : 24;       /* bits per mm                         */
+	ushort media_width;            /* media width in millimeters          */
+	ushort tracks;                 /* tracks                              */
+	uint   capacity;               /* capacity in megabytes               */
+	char   assigning_org[8];       /* assigning organization in ASCII     */
+	char   density_name[8];        /* density name in ASCII               */
+	char   description[20];        /* description in ASCII                */
+};
+
+struct report_density_support {
+	unchar  media;           /* report all or current media as defd above */
+	ushort number_reports;   /* num of density reports returned in array  */
+	struct density_report reports[MAX_DENSITY_REPORTS];
+};
+
+
+/*******************************************************************************
+* 3494 Library Device Number ioctl definition                                  *
+*******************************************************************************/
+#ifndef MTDEVICE
+#define MTDEVICE               _IOR('m', 0x45, int)
+#endif
+
+/* Define iocinfo devtype field for medium changer devices */
+#define DD_MEDIUM_CHANGER       'j'
+
+/* Define extended parameters for openx, ioctlx and readx */
+#define SC_NO_RESERVE     0x08          /* Don't reserve on open            */
+#define SC_PASSTHRU       0x00010000    /* SC_DIAGNOSTIC w/o root authority */
+#define SC_FEL            0x00020000    /* Force Error Logging on           */
+#define SC_SERVICE        0x00040000    /* Service aid mode                 */
+#define SC_NO_ERRORLOG    0x00080000    /* Disable AIX error logging        */
+#define SC_TMCP           0x00100000    /* Tape Management Control Point    */
+#define ATAPE_DIAGNOSTIC  SC_PASSTHRU
+#define TAPE_READ_REVERSE 0x00010000    /* readx parm for SCSI Read Reverse */
+
+/* 7332 DDS2 ioctls */
+#define INIT_ELEMENT            0x07
+#define MOVE_MEDIUM_LOAD        0xb4
+#define MOVE_MEDIUM_UNLOAD      0xb5
+#define READ_ELEMENT_INFO       0xb7
+#ifndef READ_ELEMENT_STATUS
+#define READ_ELEMENT_STATUS     0xb8
+#endif
+
+/* For locate, DDS2_LOCATE is opcode and arg is (uint) block number */
+#define DDS2_LOCATE             0x2b
+
+/* For read position, DDS2_READ_POS is opcode and arg is address of (unit)  */
+/* to store current block position                                          */
+#define DDS2_READ_POS                0x34
+
+/* The load/unload medium ioctls default to the first empty or first full   */
+/* slot when the argument value is 0.  In order to explicitely use slot 0   */
+/* it is defined to be -1 passed as the argument.                           */
+#define LOAD_UNLOAD_SLOT_0  ((ushort)-1)
+#define SMCIOC_LOAD_MEDIUM      MOVE_MEDIUM_LOAD
+#define SMCIOC_UNLOAD_MEDIUM    MOVE_MEDIUM_UNLOAD
+#define STIOC_READ_POSITION     DDS2_READ_POS
+#define STIOC_LOCATE            DDS2_LOCATE
+
+#define SIOC_INQUIRY                  _IOR ('C',0x01,struct inquiry_data)
+#define SIOC_REQSENSE                 _IOR ('C',0x02,struct request_sense)
+#define SMCIOC_ELEMENT_INFO           _IOR ('C',0x03,struct element_info)
+#define SMCIOC_MOVE_MEDIUM            _IOW ('C',0x04,struct move_medium)
+#define SMCIOC_POS_TO_ELEM            _IOW ('C',0x05,struct pos_to_elem)
+#define SMCIOC_INIT_ELEM_STAT         _IO  ('C',0x06)
+#define SMCIOC_INVENTORY              _IOW ('C',0x07,struct inventory)
+#define SIOC_RESERVE                  _IO  ('C',0x08)
+#define SIOC_RELEASE                  _IO  ('C',0x09)
+#define SIOC_TEST_UNIT_READY          _IO  ('C',0x0A)
+// STIOC_LOG_SENSE no supported
+//#define STIOC_LOG_SENSE              _IOR ('C',0x0B,struct log_sense)
+#define SIOC_MODE_SENSE               _IOR ('C', 0x0D, struct mode_sense)
+#define SIOC_MODE_SENSE_PAGE          _IOR ('C',0x0E,struct mode_sense_page)
+#define SMCIOC_PREVENT_MEDIUM_REMOVAL _IO  ('C',0x0F)
+#define SMCIOC_ALLOW_MEDIUM_REMOVAL   _IO  ('C',0x10)
+#define STIOC_RESET_DRIVE             _IO  ('C',0x14)
+#define SMCIOC_EXCHANGE_MEDIUM        _IOW ('C',0x19,struct exchange_medium)
+#define SMCIOC_INIT_ELEM_STAT_RANGE   _IOW ('C',0x1C,struct element_range)
+#define SIOC_INQUIRY_PAGE             _IOWR('C',0x1E,struct inquiry_page)
+#define STIOC_REPORT_DENSITY_SUPPORT  \
+	_IOWR('C',0x1F,struct report_density_support)
+#define STIOC_PREVENT_MEDIUM_REMOVAL  _IO  ('C',0x20)
+#define STIOC_ALLOW_MEDIUM_REMOVAL   _IO  ('C',0x21)
+#define SMCIOC_READ_ELEMENT_DEVIDS    \
+	_IOR ('C',0x22,struct read_element_devids)
+#define SIOC_LOG_SENSE_PAGE           _IOR ('C',0x23,struct log_sense_page)
+#define SMCIOC_READ_CARTRIDGE_LOCATION \
+	_IOR('C',0x2A,struct read_cartridge_location)
+
+/* failover ioctls for paths */
+#define PRIMARY_SCSI_PATH    1
+#define ALTERNATE_SCSI_PATH  2
+#define MAX_SCSI_PATH       16
+
+/* If no more than 2 paths, use SIOC_QUERY_PATH ioctl for the primary and first
+*  alternate path info.  If more than 2 paths are configured, use the
+*  SIOC_DEVICE_PATHS ioctl for path info
+*/
+
+#define SIOC_QUERY_PATH               _IOR ('C', 0x24,struct scsi_path)
+#define SIOC_DEVICE_PATHS             _IOR ('C', 0x25,struct device_paths)
+#define SIOC_ENABLE_PATH              _IO ('C', 0x26)
+#define SIOC_DISABLE_PATH             _IO ('C', 0x27)
+
+/******************************************************************************/
+struct scsi_path {
+	char primary_name[30];          /* primary logical device name        */
+	char primary_parent[30];        /* primary SCSI parent name, hostname */
+	unchar primary_id;              /* primary target address             */
+	unchar primary_lun;             /* primary LUN                        */
+	unchar primary_bus;             /* primary SCSI bus, "Channel" value  */
+	unsigned long long primary_fcp_scsi_id;  /* primary FCP id            */
+	unsigned long long primary_fcp_lun_id;   /* primary FCP LUN           */
+	unsigned long long primary_fcp_ww_name;  /* primary FCP ww name       */
+	unchar primary_enabled;         /* primary path enabled               */
+	unchar primary_id_valid;        /* primary id/lun/bus fields valid    */
+	unchar primary_fcp_id_valid;    /* primary FCP scsi/lun/id fields     */
+	unchar alternate_configured;    /* alternate path configured          */
+	char alternate_name[30];        /* alternate logical device name      */
+	char alternate_parent[30];      /* alternate SCSI parent name         */
+	unchar alternate_id;            /* alternate target address           */
+	unchar alternate_lun;           /* alternate logical unit             */
+	unchar alternate_bus;           /* alternate SCSI bus                 */
+	unsigned long long alternate_fcp_scsi_id; /* alternate FCP SCSI id    */
+	unsigned long long alternate_fcp_lun_id;  /* alternate FCP LUN        */
+	unsigned long long alternate_fcp_ww_name; /* alternate FCP ww name    */
+	unchar alternate_enabled;       /* alternate path enabled             */
+	unchar alternate_id_valid;      /* alternate id/lun/bus fields valid  */
+	unchar alternate_fcp_id_valid;  /* alternate FCP scsi/lun/id fields   */
+	unchar primary_drive_port_valid;/* primary drive port field valid     */
+	unchar primary_drive_port;      /* primary drive port number          */
+	unchar alternate_drive_port_valid; /* alternate drive port valid      */
+	unchar alternate_drive_port;    /* alternate drive port               */
+	unchar primary_fenced;          /* primary fenced by disable path ioc */
+	unchar alternate_fenced;        /* altern. fenced by disable path ioc */
+	unchar primary_host;            /* primary host bus adapter id        */
+	unchar alternate_host;          /* alternate host bus adapter id      */
+	char reserved[56];
+};
+
+struct device_path_t {
+	char name[30];                  /* logical device name                */
+	char parent[30];                /* logical parent name                */
+	unchar id_valid;                /* SCSI id/lun/bus fields valid       */
+	unchar id;                      /* SCSI target address of device      */
+	unchar lun;                     /* SCSI logical unit of device        */
+	unchar bus;                     /* SCSI bus for device                */
+	unchar fcp_id_valid;            /* FCP scsi/lun/id fields valid       */
+	unsigned long long fcp_scsi_id; /* FCP SCSi id of device              */
+	unsigned long long fcp_lun_id;  /* FCP logical unit of device         */
+	unsigned long long fcp_ww_name; /* FCP world wide name                */
+	unchar enabled;                 /* path enabled                       */
+	unchar drive_port_valid;        /* drive port field valid             */
+	unchar drive_port;              /* drive port number                  */
+	unchar fenced;                  /* path fenced by diable path ioctl   */
+	unchar host;                    /* host bus adapter id                */
+	char reserved[62];
+};
+
+struct device_paths {
+	int number_paths;               /* number of paths configured         */
+	struct device_path_t path[MAX_SCSI_PATH];
+};
+
+
+/******************************************************************************/
+#define INQ_HEADER_LEN (4)
+#define VEND_ID_LEN (8)
+#define PROD_ID_LEN (16)
+#define REV_LEN (4)
+
+struct inquiry_data {
+	uint  qual : 3,                 /* peripheral qualifier               */
+		type : 5;               /* device type                        */
+	uint  rm : 1,                   /* removable medium                   */
+		mod : 7;                /* device type modifier               */
+	uint  iso : 2,                  /* ISO version                        */
+		ecma : 3,               /* EMCA version                       */
+		ansi : 3;               /* ANSI version                       */
+	uint  aenc : 1,                 /* asynchronous event notification    */
+		trmiop : 1,             /* terminate I/O process message      */
+		: 2,                    /* reserved                           */
+		rdf : 4;                /* response data format               */
+	unchar len;                     /* additional length                  */
+	unchar resvd1;                  /* reserved                           */
+	uint  : 4,                      /* reserved                           */
+		mchngr : 1,             /* medium changer mode (SCSI 3 only)  */
+		: 3;                    /* reserved                           */
+	uint  reladr : 1,               /* relative addressing                */
+		wbus32 : 1,             /* 32 bit wide data transfers         */
+		wbus16 : 1,             /* 16 bit wide data transfers         */
+		sync : 1,               /* synchronous data transfers         */
+		linked : 1,             /* linked commands                    */
+		: 1,                    /* reserved                           */
+		cmdque : 1,             /* command queueing                   */
+		sftre : 1;              /* soft reset                         */
+	unchar vid[VEND_ID_LEN];        /* vendor ID                          */
+	unchar pid[PROD_ID_LEN];        /* product ID                         */
+	unchar revision[REV_LEN];       /* product revision level             */
+	unchar vendor1[20];             /* vendor specific                    */
+	unchar resvd2[40];              /* reserved                           */
+	unchar vendor2[31];             /* vendor specific (padded to 127)    */
+};
+
+struct request_sense {
+	uint valid : 1,                 /* information field is valid         */
+		err_code : 7;           /* error code                         */
+	unchar segnum;                  /* segment number                     */
+	uint fm : 1,                    /* file mark detected                 */
+		eom : 1,                /* end of medium                      */
+		ili : 1,                /* incorrect length indicator         */
+		resvd1 : 1,             /* reserved                           */
+		key : 4;                /* sense key                          */
+	int info;                       /* information bytes                  */
+	unchar addlen;                  /* additional sense length            */
+	uint cmdinfo;                   /* command specific information       */
+	unchar asc;                     /* additional sense code              */
+	unchar ascq;                    /* additional sense code qualifier    */
+	unchar fru;                     /* field replaceable unit code        */
+	uint sksv : 1,                  /* sense key specific valid           */
+		cd : 1,                 /* control/data                       */
+		resvd2 : 2,             /* reserved                           */
+		bpv : 1,                /* bit pointer valid                  */
+		sim : 3;                /* system information message         */
+	unchar field[2];                /* field pointer                      */
+	unchar vendor[109];             /* vendor specific (padded to 127)    */
+};
+
+struct element_info {
+	ushort robot_addr;              /* first robot address                */
+	ushort robots;                  /* number medium transport elements   */
+	ushort slot_addr;               /* first medium storage element addr  */
+	ushort slots;                   /* number medium storage elements     */
+	ushort ie_addr;                 /* first import/export element addr   */
+	ushort ie_stations;             /* number import-export elements      */
+	ushort drive_addr;              /* first data transfer element addr   */
+	ushort drives;                  /* number data transfer elements      */
+};
+
+struct move_medium {
+	ushort robot;                   /* robot address                      */
+	ushort source;                  /* move from location                 */
+	ushort destination;             /* move to location                   */
+	char invert;                    /* invert before placement bit        */
+};
+
+struct pos_to_elem {
+	ushort robot;                   /* robot address                      */
+	ushort destination;             /* move to location                   */
+	char invert;                    /* invert before placement bit        */
+};
+
+struct exchange_medium {
+	ushort robot;                   /* robot address                      */
+	ushort source;                  /* move from location                 */
+	ushort destination1;            /* move to location                   */
+	ushort destination2;            /* move to location                   */
+	char invert1;                   /* invert before placement into dest1 */
+	char invert2;                   /* invert before placement into dest2 */
+};
+
+struct element_status {
+	ushort address;                 /* element address                    */
+	uint   : 2,                     /* reserved                           */
+		inenab : 1,             /* media into changer's scope         */
+		exenab : 1,             /* media out of changer's scope       */
+		access : 1,             /* robot access allowed               */
+		except : 1,             /* abnormal element state             */
+		impexp : 1,             /* import/export bit                  */
+		full : 1;               /* element contains medium            */
+	unchar resvd1;                  /* reserved                           */
+	unchar asc;                     /* additional sense code              */
+	unchar ascq;                    /* additional sense code qualifier    */
+	uint   notbus : 1,              /* element not on same bus as robot   */
+		: 1,                    /* reserved                           */
+		idvalid : 1,            /* element address valid              */
+		luvalid : 1,            /* logical unit valid                 */
+		: 1,                    /* reserved                           */
+		lun : 3;                /* logical unit number                */
+	unchar scsi;                    /* scsi bus address                   */
+	unchar resvd2;                  /* reserved                           */
+	uint   svalid : 1,              /* element address valid              */
+		invert : 1,             /* medium inverted                    */
+		: 6;                    /* reserved                           */
+	ushort source;                  /* source storage element address     */
+	unchar volume[36];              /* primary volume tag                 */
+	unchar resvd3[4];               /* reserved                           */
+};
+
+struct inventory {
+	struct element_status *robot_status;  /* MTE pages                    */
+	struct element_status *slot_status;   /* SE pages                     */
+	struct element_status *ie_status;     /* IE pages                     */
+	struct element_status *drive_status;  /* DTE pages                    */
+};
+
+struct element_range {
+	ushort element_address;         /* starting element address           */
+	ushort number_elements;         /* number of elements                 */
+};
+
+struct element_devid {
+	ushort address;                 /* element address                    */
+	uint   : 4,                     /* reserved                           */
+		access : 1,             /* robot access allowed               */
+		except : 1,             /* abnormal element state             */
+		: 1,                    /* reserved                           */
+		full : 1;               /* element contains medium            */
+	unchar resvd1;                  /* reserved                           */
+	unchar asc;                     /* additional sense code              */
+	unchar ascq;                    /* additional sense code qualifier    */
+	uint   notbus : 1,              /* element not on same bus as robot   */
+		: 1,                    /* reserved                           */
+		idvalid : 1,            /* element address valid              */
+		luvalid : 1,            /* logical unit valid                 */
+		: 1,                    /* reserved                           */
+		lun : 3;                /* logical unit number                */
+	unchar scsi;                    /* scsi bus address                   */
+	unchar resvd2;                  /* reserved                           */
+	uint   svalid : 1,              /* element address valid              */
+		invert : 1,             /* medium inverted                    */
+		: 6;                    /* reserved                           */
+	ushort source;                  /* source storage element address     */
+	uint   : 4,                     /* reserved                           */
+		code_set : 4;           /* code set X'2' is all ASCII id      */
+	uint   : 4,                     /* reserved                           */
+		ident_type : 4;         /* identifier type                    */
+	unchar resvd3;                  /* reserved                           */
+	unchar ident_len;               /* identifier length                  */
+	unchar identifier[36];          /* device identification              */
+};
+
+struct read_element_devids {
+	ushort element_address;         /* starting element address           */
+	ushort number_elements;         /* number of elements                 */
+	struct element_devid *drive_devid; /* data transfer element pages     */
+};
+
+struct cartridge_location_data {
+	ushort address;
+	unchar : 4,
+		access : 1,
+		except : 1,
+		: 1,
+		full   : 1;
+	unchar resvd1;
+	unchar asc;
+	unchar ascq;
+	unchar resvd2[3];
+	unchar svalid : 1,
+		invert : 1,
+		: 6;
+	ushort source;
+	unchar volume[36];
+	unchar : 4,
+		code_set   : 4;
+	unchar : 4,
+		ident_type : 4;
+	unchar resvd3;
+	unchar ident_len;
+	unchar identifier[24];
+};
+
+struct read_cartridge_location {
+	ushort element_address;               /* starting element address     */
+	ushort number_elements;               /* number of elements           */
+	struct cartridge_location_data* data; /* storage element pages        */
+	char reserved[8];                     /* reserved                     */
+};
+
+/*******************************************************************************
+* STIOCREADRESERVKEYS is used to show info on existing reservation Keys.
+* STIOCREADRESERVAIONS is used to show info on existing reservations.
+* STIOCCLEARREGISTRATION is used to clear registration and reservation.
+*******************************************************************************/
+
+#define STIOC_READ_RESERVEKEYS \
+	_IOR('z',0x38,struct read_keys)        /* query reservation keys      */
+#define STIOC_READ_RESERVATIONS \
+	_IOR('z',0x39,struct read_reserves)    /* query reservations          */
+#define STIOC_REGISTER_KEY \
+	_IO('z',0x40)                          /* register a reservation key  */
+#define STIOC_REMOVE_REGISTRATION \
+	_IO('z',0x41)                          /* remove current host's reg   */
+#define STIOC_CLEAR_ALL_REGISTRATIONS \
+	_IO('z',0x42)                          /* clear all registration keys */
+
+#define RESERVE_KEY_LENGTH          8          /* each key is 8-byte-long     */
+
+struct read_keys {
+    uint  generation;                          /* counter for PR-out requests */
+    uint  length;                              /* bytes in the Res. Key list  */
+    char* reserve_key_list;                    /* list of reservation keys    */
+};
+
+struct reserve_descriptor {
+	char key[RESERVE_KEY_LENGTH];          /* reservation key             */
+	uint scope_spec_addr;                  /* scope-specific address      */
+	BYTE reserved;
+	BYTE scope : 4,                        /* persistent res. scope       */
+		type : 4;                      /* reservation type            */
+	ushort ext_length;                     /* extent length               */
+};
+
+struct read_reserves {
+	uint            generation;            /* counter for PR-out requests */
+	uint            length;                /* bytes in the Res. list      */
+	struct reserve_descriptor* reserve_list;  /* list of res. key descs   */
+};
+
+
+/******************************************************************************/
+
+struct density_data_t {
+	char density_code;                  /* mode sense header density code */
+	char default_density;               /* default write density          */
+	char pending_density;               /* pending write density          */
+	char reserved[9];
+};
+
+#define STIOC_GET_DENSITY              _IOR('C',0x28,struct density_data_t)
+#define STIOC_SET_DENSITY              _IOWR('C',0x29,struct density_data_t)
+
+/*******************************************************************************
+* GET_ENCRYPITON_STATE is used to query the current drive's encryption status.
+* SET_ENCRYPTION_STATE is used to set application-managed encrption state.
+* SET_DATA_KEY is used for application to set the encryption key.
+*******************************************************************************/
+
+struct encryption_status {
+	unchar encryption_capable;
+	unchar encryption_method;
+#define METHOD_NONE 0
+#define METHOD_LIBRARY 1
+#define METHOD_SYSTEM 2
+#define METHOD_APPLICATION 3
+#define METHOD_CUSTOM 4
+#define METHOD_UNKNOWN 5
+	unchar encryption_state;
+#define STATE_OFF 0
+#define STATE_ON 1
+#define STATE_NA 2
+#define STATE_UNKNOWN 3
+	unchar reserved[13];
+};
+
+#define GET_ENCRYPTION_STATE           _IOR('C',0x30,struct encryption_status)
+#define SET_ENCRYPTION_STATE           _IOWR('C',0x31,struct encryption_status)
+
+struct data_key {
+	unchar data_key_index[12];
+	unchar data_key_index_length;
+	unchar reserved1[15];
+	unchar data_key[32];
+	unchar rserved2[48];
+};
+
+#define SET_DATA_KEY	                 _IOWR('C',0x32,struct data_key)
+
+/******************************************************************************/
+/* Data Encryption diagnostic ioctl data structure and defines                */
+/******************************************************************************/
+#define SERVER_PING_DIAG         1
+#define BASIC_ENCRYPTION_DIAG    2
+#define FULL_ENCRYPTION_DIAG     3
+
+struct encryption_diagnostics {
+	int diag_type;           /* diagtype defined above to be invoked      */
+	int diag_errno;          /* errno return code for failures or 0       */
+	int diag_cc;             /* diag completion code for diag type        */
+	unchar reserved[8];
+};
+
+#define DATA_ENCRYPTION_DIAGNOSTICS \
+	_IOWR('C',0x33,struct encryption_diagnostics)
+
+/******************************************************************************/
+/* Partition IOCTLs                                                           */
+/******************************************************************************/
+
+#define IDP_PARTITION    (1)
+#define SDP_PARTITION    (2)
+#define FDP_PARTITION    (3)
+
+#define UNKNOWN_PAR_TYPE (0)
+#define WRAP_WISE_PART   (1)
+#define LONGITUDE_PART   (2)
+
+#define SIZE_UNIT_BYTES  (0)
+#define SIZE_UNIT_KBYTES (3)
+#define SIZE_UNIT_MBYTES (6)
+#define SIZE_UNIT_GBYTES (9)
+#define SIZE_UNIT_TBYTES (12)
+
+#define MAX_PARTITIONS   (255)
+#define MAX_SUPPORTED_PARTITIONS (4)
+
+struct query_partition {
+	unchar max_partitions;
+	unchar active_partition;
+	unchar number_of_partitions;
+	unchar size_unit;
+	ushort size[MAX_PARTITIONS];
+	unchar partition_method; /* for 3592-E07 and later */
+	char reserved[31];
+};
+
+#define DEVICE_CONFIG_MODE_PAGE    (0x10)
+#define MEDIUM_PARTITION_MODE_PAGE (0x11)
+
+#define STIOC_QUERY_PARTITION _IOR('z', 0x43, struct query_partition)
+
+struct tape_partition {
+	unchar type;
+	unchar number_of_partitions;
+	unchar size_unit;
+	ushort size[MAX_PARTITIONS];
+	unchar partition_method; /* for 3592-E07 and later */
+	char reserved[31];
+};
+
+#define STIOC_CREATE_PARTITION _IOW('z', 0x44, struct tape_partition)
+
+struct set_active_partition {
+	unchar partition_number;
+	unsigned long long logical_block_id;
+	char reserved[32];
+};
+
+#define STIOC_SET_ACTIVE_PARTITION _IOW('z', 0x45, struct set_active_partition)
+
+struct allow_data_overwrite {
+	unchar partition_number;
+	unsigned long long logical_block_id;
+	unchar allow_format_overwrite;
+	char reserved[32];
+};
+
+#define STIOC_ALLOW_DATA_OVERWRITE _IOW('z', 0x46, struct allow_data_overwrite)
+
+/******************************************************************************/
+/* Enhanced Position IOCTLs                                                   */
+/******************************************************************************/
+
+/* Extended READ_POSITION */
+
+#define RP_SHORT_FORM (0x00)
+#define RP_LONG_FORM (0x06)
+#define RP_EXTENDED_FORM (0x08)
+
+struct short_data_format {
+#if BYTE_ORDER == LITTLE_ENDIAN
+	unchar bpew : 1;
+	unchar perr : 1;
+	unchar lolu : 1;
+	unchar rsvd : 1;
+	unchar bycu : 1;
+	unchar locu : 1;
+	unchar eop : 1;
+	unchar bop : 1;
+#elif BYTE_ORDER == BIG_ENDIAN
+	unchar bop : 1;
+	unchar eop : 1;
+	unchar locu : 1;
+	unchar bycu : 1;
+	unchar rsvd : 1;
+	unchar lolu : 1;
+	unchar perr : 1;
+	unchar bpew : 1;
+#else
+		error
+#endif
+	unchar active_partition;
+	char reserved[2];
+	unchar first_logical_obj_position[4];
+	unchar last_logical_obj_position[4];
+	unchar num_buffer_logical_obj[4];
+	unchar num_buffer_bytes[4];
+	char reserved1;
+};
+
+struct long_data_format {
+#if BYTE_ORDER == LITTLE_ENDIAN
+	unchar bpew : 1;
+	unchar rsvd2 : 1;
+	unchar lonu : 1;
+	unchar mpu : 1;
+	unchar rsvd1 : 2;
+	unchar eop : 1;
+	unchar bop : 1;
+#elif BYTE_ORDER == BIG_ENDIAN
+	unchar bop : 1;
+	unchar eop : 1;
+	unchar rsvd1 : 2;
+	unchar mpu : 1;
+	unchar lonu : 1;
+	unchar rsvd2 : 1;
+	unchar bpew : 1;
+#else
+		error
+#endif
+	char reserved[6];
+	unchar active_partition;
+	unchar logical_obj_number[8];
+	unchar logical_file_id[8];
+	unchar obsolete[8];
+};
+
+struct extended_data_format {
+#if BYTE_ORDER == LITTLE_ENDIAN
+	unchar bpew : 1;
+	unchar perr : 1;
+	unchar lolu : 1;
+	unchar rsvd : 1;
+	unchar bycu : 1;
+	unchar locu : 1;
+	unchar eop : 1;
+	unchar bop : 1;
+#elif BYTE_ORDER == BIG_ENDIAN
+	unchar bop : 1;
+	unchar eop : 1;
+	unchar locu : 1;
+	unchar bycu : 1;
+	unchar rsvd : 1;
+	unchar lolu : 1;
+	unchar perr : 1;
+	unchar bpew : 1;
+#else
+		error
+#endif
+	unchar active_partition;
+	unchar additional_length[2];
+	unchar num_buffer_logical_obj[4];
+	unchar first_logical_obj_position[8];
+	unchar last_logical_obj_position[8];
+	unchar num_buffer_bytes[8];
+	unchar reserved;
+};
+
+struct read_tape_position {
+	unchar data_format;
+	union {
+		struct short_data_format rp_short;
+		struct long_data_format rp_long;
+		struct extended_data_format rp_extended;
+	} rp_data;
+};
+
+#define STIOC_READ_POSITION_EX _IOWR('z', 0x47, struct read_tape_position)
+
+/* LOCATE 16 */
+
+#define LOGICAL_ID_BLOCK_TYPE (0x00)
+#define LOGICAL_ID_FILE_TYPE (0x01)
+
+struct set_tape_position {
+	unchar logical_id_type;
+	unsigned long long logical_id;
+	char reserved[32];
+};
+
+#define STIOC_LOCATE_16 _IOW('z', 0x48, struct set_tape_position)
+
+/******************************************************************************/
+/* Logical Block Protection IOCTLs                                            */
+/******************************************************************************/
+
+#define LBP_DISABLE             (0x00)
+#define REED_SOLOMON_CRC        (0x01)
+
+struct logical_block_protection {
+	unchar lbp_capable;
+	unchar lbp_method;
+	unchar lbp_info_length;
+	unchar lbp_w;
+	unchar lbp_r;
+	unchar rbdp;
+	unchar reserved[26];
+};
+
+#define EXTENDED_INQUIRY_PAGE   (0x86)
+
+#define STIOC_QUERY_BLK_PROTECTION  _IOR('z', 0x49, \
+	struct logical_block_protection)
+#define STIOC_SET_BLK_PROTECTION _IOW('z', 0x50, \
+	struct logical_block_protection)
+
+/******************************************************************************/
+/* EOT warning IOCTLs                                                         */
+/******************************************************************************/
+
+struct eot_warn {
+	unchar warn;
+	unchar reserved[7];
+};
+
+#define STIOC_QUERY_EOT_WARN _IOR('z', 0x52, struct eot_warn)
+#define STIOC_SET_EOT_WARN _IOW('z', 0x53, struct eot_warn)
+
+/******************************************************************************/
+/* VERIFY_TAPE_DATA IOCTL                                                     */
+/******************************************************************************/
+
+struct verify_data {
+
+#if BYTE_ORDER == LITTLE_ENDIAN
+	unchar fixed     : 1;
+	unchar bytcmp    : 1;
+	unchar immed     : 1;
+	unchar vbf       : 1;
+	unchar vlbpm     : 1;
+	unchar vte       : 1;
+	unchar reserved1 : 2;
+#elif BYTE_ORDER == BIG_ENDIAN
+	unchar reserved1 : 2;
+	unchar vte       : 1;
+	unchar vlbpm     : 1;
+	unchar vbf       : 1;
+	unchar immed     : 1;
+	unchar bytcmp    : 1;
+	unchar fixed     : 1;
+#else
+	error
+#endif
+	unchar verify_length[3];
+	unchar reserved2[15];
+};
+
+#define STIOC_VERIFY_TAPE_DATA _IOW('z', 0x54, struct verify_data)
+
+/******************************************************************************/
+/* New passthrough ioctl data structure and defines                           */
+/******************************************************************************/
+
+struct sioc_pass_through {
+	unsigned char cmd_length;     /* Input: Length of SCSI command        */
+	unsigned char* cdb;           /* Input: SCSI command descriptor block */
+	uint buffer_length;           /* Input: Length of data buffer         */
+                                      /* Output: bytes actually transferred   */
+	unsigned char *buffer;        /* Input/Output: data transfer or NULL  */
+	unsigned int data_direction;  /* Input: Data transfer direction       */
+	uint timeout;                 /* Input: Timeout in seconds            */
+	unsigned char sense_length;   /* Input/Output: sense data bytes       */
+	unsigned char* sense;         /* Output: Sense when sense length > 0  */
+	int resid;                    /* Output: resid bytes after transfer   */
+	int32_t result;               /* Output: result from lower driver     */
+	unsigned char msg_status;     /* Output: from SCSI transport layer    */
+	unsigned char target_status;  /* Output: target device status         */
+	unsigned short driver_status; /* Output: level driver status          */
+	unsigned short host_status;   /* Output: host bus adapter status      */
+
+	unsigned char reserved[64];
+};
+
+#define SIOC_PASS_THROUGH     _IOWR('C', 0x34, struct sioc_pass_through)
+
+#define MaxScsiPath		16
+
+#endif

--- a/src/tape_drivers/freebsd/cam/Makefile.am
+++ b/src/tape_drivers/freebsd/cam/Makefile.am
@@ -1,0 +1,59 @@
+#
+#
+#  OO_Copyright_BEGIN
+#
+#
+#  Copyright 2010, 2018 IBM Corp. All rights reserved.
+#  Copyright (c) 2013-2018 Spectra Logic Corporation. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#   modification, are permitted provided that the following conditions
+#  are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#  documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the names of its
+#     contributors may be used to endorse or promote products derived from
+#     this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#
+#  OO_Copyright_END
+#
+
+
+lib_LTLIBRARIES = libtape-camtape-freebsd.la
+libdir = @libdir@/ltfs
+
+AM_LIBTOOLFLAGS = --tag=disable-static
+
+libtape_camtape_freebsd_la_SOURCES = camtape_cmn.c camtape_tc.c
+libtape_camtape_freebsd_la_DEPENDENCIES = ../../../../messages/tape_freebsd_camtape_dat.o libtape_camtape_freebsd_la-reed_solomon_crc.lo libtape_camtape_freebsd_la-crc32c_crc.lo libtape_camtape_freebsd_la-ibm_tape.lo
+libtape_camtape_freebsd_la_LIBADD = ../../../../messages/tape_freebsd_camtape_dat.o ./libtape_camtape_freebsd_la-reed_solomon_crc.lo ./libtape_camtape_freebsd_la-crc32c_crc.lo ./libtape_camtape_freebsd_la-ibm_tape.lo
+libtape_camtape_freebsd_la_LDFLAGS = -avoid-version -module
+libtape_camtape_freebsd_la_CPPFLAGS = @AM_CPPFLAGS@ -I ../../.. -I ../..
+libtape_camtape_freebsd_la-reed_solomon_crc.lo: ../../reed_solomon_crc.c
+	$(LIBTOOL)  --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libtape_camtape_freebsd_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) $(CRC_OPTIMIZE) -MT libtape_camtape_freebsd_la-reed_solomon_crc.lo -MD -MP -c -o libtape_camtape_freebsd_la-reed_solomon_crc.lo ../../reed_solomon_crc.c
+
+libtape_camtape_freebsd_la-crc32c_crc.lo: ../../crc32c_crc.c
+	$(LIBTOOL)  --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libtape_camtape_freebsd_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) $(CRC_OPTIMIZE) -MT libtape_camtape_freebsd_la-crc32c_crc.lo -MD -MP -c -o libtape_camtape_freebsd_la-crc32c_crc.lo ../../crc32c_crc.c
+
+libtape_camtape_freebsd_la-ibm_tape.lo: ../../ibm_tape.c
+	$(LIBTOOL)  --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libtape_camtape_freebsd_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) $(CRC_OPTIMIZE) -MT libtape_camtape_freebsd_la-ibm_tape.lo -MD -MP -c -o libtape_camtape_freebsd_la-ibm_tape.lo ../../ibm_tape.c
+
+
+install-exec-hook:
+	for f in $(lib_LTLIBRARIES); do rm -f $(libdir)/$$f; done

--- a/src/tape_drivers/freebsd/cam/camtape_cmn.c
+++ b/src/tape_drivers/freebsd/cam/camtape_cmn.c
@@ -1,0 +1,887 @@
+/*
+**
+**  OO_Copyright_BEGIN
+**
+**
+**  Copyright 2010, 2018 IBM Corp. All rights reserved.
+**  Copyright (c) 2013-2018 Spectra Logic Corporation. All rights reserved.
+**
+**  Redistribution and use in source and binary forms, with or without
+**   modification, are permitted provided that the following conditions
+**  are met:
+**  1. Redistributions of source code must retain the above copyright
+**     notice, this list of conditions and the following disclaimer.
+**  2. Redistributions in binary form must reproduce the above copyright
+**     notice, this list of conditions and the following disclaimer in the
+**  documentation and/or other materials provided with the distribution.
+**  3. Neither the name of the copyright holder nor the names of its
+**     contributors may be used to endorse or promote products derived from
+**     this software without specific prior written permission.
+**
+**  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+**  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+**  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+**  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+**  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+**  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+**  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+**  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+**  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+**  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+**  POSSIBILITY OF SUCH DAMAGE.
+**
+**
+**  OO_Copyright_END
+**
+*************************************************************************************
+**
+** COMPONENT NAME:  IBM Linear Tape File System
+**
+** FILE NAME:       tape_drivers/freebsd/cam/camtape_cmn.c
+**
+** DESCRIPTION:     Implements FreeBSD CAM backend for LTFS.
+**
+** AUTHORS:         Atsushi Abe
+**                  IBM Yamato, Japan
+**                  PISTE@jp.ibm.com
+**
+**                  Ken Merry
+**                  Spectra Logic Corporation
+**                  ken@FreeBSD.ORG, kenm@spectralogic.com
+**
+*************************************************************************************
+*/
+
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <time.h>
+#include <cam/scsi/scsi_message.h>
+#include "ltfs_copyright.h"
+#include "ibm_tape.h"
+#include "libltfs/ltfslogging.h"
+#include "camtape_cmn.h"
+
+volatile char *copyright = LTFS_COPYRIGHT_0"\n"LTFS_COPYRIGHT_1"\n"LTFS_COPYRIGHT_2"\n";
+
+extern struct error_table *standard_table;
+extern struct error_table *vendor_table;
+
+/* Global Functions */
+
+int camtape_sense2rc(void *device, struct scsi_sense_data *sense, int sense_len)
+{
+	uint32_t sense_concat;
+	int error_code, sense_key, asc, ascq;
+	int rc;
+
+	scsi_extract_sense_len(sense, sense_len, &error_code, &sense_key, &asc, &ascq,
+		/*show_errors*/ 1);
+	sense_concat = ((sense_key & 0xff) << 16) |
+					((asc & 0xff) << 8) |
+					(ascq & 0xff);
+	/*
+	 * If the asc and/or ascq are 0xff (i.e. -1), it will return an error that the
+	 * sense code is vendor unique.  Those are the first fields (before the sense key)
+	 * that will get trimmed off and therefore cause an error
+	 */
+	rc = _sense2errcode(sense_concat, standard_table, NULL, MASK_WITH_SENSE_KEY);
+
+	if (rc == -EDEV_VENDOR_UNIQUE) {
+		rc = _sense2errcode(sense_concat, vendor_table, NULL, MASK_WITH_SENSE_KEY);
+	}
+
+	return rc;
+}
+
+/**
+ * Given a completed CCB, return an LTFS error code.
+ * @param ccb CAM CCB
+ * @return 0 on success or negative value on error
+ */
+int camtape_ccb2rc(struct camtape_data *softc, union ccb *ccb)
+{
+	int rc;
+
+	switch (ccb->ccb_h.status & CAM_STATUS_MASK) {
+	case CAM_REQ_CMP:
+		rc = DEVICE_GOOD;
+		break;
+	case CAM_SCSI_STATUS_ERROR: {
+		switch (ccb->csio.scsi_status) {
+		case SCSI_STATUS_OK:
+			/* This shouldn't happen, but just in case... */
+			rc = DEVICE_GOOD;
+			break;
+		case SCSI_STATUS_CHECK_COND:
+			if (ccb->ccb_h.status & CAM_AUTOSNS_VALID)
+				rc = camtape_sense2rc(softc, &ccb->csio.sense_data, ccb->csio.sense_len -
+					ccb->csio.sense_resid);
+			else
+				rc = -EDEV_TARGET_ERROR;
+			break;
+		case SCSI_STATUS_BUSY:
+		case SCSI_STATUS_QUEUE_FULL:
+			rc = -EDEV_DEVICE_BUSY;
+			break;
+		case SCSI_STATUS_RESERV_CONFLICT:
+		default:
+			rc = -EDEV_TARGET_ERROR;
+			break;
+		}
+		break;
+	}
+	case CAM_REQ_INVALID:
+		rc = -EDEV_INVALID_ARG;
+		break;
+	case CAM_SEL_TIMEOUT:
+	case CAM_DEV_NOT_THERE:
+		rc = -EDEV_DEVICE_UNOPENABLE;
+		break;
+	case CAM_REQ_ABORTED:
+		rc = -EDEV_ABORTED_COMMAND;
+		break;
+	case CAM_CMD_TIMEOUT:
+		rc = -EDEV_TIMEOUT;
+		break;
+	default:
+		rc = -EDEV_HOST_ERROR;
+		break;
+	}
+
+	return rc;
+}
+
+int camtape_ioctlrc2err(void *device, int fd, struct scsi_sense_data *sense_data, 
+	int control_cmd, char **msg)
+{
+	union mterrstat errstat;
+	int rc, rc_sense;
+
+	memset(&errstat, 0, sizeof(errstat));
+
+	rc_sense = ioctl(fd, MTIOCERRSTAT, &errstat);
+
+	if (rc_sense == 0) {
+		size_t sense_data_len;
+
+		if (control_cmd == 0) {
+			sense_data_len = sizeof(errstat.scsi_errstat.io_sense);
+			memcpy(sense_data, &errstat.scsi_errstat.io_sense,
+				MIN(sizeof(*sense_data), sense_data_len));
+		} else {
+			sense_data_len = sizeof(errstat.scsi_errstat.ctl_sense);
+			memcpy(sense_data, &errstat.scsi_errstat.ctl_sense,
+				MIN(sizeof(*sense_data), sense_data_len));
+		}
+
+		/*
+		 * The latched sense data in the sa(4) driver is cleared after it is read,
+		 * if the non-control device (e.g. /dev/sa0, not /dev/sa0.ctl) was opened.
+		 */
+		if (sense_data->error_code == 0) {
+			ltfsmsg(LTFS_DEBUG, 30409D);
+
+			if (msg) {
+				*msg = strdup("No Sense Information");
+			}
+			rc = -EDEV_NO_SENSE;
+		} else {
+			int error_code, sense_key, asc, ascq;
+
+			scsi_extract_sense_len(sense_data, sense_data_len, &error_code, &sense_key, &asc,
+				&ascq, /*show_errors*/ 1);
+			ltfsmsg(LTFS_DEBUG, 30406D, sense_key, asc, ascq);
+			/*
+			 * XXX KDM we should figure out a better way to extract these vendor specific bits.
+			 * Do the IBM drives not support descriptor sense?
+			 * The vendor specific data that this debug statement pulls out is beyond the 32
+			 * bytes of sense data that the sa(4) driver provides through the MTIOCERRSTAT ioctl.
+			 * This means that we will have to bump the size of the sense data used in the
+			 * ioctl.  That also means we have an opportunity to provide more information in
+			 * the ioctl, like the valid length of the sense data.
+			 */
+
+#if 0
+			ltfsmsg(LTFS_DEBUG, 30407D, sense_data->vendor[27], sense_data->vendor[28], sense_data->vendor[29], sense_data->vendor[30],
+										((struct camtape_data *) device)->drive_serial);
+#endif
+			rc = camtape_sense2rc(device, sense_data, sense_data_len);
+		}
+	} else {
+		ltfsmsg(LTFS_INFO, 30412I, rc_sense);
+		if (msg)
+			*msg = strdup("Cannot get sense information");
+
+		rc = -EDEV_CANNOT_GET_SENSE;
+	}
+
+	return rc;
+}
+
+/**
+ * Get inquiry data from a specific page
+ * @param device tape device
+ * @param page page
+ * @param inq pointer to inquiry data. This function will update this value
+ * @return 0 on success or negative value on error
+ */
+int _camtape_inquiry_page(void *device, unsigned char page, struct tc_inq_page *inq, bool error_handle)
+{
+	char *msg = NULL;
+	int rc = DEVICE_GOOD;
+	union ccb *ccb = NULL;
+	struct camtape_data *softc = device;
+	uint8_t *data_ptr = NULL;
+	int timeout;
+
+	if (!inq)
+		return -EDEV_INVALID_ARG;
+
+	ccb = cam_getccb(softc->cd);
+	if (ccb == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+
+	bzero(&(&ccb->ccb_h)[1],
+		sizeof(struct ccb_scsiio) - sizeof(struct ccb_hdr));
+
+	data_ptr = malloc(sizeof(*inq));
+	if (data_ptr == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+	bzero(data_ptr, sizeof(*inq));
+
+	timeout = camtape_get_timeout(softc->timeouts, INQUIRY);
+	if (timeout < 0) {
+		rc = -EDEV_UNSUPPORETD_COMMAND;
+		goto bailout;
+	}
+
+	ltfsmsg(LTFS_DEBUG, 30593D, "inquiry", page, ((struct camtape_data *) device)->drive_serial);
+
+	scsi_inquiry(&ccb->csio,
+				 /*retries*/ 1,
+				 /*cbfcnp*/ NULL,
+				 /*tag_action*/ MSG_SIMPLE_Q_TAG,
+				 /*inq_buf*/ data_ptr,
+				 /*inq_len*/ sizeof(*inq),
+				 /*evpd*/ 1,
+				 /*page_code*/ page,
+				 /*sense_len*/ SSD_FULL_SIZE,
+				 /*timeout*/ timeout);
+
+	ccb->ccb_h.flags |= CAM_DEV_QFRZDIS | CAM_PASS_ERR_RECOVER;
+
+	rc = camtape_send_ccb(softc, ccb, &msg);
+
+	if (rc != DEVICE_GOOD) {
+		if(error_handle)
+			camtape_process_errors(device, rc, msg, "inquiry", true);
+	} else {
+		memcpy(inq->data, data_ptr, sizeof(inq->data));
+	}
+
+bailout:
+	if (ccb != NULL)
+		cam_freeccb(ccb);
+
+	if (data_ptr != NULL)
+		free(data_ptr);
+
+	return rc;
+}
+
+int camtape_inquiry_page(void *device, unsigned char page, struct tc_inq_page *inq)
+{
+	struct camtape_data *softc = device;
+	int ret = 0;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_INQUIRYPAGE));
+	ret = _camtape_inquiry_page(device, page, inq, true);
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_INQUIRYPAGE));
+	return ret;
+}
+
+/**
+ * Get inquiry data
+ * @param inq pointer to inquiry data. This function will update this value
+ * @return 0 on success or negative value on error
+ */
+int camtape_inquiry(void *device, struct tc_inq *inq)
+{
+	int rc = DEVICE_GOOD;
+	struct scsi_inquiry_data *inq_data;
+	struct camtape_data *td = (struct camtape_data *)device;
+	int vendor_length;
+
+	ltfs_profiler_add_entry(td->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_INQUIRY));
+	if (td->cd == NULL) {
+		rc = -EDEV_INVALID_ARG;
+		goto bailout;
+	}
+
+	inq_data = &td->cd->inq_data;
+	inq->devicetype = SID_TYPE(inq_data);
+	inq->cmdque = (inq_data->flags & SID_CmdQue) ? 1 : 0;
+	strncpy((char *)inq->vid, (char *)inq_data->vendor, 8);
+	inq->vid[8] = '\0';
+	strncpy((char *)inq->pid, (char *)inq_data->product, 16);
+	inq->pid[16] = '\0';
+	strncpy((char *)inq->revision, (char *)inq_data->revision, 4);
+	inq->revision[4] = '\0';
+
+	vendor_length = 20;
+	if (IS_ENTERPRISE(td->drive_type))
+		vendor_length = 18;
+
+	strncpy((char *)inq->vendor, (char *)inq_data->vendor_specific0,
+		vendor_length);
+	inq->vendor[vendor_length] = '\0';
+
+bailout:
+	ltfs_profiler_add_entry(td->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_INQUIRY));
+	return rc;
+}
+
+/**
+ * Request Sense
+ * @param device a pointer to the camtape backend
+ * @param sense pointer to sense data.  This function will update this value if successful.
+ * @param alloc_sense_len length of sense data allocated
+ * @param valid_sense_len length of sense data returned, this may be longer than alloc_sense_len
+ * @return 0 for success, negative number for failure
+ */
+int camtape_request_sense(void *device, struct scsi_sense_data *sense, int alloc_sense_len,
+    int *valid_sense_len)
+{
+	int rc = DEVICE_GOOD;
+	char *msg;
+	struct camtape_data *softc = device;
+	struct scsi_sense_data sense_data;
+	union ccb *ccb = NULL;
+
+	ccb = cam_getccb(softc->cd);
+	if (ccb == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+
+	bzero(&sense_data, sizeof(sense_data));
+
+	scsi_request_sense(&ccb->csio,
+					   /*retries*/ 0,
+					   /*cbfcnp*/ NULL,
+					   /*data_ptr*/ &sense_data,
+					   /*dxfer_len*/ sizeof(sense_data),
+					   /*tag_action*/ MSG_SIMPLE_Q_TAG,
+					   /*sense_len*/ SSD_FULL_SIZE,
+					   /*timeout*/ 90000);
+
+	ccb->ccb_h.flags |= CAM_DEV_QFRZDIS;
+
+	rc = camtape_send_ccb(softc, ccb, &msg);
+
+	if (rc == DEVICE_GOOD) {
+		*valid_sense_len = ccb->csio.dxfer_len - ccb->csio.resid;
+		bcopy(&sense_data, sense, MIN(alloc_sense_len, *valid_sense_len));
+	}
+bailout:
+	if (ccb != NULL)
+		cam_freeccb(ccb);
+
+	return rc;
+}
+
+
+/**
+ * Test Unit Ready
+ * @param device a pointer to the camtape backend
+ * @param inq pointer to inquiry data. This function will update this value
+ * @return 0 on success or negative value on error
+ */
+int camtape_test_unit_ready(void *device)
+{
+	char *msg;
+	int rc = DEVICE_GOOD;
+	bool take_dump = true, print_message = true;
+	struct camtape_data *softc = device;
+	int timeout;
+	union ccb *ccb = NULL;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_TUR));
+	ltfsmsg(LTFS_DEBUG3, 30592D, "test unit ready",
+			softc->drive_serial);
+
+	timeout = camtape_get_timeout(softc->timeouts, TEST_UNIT_READY);
+	if (timeout < 0) {
+		rc = -EDEV_UNSUPPORETD_COMMAND;
+		goto bailout;
+	}
+
+	ccb = cam_getccb(softc->cd);
+	if (ccb == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+
+	bzero(&(&ccb->ccb_h)[1],
+		sizeof(struct ccb_scsiio) - sizeof(struct ccb_hdr));
+
+	scsi_test_unit_ready(&ccb->csio,
+						 /*retries*/ 1,
+						 /*cbfcnp*/ NULL,
+						 /*tag_action*/ MSG_SIMPLE_Q_TAG,
+						 /*sense_len*/ SSD_FULL_SIZE,
+						 /*timeout*/ timeout * 1000);
+
+	/*
+	 * XXX KDM enabling error recovery here, so the retry count will work.
+	 * Not sure whether this is the correct thing to do.
+	 */
+	ccb->ccb_h.flags |= CAM_DEV_QFRZDIS | CAM_PASS_ERR_RECOVER;
+
+	rc = camtape_send_ccb(softc, ccb, &msg);
+
+	if (rc != DEVICE_GOOD) {
+		switch (rc) {
+		case -EDEV_NEED_INITIALIZE:
+		case -EDEV_CONFIGURE_CHANGED:
+		case -EDEV_OPERATION_IN_PROGRESS:
+			print_message = false;
+			/* Fall through */
+		case -EDEV_NO_MEDIUM:
+		case -EDEV_BECOMING_READY:
+		case -EDEV_MEDIUM_MAY_BE_CHANGED:
+		case -EDEV_NOT_READY:
+		case -EDEV_NOT_REPORTABLE:
+		case -EDEV_MEDIUM_REMOVAL_REQ:
+		case -EDEV_CLEANING_IN_PROGRESS:
+			take_dump = false;
+			break;
+		default:
+			break;
+		}
+		if (print_message)
+			camtape_process_errors(device, rc, msg, "test unit ready", take_dump);
+	}
+
+bailout:
+
+	if (ccb != NULL)
+		cam_freeccb(ccb);
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_TUR));
+	return rc;
+}
+
+/**
+ * Reserve the unit
+ * @param device a pointer to the camtape backend
+ * @param lun lun to reserve
+ * @return 0 on success or a negative value on error
+ */
+int camtape_reserve_unit(void *device)
+{
+	struct camtape_data *softc = device;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_RESERVEUNIT));
+	ltfsmsg(LTFS_DEBUG, 30592D, "reserve unit (6)", softc->drive_serial);
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_RESERVEUNIT));
+	/*
+	 * The FreeBSD tape driver issues a RESERVE UNIT command during the open process.  So a
+	 * separate reserve is not needed.
+	 */
+	return DEVICE_GOOD;
+}
+
+/**
+ * Release the unit
+ * @param device a pointer to the camtape backend
+ * @param lun lun to release
+ * @return 0 on success or a negative value on error
+ */
+int camtape_release_unit(void *device)
+{
+	struct camtape_data *softc = device;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_RELEASEUNIT));
+	ltfsmsg(LTFS_DEBUG, 30592D, "release unit (6)", softc->drive_serial);
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_RELEASEUNIT));
+	/*
+	 * The FreeBSD tape driver issues a RELEASE UNIT during the close process.  So a separate
+	 * release is not needed.
+	 */
+	return DEVICE_GOOD;
+}
+
+/**
+ * Read buffer
+ * @param device a pointer to the camtape backend
+ * @param id
+ * @param buf
+ * @param offset
+ * @param len
+ * @param type
+ * @return 0 on success or negative value on error
+ */
+int camtape_readbuffer(struct camtape_data *softc, int id, unsigned char *buf, size_t offset,
+					   size_t len, int type)
+{
+	char *msg;
+	int rc = DEVICE_GOOD;
+	union ccb *ccb;
+	int timeout;
+
+	ltfsmsg(LTFS_DEBUG, 30593D, "read buffer", id, softc->drive_serial);
+
+	ccb = cam_getccb(softc->cd);
+	if (ccb == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+
+	/* cam_getccb cleans up the header, caller has to zero the payload */
+	bzero(&(&ccb->ccb_h)[1],
+		  sizeof(struct ccb_scsiio) - sizeof(struct ccb_hdr));
+
+	timeout = camtape_get_timeout(softc->timeouts, READ_BUFFER);
+	if (timeout < 0) {
+		rc = -EDEV_UNSUPPORETD_COMMAND;
+		goto bailout;
+	}
+
+	scsi_read_buffer(&ccb->csio,
+					 /*retries*/ 1,
+					 /*cbfcnp*/ NULL,
+					 /*tag_action*/ MSG_SIMPLE_Q_TAG,
+					 /*mode*/ type,
+					 /*buffer_id*/ id,
+					 /*offset*/ offset,
+					 /*data_ptr*/ buf,
+					 /*allocation_length*/ len,
+					 /*sense_len*/ SSD_FULL_SIZE,
+					 /*timeout*/ timeout);
+
+	ccb->ccb_h.flags |= CAM_DEV_QFRZDIS | CAM_PASS_ERR_RECOVER;
+
+	rc = camtape_send_ccb(softc, ccb, &msg);
+
+	if (rc != DEVICE_GOOD)
+		camtape_process_errors(softc, rc, msg, "read buffer", false);
+
+bailout:
+	if (ccb != NULL)
+		cam_freeccb(ccb);
+
+	return rc;
+}
+
+/**
+ * Take drive dump
+ * @param device a pointer to the camtape backend
+ * @param fname a file name of dump
+ * @return 0 on success or negative value on error
+ */
+#define DUMP_HEADER_SIZE   (4)
+#define DUMP_TRANSFER_SIZE (512 * KB)
+
+int camtape_getdump_drive(void *device, const char *fname)
+{
+	struct camtape_data *softc = device;
+	long long data_length, buf_offset;
+	int dumpfd = -1;
+	int transfer_size, num_transfers, excess_transfer;
+	int rc = 0;
+	int i, bytes;
+	int buf_id;
+	unsigned char cap_buf[DUMP_HEADER_SIZE];
+	unsigned char *dump_buf;
+
+	ltfsmsg(LTFS_INFO, 30478I, fname);
+
+	/* Set transfer size */
+	transfer_size = DUMP_TRANSFER_SIZE;
+	dump_buf = calloc(1, DUMP_TRANSFER_SIZE);
+	if (dump_buf == NULL) {
+		ltfsmsg(LTFS_ERR, 10001E, "camtape_getdump_drive: dump buffer");
+		return -EDEV_NO_MEMORY;
+	}
+
+	/* Set buffer ID */
+	if (IS_ENTERPRISE(softc->drive_type)) {
+		buf_id = 0x00;
+	} else {
+		buf_id = 0x01;
+	}
+
+	/* Get buffer capacity */
+	camtape_readbuffer(device, buf_id, cap_buf, 0, sizeof(cap_buf), 0x03);
+	data_length = (cap_buf[1] << 16) + (cap_buf[2] << 8) + (int) cap_buf[3];
+
+	/* Open dump file for write only */
+	dumpfd = open(fname, O_WRONLY | O_CREAT | O_TRUNC, 0666);
+	if (dumpfd < 0) {
+		rc = -errno;
+		ltfsmsg(LTFS_WARN, 30479W, rc);
+		free(dump_buf);
+		return rc;
+	}
+
+	/* get the total number of transfers */
+	num_transfers = data_length / transfer_size;
+	excess_transfer = data_length % transfer_size;
+	if (excess_transfer)
+		num_transfers += 1;
+
+	/* Total dump data length is %lld. Total number of transfers is %d. */
+	ltfsmsg(LTFS_DEBUG, 30480D, data_length);
+	ltfsmsg(LTFS_DEBUG, 30481D, num_transfers);
+
+	/* start to transfer data */
+	buf_offset = 0;
+	i = 0;
+	ltfsmsg(LTFS_DEBUG, 30482D);
+	while (num_transfers) {
+		int length;
+
+		i++;
+
+		/* Allocation Length is transfer_size or excess_transfer */
+		if (excess_transfer && num_transfers == 1)
+			length = excess_transfer;
+		else
+			length = transfer_size;
+
+		rc = camtape_readbuffer(device, buf_id, dump_buf, buf_offset, length, 0x02);
+		if (rc) {
+			ltfsmsg(LTFS_WARN, 30483W, rc);
+			free(dump_buf);
+			close(dumpfd);
+			return rc;
+		}
+
+		/* write buffer data into dump file */
+		bytes = write(dumpfd, dump_buf, length);
+		if (bytes == -1) {
+			rc = -errno;
+			ltfsmsg(LTFS_WARN, 30484W, rc);
+			free(dump_buf);
+			close(dumpfd);
+			return rc;
+		}
+
+		ltfsmsg(LTFS_DEBUG, 30485D, i, bytes);
+		if (bytes != length) {
+			ltfsmsg(LTFS_WARN, 30486W, bytes, length);
+			free(dump_buf);
+			close(dumpfd);
+			return -EDEV_DUMP_EIO;
+		}
+
+		/* update offset and num_transfers, free buffer */
+		buf_offset += transfer_size;
+		num_transfers -= 1;
+
+	}							/* end of while(num_transfers) */
+
+	free(dump_buf);
+	close(dumpfd);
+
+	return rc;
+}
+
+/**
+ * Force Dump for Drive
+ * @param device a pointer to the camtape backend
+ * @return 0 on success or negative value on error
+ */
+#define SENDDIAG_BUF_LEN (8)
+int camtape_forcedump_drive(struct camtape_data *softc)
+{
+	union ccb *ccb = NULL;
+	unsigned char buf[SENDDIAG_BUF_LEN];
+	int rc = DEVICE_GOOD;
+	char *msg;
+	int timeout;
+
+	ltfsmsg(LTFS_DEBUG, 30593D, "force dump", 0, softc->drive_serial);
+
+	ccb = cam_getccb(softc->cd);
+	if (ccb == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+
+	memset(buf, 0, sizeof(buf));
+
+	/* Prepare payload */
+	buf[0] = 0x80;		/* page code */
+	buf[2] = 0x00;
+	buf[3] = 0x04;		/* page length */
+	buf[4] = 0x01;
+	buf[5] = 0x60;		/* diagnostic id */
+
+	timeout = camtape_get_timeout(softc->timeouts, SEND_DIAGNOSTIC);
+	if (timeout < 0) {
+		rc = EDEV_UNSUPPORETD_COMMAND;
+		goto bailout;
+	}
+	scsi_send_diagnostic(&ccb->csio,
+						 /*retries*/ 1,
+						 /*cbfcnp*/ NULL,
+						 /*tag_action*/ MSG_SIMPLE_Q_TAG,
+						 /*unit_offline*/ 0,
+						 /*device_offline*/ 0,
+						 /*self_test*/ 0,
+						 /*page_format*/ 1,
+						 /*self_test_code*/ SSD_SELF_TEST_CODE_NONE,
+						 /*data_ptr*/ buf,
+						 /*param_list_length*/ sizeof(buf),
+						 /*sense_len*/ SSD_FULL_SIZE,
+						 /*timeout*/ timeout);
+
+	ccb->ccb_h.flags |= CAM_DEV_QFRZDIS | CAM_PASS_ERR_RECOVER;
+
+	rc = camtape_send_ccb(softc, ccb, &msg);
+
+	if (rc != DEVICE_GOOD)
+		camtape_process_errors(softc, rc, msg, "force dump", false);
+
+bailout:
+	if (ccb != NULL)
+		cam_freeccb(ccb);
+
+	return rc;
+}
+
+/**
+ * Take normal drive dump and forces drive dump
+ * @param device a pointer to the camtape backend
+ * @return 0 on success or negative value on error
+ */
+int camtape_takedump_drive(void *device, bool nonforced_dump)
+{
+	char fname_base[1024];
+	char fname[1024];
+	time_t now;
+	struct tm *tm_now;
+	struct camtape_data *softc = device;
+	unsigned char *serial = softc->drive_serial;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_TAKEDUMPDRV));
+	/* Make base filename */
+	time(&now);
+	tm_now = localtime(&now);
+	sprintf(fname_base, "%s/ltfs_%s_%d_%02d%02d_%02d%02d%02d", ltfs_dump_dir, serial, tm_now->tm_year + 1900,
+			tm_now->tm_mon + 1, tm_now->tm_mday, tm_now->tm_hour, tm_now->tm_min, tm_now->tm_sec);
+
+	if (nonforced_dump) {
+		strcpy(fname, fname_base);
+		strcat(fname, ".dmp");
+
+		ltfsmsg(LTFS_ERR, 30487I);
+		camtape_getdump_drive(softc, fname);
+	}
+
+	ltfsmsg(LTFS_ERR, 30488I);
+	camtape_forcedump_drive(device);
+	strcpy(fname, fname_base);
+	strcat(fname, "_f.dmp");
+	camtape_getdump_drive(device, fname);
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_TAKEDUMPDRV));
+
+	return 0;
+}
+
+/**
+ * Get the serial number of the changer device.
+ * @param device Handle of the changer device to get the serial number for
+ * @param[out] result On success, contains the serial number of the changer. The memory
+ *             is allocated on demand and must be freed by the caller once it's gone using it.
+ * @return 0 on success or a negative value on error.
+ */
+int camtape_get_serialnumber(void *device, char **result)
+{
+	struct camtape_data *softc = (struct camtape_data *) device;
+
+	CHECK_ARG_NULL(device, -LTFS_NULL_ARG);
+	CHECK_ARG_NULL(result, -LTFS_NULL_ARG);
+	ltfs_profiler_add_entry(softc->profiler, NULL, CHANGER_REQ_ENTER(REQ_TC_GETSER));
+
+	*result = strdup((const char *) softc->drive_serial);
+	if (! *result) {
+		ltfsmsg(LTFS_ERR, 10001E, "camtape_get_serialnumber: result");
+		ltfs_profiler_add_entry(softc->profiler, NULL, CHANGER_REQ_EXIT(REQ_TC_GETSER));
+		return -EDEV_NO_MEMORY;
+	}
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, CHANGER_REQ_EXIT(REQ_TC_GETSER));
+	return 0;
+}
+
+/**
+ * Enable profiler function
+ * @param device a pointer to the tape device
+ * @param work_dir work directory to store profiler data
+ * @paran enable enable or disable profiler function of this backend
+ * @return 0 on success or a negative value on error
+ */
+int camtape_set_profiler(void *device, char *work_dir, bool enable)
+{
+	int rc = 0;
+	char *path;
+	FILE *p;
+	struct timer_info timerinfo;
+	struct camtape_data *softc = device;
+
+	if (enable) {
+		if (softc->profiler)
+			return 0;
+		if (!work_dir)
+			return -LTFS_BAD_ARG;
+
+		rc = asprintf(&path, "%s/%s%s%s", work_dir, DRIVER_PROFILER_BASE,
+					  softc->drive_serial, PROFILER_EXTENSION);
+		if (rc < 0) {
+			ltfsmsg(LTFS_ERR, 10001E, __FILE__);
+			return -LTFS_NO_MEMORY;
+		}
+
+		p = fopen(path, PROFILER_FILE_MODE);
+
+		free(path);
+
+		if (! p)
+			rc = -LTFS_FILE_ERR;
+		else {
+			get_timer_info(&timerinfo);
+			fwrite((void*)&timerinfo, sizeof(timerinfo), 1, p);
+			softc->profiler = p;
+			rc = 0;
+		}
+	} else {
+		if (softc->profiler) {
+			fclose(softc->profiler);
+			softc->profiler = NULL;
+		}
+	}
+
+	return rc;
+}
+
+int camtape_get_timeout(struct timeout_tape *table, int op_code)
+{
+	int ret;
+
+	ret = ibm_tape_get_timeout(table, op_code);
+	if (ret < 0)
+		return ret;
+	else
+		return (ret * 1000);
+}

--- a/src/tape_drivers/freebsd/cam/camtape_cmn.h
+++ b/src/tape_drivers/freebsd/cam/camtape_cmn.h
@@ -1,0 +1,614 @@
+/*
+**
+**  OO_Copyright_BEGIN
+**
+**
+**  Copyright 2010, 2018 IBM Corp. All rights reserved.
+**  Copyright (c) 2013-2018 Spectra Logic Corporation. All rights reserved.
+**
+**  Redistribution and use in source and binary forms, with or without
+**   modification, are permitted provided that the following conditions
+**  are met:
+**  1. Redistributions of source code must retain the above copyright
+**     notice, this list of conditions and the following disclaimer.
+**  2. Redistributions in binary form must reproduce the above copyright
+**     notice, this list of conditions and the following disclaimer in the
+**  documentation and/or other materials provided with the distribution.
+**  3. Neither the name of the copyright holder nor the names of its
+**     contributors may be used to endorse or promote products derived from
+**     this software without specific prior written permission.
+**
+**  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+**  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+**  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+**  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+**  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+**  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+**  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+**  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+**  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+**  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+**  POSSIBILITY OF SUCH DAMAGE.
+**
+**
+**  OO_Copyright_END
+**
+*************************************************************************************
+**
+** COMPONENT NAME:  IBM Linear Tape File System
+**
+** FILE NAME:       tape_drivers/freebsd/cam/camtape_cmn.h
+**
+** DESCRIPTION:     Implements FreeBSD CAM backend for LTFS.
+**
+** AUTHORS:         Ken Merry
+**                  Spectra Logic Corporation
+**                  ken@FreeBSD.ORG, kenm@spectralogic.com
+**
+*************************************************************************************
+*/
+
+
+#ifndef __camtape_cmn_h
+#define __camtape_cmn_h
+
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <sys/mtio.h>
+#include <sys/ioctl.h>
+#include <cam/cam.h>
+#include <cam/cam_ccb.h>
+#include <cam/scsi/scsi_all.h>
+#include <cam/scsi/scsi_pass.h>
+#include <cam/scsi/scsi_sa.h>
+#include <camlib.h>
+#include <err.h>
+
+#include "libltfs/tape_ops.h"
+#include "libltfs/ltfs_error.h"
+#include "libltfs/ltfs_endian.h"
+#include "tape_drivers/tape_drivers.h"
+#undef MAXSENSE
+#include "IBM_tape.h"
+#include "libltfs/ltfstrace.h"
+
+/*
+ * Mode page 0x24.  This is called "Initiator-Specific Extensions" mode page in the IBM TS spec,
+ * and "Vendor-Specific Speed Matching Control" mode page in the LTO spec.  The IBM LTO spec
+ * only documents 8 bytes (page length field is 6) in the mode page, and that matches what an
+ * IBM LTO-6 drive reports at least.  The IBM TS spec documents 24 bytes in the mode page (the
+ * page length field is 22).
+ */
+struct camtape_ibm_initiator_spec_ext_page {
+	uint8_t page_code;
+#define	CT_ISE_PAGE_CODE						0x24
+	uint8_t page_length;
+	uint8_t crc_target_support;
+#define	CT_ISE_IEEE_CRC_SUPPORT					0x80
+#define	CT_ISE_DEVSPEC_CRC_SUPPORT				0x40
+	uint8_t crc_target_enablement;
+#define	CT_ISE_CRC_DISABLED						0x00
+#define	CT_ISE_IEEE_CRC_ENABLED					0x01
+#define	CT_ISE_DEVSPEC_CRC_ENABLED				0x02
+	uint8_t crc_placement_length;
+#define	CT_ISE_CRC_PLACEMENT_MASK				0xc0
+#define	CT_ISE_CRC_APPEND						0x80
+#define	CT_ISE_CRC_PREFIX						0x40
+#define	CT_ISE_CRC_LENGTH_MASK					0x3f
+	uint8_t crc_scope;
+#define	CT_ISE_CRC_READ_DATA_CHECKED			0x80
+#define	CT_ISE_CRC_WRITE_DATA_CHECKED			0x40
+#define	CT_ISE_CRC_PARAM_READ_DATA_CHECKED		0x20
+#define	CT_ISE_CRC_PARAM_WRITE_DATA_CHECKED		0x10
+#define	CT_ISE_CRC_CDB_CHECKED					0x08
+#define	CT_ISE_CRC_RDB_DATA_CHECKED				0x04
+	uint8_t crc_characteristics;
+#define	CT_ISE_CRC_CDB_LENGTH_INCLUDES_CRC		0x80
+#define	CT_ISE_CRC_ENDIAN_BIG					0x40
+#define	CT_ISE_CRC_READ_REPORTING				0x20
+#define	CT_ISE_CRC_WRITE_REPORTING				0x10
+#define	CT_ISE_CRC_WRITE_IMMED_CHECK			0x08
+	uint8_t support_flags;
+#define	CT_ISE_PARTITION_SUPPORT				0x80
+#define	CT_ISE_PERF_SEGMENT_SCALING				0x40
+#define	CT_ISE_CAPACITY_SCALING					0x20
+#define	CT_ISE_WORM_SUPPORT						0x10
+#define	CT_ISE_ENCRYPTION_ENABLED				0x08
+#define	CT_ISE_FIPS								0x02
+#define	CT_ISE_ENCRYPTION_CAPABLE				0x01
+	/*
+	 * The following fields are only defined in the TS spec.
+	 */
+	uint8_t vendor_reserved1[5];
+	uint8_t transfer_period;
+	uint8_t req_ack_offset;
+	uint8_t buf_assocation_enablement;
+#define	CT_ISE_MANUAL_UNLOAD_ASSOC_ENABLED		0x80
+#define	CT_ISE_MANUAL_REWIND_ASSOC_ENABLED		0x40
+#define	CT_ISE_UNLOAD_WRITE_ERROR_ASSOC_ENABLED	0x20
+	uint8_t vendor_reserved2[8];
+};
+
+/*
+ * Mode page 0x25, the Read/Write Control page.  This page is undocumented in IBM's LTO spec,
+ * but is somewhat documented in IBM's TS spec.
+ */
+struct camtape_ibm_rw_control_page {
+	uint8_t page_code;
+#define	CT_RWC_PAGE_CODE						0x25
+	uint8_t page_length;
+	uint8_t ignore_sequence_checks;
+#define	CT_RWC_LOCATE_IGNORE_SEQ_CHECKS			0x04
+#define	CT_RWC_SPACE_BLK_IGNORE_SEQ_CHECKS		0x02
+#define	CT_RWC_SPACE_FILE_IGNORE_SEQ_CHECKS		0x01
+	uint8_t ignore_data_checks;
+#define	CT_RWC_LOCATE_IGNORE_DATA_CHECKS		0x04
+#define	CT_RWC_SPACE_BLK_IGNORE_DATA_CHECKS		0x02
+#define	CT_RWC_SPACE_FILE_IGNORE_DATA_CHECKS	0x01
+	uint8_t reserved1;
+	uint8_t leop_method;
+#define	CT_RWC_LEOP_DENSITY_SPECIFIC			0x00
+#define	CT_RWC_LEOP_MAX_CAPACITY				0x01
+#define	CT_RWC_LEOP_CONSTANT_CAPACITY			0x02
+	uint8_t leop_ew_mbytes[2];
+	uint8_t byte8;
+#define	CT_RWC_FASTSYNC_DISABLE					0x80
+#define	CT_RWC_SKIPSYNC_DISABLE					0x40
+#define	CT_RWC_CROSSING_EOD_DISABLE				0x08
+#define	CT_RWC_CROSSING_PERM_ERR_DISABLE		0x04
+#define	CT_RWC_REPORT_SEG_EW					0x02
+#define	CT_RWC_REPORT_HOUSEKEEPING_ERR			0x01
+	uint8_t default_write_density_bop;
+	uint8_t pending_write_density_bop;
+	uint8_t reserved2[5];
+	uint8_t reserved3[4];
+	uint8_t encryption_state;
+#define	CT_RWC_ENCRYPTION_STATE_MASK			0x03
+#define	CT_RWC_ENCRYPTION_STATE_OFF				0x00
+#define	CT_RWC_ENCRYPTION_STATE_ON				0x01
+#define	CT_RWC_ENCRYPTION_STATE_NA				0x02
+#define	CT_RWC_ENCRYPTION_STATE_UNKNOWN			0x03
+	uint8_t keypath_configured;
+	/*
+	 * These values are undocumented and somewhat obfuscated in the driver.  The test to see
+	 * whether the encryption keypath is configured is:
+	 *
+	 * is_keypath_config  = (((keypath_configured & CT_RWC_KP_MASK_1) == CT_RWC_KP_VALUE_1 &&
+	 *						  (keypath_configured & CT_RWC_KP_MASK_2) == CT_RWC_KP_VALUE_2) ||
+	 * 						  (keypath_configured & CT_RWC_KP_MASK_2) == CT_RWC_KP_VALUE_3);
+	 */
+#define	CT_RWC_KP_MASK_1						0xe0
+#define	CT_RWC_KP_VALUE_1						0x20
+#define	CT_RWC_KP_MASK_2						0x1c
+#define	CT_RWC_KP_VALUE_2						0x00
+#define	CT_RWC_KP_VALUE_3						0x04
+	uint8_t reserved4[5];
+	uint8_t encryption_method;
+#define	CT_RWC_ENC_METHOD_NONE					0x00
+#define	CT_RWC_ENC_METHOD_SYSTEM				0x10
+#define	CT_RWC_ENC_METHOD_APPLICATION			0x50
+#define	CT_RWC_ENC_METHOD_LIBRARY				0x60
+#define	CT_RWC_ENC_METHOD_INTERNAL				0x70
+#define	CT_RWC_ENC_METHOD_CONTROLLER			0x1f
+#define	CT_RWC_ENC_METHOD_CUSTOM				0xff
+	uint8_t reserved5[4];
+};
+
+/*
+ * This is mode page 0x25, subpage 0xc0, which controls encryption on IBM tape drives.  It is
+ * left out of the LTO drive spec completely.  In the TS spec, it is lumped into a bunch of IBM
+ * proprietary encryption parameters that you need to ask IBM about.
+ *
+ * The values here were obtained from the tape_set_data_key() function in lin_tape_ioctl_tape.c
+ * in the IBM Linux tape driver.  They are obfuscated there, thus the very generic names here.
+ * If there isn't a value for a particular byte, it is assumed to be 0.
+ */
+struct camtape_ibm_enc_param_subpage {
+	uint8_t page_code;
+#define	CT_ENC_PARAM_SUBPAGE_PAGE_CODE			CT_RWC_PAGE_CODE
+	uint8_t subpage_code;
+#define	CT_ENC_PARAM_SUBPAGE_CODE				0xc0
+	uint8_t page_length[2];
+#define	CT_ENC_PARAM_NO_KI_EXTRA_LENGTH			132
+#define	CT_ENC_PARAM_KI_EXTRA_LENGTH			144
+	uint8_t desc1[3];
+#define	CT_ENC_PARAM_DESC_1_BYTE_0_VAL			0x65
+#define	CT_ENC_PARAM_DESC_1_BYTE_1_VAL			0xe0
+	uint8_t desc1_length;
+#define	CT_ENC_PARAM_DESC_1_ADDL_LENGTH_SUB		4
+	uint8_t desc2[3];
+	uint8_t desc2_length;
+#define	CT_ENC_PARAM_DESC_2_ADDL_LENGTH_SUB		8
+	uint8_t desc3[3];
+	uint8_t desc3_length;
+#define	CT_ENC_PARAM_DESC_3_ADDL_LENGTH_SUB		16
+	uint8_t desc4[59];
+#define	CT_ENC_PARAM_DESC_4_BYTE_57_VAL			0x21
+#define	CT_ENC_PARAM_DESC_4_BYTE_58_VAL			0xe0;
+	uint8_t desc4_length;
+#define	CT_ENC_PARAM_DESC_4_ADDL_LENGTH_SUB		76
+	uint8_t byte76;
+#define	CT_ENC_PARAM_BYTE_76_MASK				0x78
+	uint8_t byte77;
+	uint8_t byte78;
+	uint8_t byte79;
+#define	CT_ENC_PARAM_BYTE_79_VALUE				0x01
+	uint8_t byte80;
+#define	CT_ENC_PARAM_BYTE_80_VALUE				0x11;
+	uint8_t byte81;
+	uint8_t byte82;
+	uint8_t byte83;
+#define	CT_ENC_PARAM_BYTE_83_VALUE				0x20
+#define	CT_ENC_PARAM_DATA_KEY_LEN				32
+	uint8_t data_key[CT_ENC_PARAM_DATA_KEY_LEN];
+	uint8_t byte116;
+#define	CT_ENC_PARAM_BYTE_116_VALUE				0x18
+	uint8_t byte117;
+	uint8_t byte118;
+	uint8_t byte119;
+#define	CT_ENC_PARAM_BYTE_119_VALUE_1			0x14
+#define	CT_ENC_PARAM_BYTE_119_VALUE_2			0x08
+	uint8_t byte120;
+	uint8_t byte121;
+#define	CT_ENC_PARAM_BYTE_121_VALUE				0x02
+	uint8_t byte122;
+	uint8_t byte123;
+	uint8_t byte124;
+#define	CT_ENC_PARAM_BYTE_124_VALUE				0x1a
+	uint8_t byte125;
+	uint8_t byte126;
+	union ki_or_no_ki {
+		struct ki_set {
+			uint8_t byte127;
+#define	CT_ENC_PARAM_BYTE127_KI_VALUE			0x0c
+#define	CT_ENC_PARAM_KEY_INDEX_LEN				12
+			uint8_t key_index[CT_ENC_PARAM_KEY_INDEX_LEN];
+			uint8_t byte140;
+			uint8_t byte141;
+			uint8_t byte142;
+			uint8_t byte143;
+			uint8_t byte144;
+#define	CT_ENC_PARAM_BYTE144_KI_VALUE			0x04
+			uint8_t byte145;
+			uint8_t byte146;
+			uint8_t byte147;
+		} ki_is_set;
+		struct no_ki_set {
+			uint8_t byte127;
+			uint8_t byte128;
+			uint8_t byte129;
+			uint8_t byte130;
+			uint8_t byte131;
+			uint8_t byte132;
+#define	CT_ENC_PARAM_BYTE132_NO_KI_VALUE		0x04
+			uint8_t byte133;
+			uint8_t byte134;
+			uint8_t byte135;
+		} ki_not_set;
+	} ki_or_not;
+};
+
+typedef enum {
+	CT_ENC_CAPABLE,
+	CT_ENC_NOT_CAPABLE
+} camtape_encryption_capable;
+
+typedef enum {
+	CT_ENC_METHOD_NONE			= CT_RWC_ENC_METHOD_NONE,
+	CT_ENC_METHOD_SYSTEM		= CT_RWC_ENC_METHOD_SYSTEM,
+	CT_ENC_METHOD_APPLICATION	= CT_RWC_ENC_METHOD_APPLICATION,
+	CT_ENC_METHOD_LIBRARY		= CT_RWC_ENC_METHOD_LIBRARY,
+	CT_ENC_METHOD_INTERNAL		= CT_RWC_ENC_METHOD_INTERNAL,
+	CT_ENC_METHOD_CONTROLLER	= CT_RWC_ENC_METHOD_CONTROLLER,
+	CT_ENC_METHOD_CUSTOM		= CT_RWC_ENC_METHOD_CUSTOM,
+	CT_ENC_METHOD_UNKNOWN
+} camtape_encryption_method;
+
+typedef enum {
+	CT_ENC_STATE_OFF			= CT_RWC_ENCRYPTION_STATE_OFF,
+	CT_ENC_STATE_ON				= CT_RWC_ENCRYPTION_STATE_ON,
+	CT_ENC_STATE_NA				= CT_RWC_ENCRYPTION_STATE_NA,
+	CT_ENC_STATE_UNKNOWN		= CT_RWC_ENCRYPTION_STATE_UNKNOWN
+} camtape_encryption_state;
+
+struct camtape_encryption_status {
+	camtape_encryption_capable	encryption_capable;
+	camtape_encryption_method	encryption_method;
+	camtape_encryption_state	encryption_state;
+};
+
+/**
+ *  Status definitions of lower scsi handling code
+ *  This statuses are exposed into SIOC pass through interface
+ */
+enum scsi_status {
+	SCSI_GOOD                 = 0x00,
+	SCSI_CHECK_CONDITION      = 0x01,
+	SCSI_CONDITION_GOOD       = 0x02,
+	SCSI_BUSY                 = 0x04,
+	SCSI_INTERMEDIATE_GOOD    = 0x08,
+	SCSI_INTERMEDIATE_C_GOOD  = 0x0a,
+	SCSI_RESERVATION_CONFRICT = 0x0c,
+};
+
+enum host_status {
+	HOST_GOOD       = 0x00,
+	HOST_NO_CONNECT = 0x01,
+	HOST_BUS_BUSY   = 0x02,
+	HOST_TIME_OUT   = 0x03,
+	HOST_BAD_TARGET = 0x04,
+	HOST_ABORT      = 0x05,
+	HOST_PARITY     = 0x06,
+	HOST_ERROR      = 0x07,
+	HOST_RESET      = 0x08,
+	HOST_BAD_INTR   = 0x09,
+};
+
+enum driver_status {
+	DRIVER_GOOD     = 0x00,
+	DRIVER_BUSY     = 0x01,
+	DRIVER_SOFT     = 0x02,
+	DRIVER_MEDIA    = 0x03,
+	DRIVER_ERROR    = 0x04,
+	DRIVER_INVALID  = 0x05,
+	DRIVER_TIMEOUT  = 0x06,
+	DRIVER_HARD     = 0x07,
+	DRIVER_SENSE    = 0x08,
+	SUGGEST_RETRY   = 0x10,
+	SUGGEST_ABORT   = 0x20,
+	SUGGEST_REMAP   = 0x30,
+	SUGGEST_DIE     = 0x40,
+	SUGGEST_SENSE   = 0x80,
+	SUGGEST_IS_OK   = 0xff,
+};
+
+/**
+ * camtape private data structure. Shared by camtape_tc.c and camtape_cc.c
+ */
+struct itd_conversion_entry {
+	uint16_t src_asc_ascq; /**< ASC/ASCQ receive from device */
+	uint16_t dst_asc_ascq; /**< ASC/ASCQ converted */
+};
+
+enum _device_type {
+	DEVICE_TAPE,
+	DEVICE_CHANGER,
+};
+
+struct camtape_data {
+	int           fd_sa;             /**< file descriptor of the SA device */
+	struct cam_device *cd;           /**< CAM device for PT device, contains file descriptor of the PT device */
+	bool          loaded;            /**< Is cartridge loaded? */
+	bool          loadfailed;        /**< Is load/unload failed? */
+	unsigned char drive_serial[255]; /**< serial number of device */
+	int           drive_type;        /**< device type */
+	int           itd_command_size;  /**< ITD sense conversion table size for commands */
+	struct itd_conversion_entry *itd_command; /**< ITD sense conversion table for commands */
+	int           itd_slot_size;     /**< ITD sense conversion table size for RES data */
+	struct itd_conversion_entry *itd_slot;    /**< ITD sense conversion table for RES data */
+	long          fetch_sec_acq_loss_w; /**< Sec to fetch Active CQs loss write */
+	bool          dirty_acq_loss_w;  /**< Is Active CQs loss write dirty */
+	float         acq_loss_w;        /**< Active CQs loss write */
+	uint64_t      tape_alert;        /**< Latched tape alert flag */
+	bool          is_data_key_set;   /**< Is a valid data key set? */
+	unsigned char dki[12];           /**< key-alias */
+	uint64_t      force_writeperm;   /**< pseudo write perm threshold */
+	uint64_t      force_readperm;    /**< pseudo read perm threashold */
+	uint64_t      write_counter;     /**< write call counter for pseudo write perm */
+	uint64_t      read_counter;      /**< read call counter for pseudo write perm */
+	int			  force_errortype;	 /**< 0 is R/W Perm, otherwise no sense */
+	char          *devname;          /**< device name */
+	bool          is_worm;           /**< Is worm cartridge loaded? */
+	unsigned char cart_type;		 /**< Cartridge type in CM */
+	unsigned char density_code;		 /**< Density code */
+	crc_enc       f_crc_enc;         /**< Pointer to CRC encode function */
+	crc_check     f_crc_check;       /**< Pointer to CRC encode function */
+	struct timeout_tape *timeouts;	 /**< Timeout table */
+	FILE*		  profiler;			 /**< The file pointer for profiler */
+
+};
+
+struct camtape_global_data {
+	unsigned          disable_auto_dump; /**< Is auto dump disabled? */
+	char              *str_crc_checking; /**< option string for crc_checking */
+	unsigned          crc_checking;      /**< Is crc checking enabled? */
+	unsigned          strict_drive;      /**< Is bar code length checked strictly? */
+};
+
+/**
+ *  Macros
+ */
+
+#define MASK_WITH_SENSE_KEY    (0xFFFFFF)
+#define MASK_WITHOUT_SENSE_KEY (0x00FFFF)
+
+/*
+ *  Function Prototypes
+ */
+extern int camtape_sense2rc(void *device, struct scsi_sense_data *sense, int sense_len);
+extern int camtape_ccb2rc(struct camtape_data *softc, union ccb *ccb);
+extern int camtape_ioctlrc2err(void *device, int fd, struct scsi_sense_data *sense,
+							   int control_cmd, char **msg);
+extern int _sioc_stioc_command(void *device, int cmd, char *cmd_name, void *param, char **msg);
+extern int camtape_check_lin_tape_version(void);
+extern int camtape_inquiry(void *device, struct tc_inq *inq);
+extern int _camtape_inquiry_page(void *device, unsigned char page, struct tc_inq_page *inq, bool error_handle);
+extern int camtape_inquiry_page(void *device, unsigned char page, struct tc_inq_page *inq);
+extern int camtape_request_sense(void *device, struct scsi_sense_data *sense, int alloc_sense_len,
+								 int *valid_sense_len);
+extern int camtape_test_unit_ready(void *device);
+extern int camtape_reserve_unit(void *device);
+extern int camtape_release_unit(void *device);
+
+extern int camtape_readbuffer(struct camtape_data *softc, int id, unsigned char *buf,
+							  size_t offset, size_t len, int type);
+extern int camtape_takedump_drive(void *device, bool nonforced_dump);
+extern int camtape_get_serialnumber(void *device, char **result);
+extern int camtape_set_profiler(void *device, char *work_dir, bool enable);
+extern int camtape_get_timeout(struct timeout_tape *table, int op_code);
+
+extern int camtape_logsense_page(struct camtape_data *softc, const uint8_t page, const uint8_t subpage,
+								 unsigned char *buf, const size_t size);
+
+/**
+ * Get Dump
+ * @param device a pointer to the camtape backend
+ * @return none
+ */
+static inline void camtape_get_dump(void *device, bool nonforced_dump)
+{
+	camtape_takedump_drive(device, nonforced_dump);
+	return;
+}
+
+/**
+ * Convert sense code to ITD sense code
+ * @param sense sense code packed to uint32_t
+ * @param table pointer to itd conversion table
+ * @param int the size of itd conversion table
+ * @return LTFS internal error code
+ */
+static inline uint32_t camtape_conv_itd(uint32_t sense, struct itd_conversion_entry *table, int size)
+{
+	uint32_t ret = sense;
+	uint16_t src = sense & 0xFFFF;
+	int i;
+
+	for(i = 0 ; i < size; i++) {
+		if( src == table[i].src_asc_ascq )
+			ret = (sense & 0xFF0000) + table[i].dst_asc_ascq;
+	}
+
+	return ret;
+}
+
+/**
+ * Convert sense information to negative errno
+ * @param spt pointer to sioc_pass_through
+ * @return negative errno
+ */
+static inline int _sense2errcode(uint32_t sense, struct error_table *table, char **msg, uint32_t mask)
+{
+	int rc = -EDEV_UNKNOWN;
+	int i;
+
+	if (msg)
+		*msg = NULL;
+
+	if ( (sense & 0xFFFF00) == 0x044000 )
+		sense = 0x044000;
+	else if ( (sense & 0xFFF000) == 0x048000 ) /* 04/8xxx in TS3100/TS3200 */
+		sense = 0x048000;
+	else if ( (sense & 0xFFF000) == 0x0B4100 ) /* 0B/41xx in TS2900 */
+		sense = 0x0B4100;
+
+	if ( (sense & 0x00FF00) >= 0x008000 || (sense & 0x0000FF) >= 0x000080)
+		rc = -EDEV_VENDOR_UNIQUE;
+
+	i = 0;
+	while (table[i].sense != 0xFFFFFF) {
+		if((table[i].sense & mask) == (sense & mask)) {
+			rc  = table[i].err_code;
+			if (msg)
+				*msg = strdup(table[i].msg);
+			break;
+		}
+		i++;
+	}
+
+	if (table[i].err_code == -EDEV_RECOVERED_ERROR)
+		rc = DEVICE_GOOD;
+	else if (table[i].sense == 0xFFFFFF && table[i].err_code == rc && msg)
+		*msg = strdup(table[i].msg);
+
+	return rc;
+}
+
+/**
+ * Send a CAM passthrough CCB and decode any errors.
+ * @param softc pointer to camtape_data structre
+ * @param ccb pointer to CAM CCB
+ * @param msg pointer to a description of the error
+ * @return internal error code defined in ltfs_error.h
+ */
+static inline int camtape_send_ccb(struct camtape_data *softc, union ccb *ccb, char **msg)
+{
+	int rc;
+
+	*msg = NULL;
+	if (cam_send_ccb(softc->cd, ccb) == -1) {
+		char tmpstr[512];
+
+		snprintf(tmpstr, sizeof(tmpstr), "cam_send_ccb() failed: %s", strerror(errno));
+		*msg = strdup(tmpstr);
+		rc = -errno;
+	} else
+		rc = camtape_ccb2rc(softc, ccb);
+
+	if ((rc != DEVICE_GOOD) && (*msg == NULL)) {
+		char *tmpstr;
+
+		tmpstr = malloc(2048);
+		if (tmpstr == NULL)
+			goto bailout;
+
+		cam_error_string(softc->cd, ccb, tmpstr, 2048, CAM_ESF_ALL, CAM_EPF_ALL);
+		*msg = tmpstr;
+	}
+bailout:
+	return rc;
+}
+
+static inline bool is_dump_required_error(struct camtape_data *softc, int ret, bool *nonforced_dump)
+{
+	int rc, err = -ret;
+	bool ans = FALSE;
+	struct log_sense10_page log_page;
+
+	if (err == EDEV_NO_SENSE || err == EDEV_OVERRUN) {
+		/* Sense Key 0 situation. */
+		/* Drive may not exist or may not be able to transfer any data. */
+		/* Checking capability of data transfer by logsense. */
+		log_page.page_code = 0x17;	// volume status
+		log_page.subpage_code = 0;
+		log_page.len = 0;
+		log_page.parm_pointer = 0;
+		memset(log_page.data, 0, LOGSENSEPAGE);
+
+		rc = camtape_logsense_page(softc, log_page.page_code, 0, (unsigned char *)&log_page.data,
+								   LOGSENSEPAGE);
+
+		ans = (rc == DEVICE_GOOD);
+	}
+	else if (err >= EDEV_NOT_READY && err < EDEV_INTERNAL_ERROR) {
+		ans = TRUE;
+	}
+
+	*nonforced_dump = (IS_MEDIUM_ERROR(err) || IS_HARDWARE_ERROR(err));
+
+	return ans;
+}
+
+
+extern struct camtape_global_data global_data;
+
+static inline void camtape_process_errors(struct camtape_data *softc, int rc, char *msg, char *cmd, bool take_dump)
+{
+	bool nonforced_dump = false;
+
+	if (msg != NULL) {
+		ltfsmsg(LTFS_INFO, 30413I, cmd, msg, rc, softc->drive_serial);
+		free(msg);
+	} else
+		ltfsmsg(LTFS_ERR, 30414E, cmd, rc, softc->drive_serial);
+
+	if (softc) {
+		if ( take_dump &&
+			 !global_data.disable_auto_dump &&
+			 is_dump_required_error(softc, rc, &nonforced_dump))
+			camtape_get_dump(softc, nonforced_dump);
+	}
+}
+
+#endif // __camtape_cmn_h

--- a/src/tape_drivers/freebsd/cam/camtape_tc.c
+++ b/src/tape_drivers/freebsd/cam/camtape_tc.c
@@ -1,0 +1,4206 @@
+/*
+**
+**  OO_Copyright_BEGIN
+**
+**
+**  Copyright 2010, 2018 IBM Corp. All rights reserved.
+**  Copyright (c) 2013-2018 Spectra Logic Corporation. All rights reserved.
+**
+**  Redistribution and use in source and binary forms, with or without
+**   modification, are permitted provided that the following conditions
+**  are met:
+**  1. Redistributions of source code must retain the above copyright
+**     notice, this list of conditions and the following disclaimer.
+**  2. Redistributions in binary form must reproduce the above copyright
+**     notice, this list of conditions and the following disclaimer in the
+**  documentation and/or other materials provided with the distribution.
+**  3. Neither the name of the copyright holder nor the names of its
+**     contributors may be used to endorse or promote products derived from
+**     this software without specific prior written permission.
+**
+**  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+**  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+**  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+**  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+**  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+**  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+**  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+**  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+**  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+**  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+**  POSSIBILITY OF SUCH DAMAGE.
+**
+**
+**  OO_Copyright_END
+**
+*************************************************************************************
+**
+** COMPONENT NAME:  IBM Linear Tape File System
+**
+** FILE NAME:       tape_drivers/freebsd/cam/camtape_tc.c
+**
+** DESCRIPTION:     Implements FreeBSD CAM backend for LTFS.
+**
+** AUTHORS:         Atsushi Abe
+**                  IBM Yamato, Japan
+**                  PISTE@jp.ibm.com
+**
+**                  Ken Merry
+**                  Spectra Logic Corporation
+**                  ken@FreeBSD.ORG, kenm@spectralogic.com
+**
+*************************************************************************************
+*/
+
+#define __camtape_tc_c
+
+#include <inttypes.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/queue.h>
+#include <dirent.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+#include <stddef.h>
+#include <ctype.h>
+#include <bsdxml.h>
+#include <mtlib.h>
+#include <cam/scsi/scsi_message.h>
+#include <libxml/parser.h>
+#include <libxml/tree.h>
+
+#include "libltfs/ltfs_fuse_version.h"
+#include "libltfs/arch/time_internal.h"
+#include <fuse.h>
+
+#include "libltfs/ltfslogging.h"
+
+#include "tape_drivers/tape_drivers.h"
+#include "tape_drivers/ibm_tape.h"
+
+#define TAPE_BACKEND /* Use static vriable definition in tape_drivers.h */
+#include "camtape_cmn.h"
+#include "reed_solomon_crc.h"
+#include "crc32c_crc.h"
+
+/*
+ * Prototypes for opening the SA (Sequential Access) and pass (Pass Through) 
+ * device drivers on FreeBSD
+*/
+int open_sa_pass(struct camtape_data *priv, const char *saDeviceName);
+
+int open_sa_device(struct camtape_data *priv, const char* saDeviceName);
+void close_sa_device(struct camtape_data *priv);
+
+void close_cd_pass_device(struct camtape_data *priv);
+
+/*
+ * Default tape device
+ */
+const char *camtape_default_device = "/dev/sa0";
+
+/*
+ * Default changer device
+ */
+const char *camtape_default_changer_device = "/dev/ch0";
+
+/*
+ *  Definitions
+ */
+#define LOG_PAGE_HEADER_SIZE      (4)
+#define LOG_PAGE_PARAMSIZE_OFFSET (3)
+#define LOG_PAGE_PARAM_OFFSET     (4)
+
+#define LINUX_MAX_BLOCK_SIZE (1 * MB)
+#define	LTFS_CRC_LEN			  4
+#ifndef MIN
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
+#endif
+
+#define THRESHOLD_FORCE_WRITE_NO_WRITE (5)
+
+#define CRC32C_CRC (0x02)
+
+#define DEFAULT_WRITEPERM		(0)
+#define DEFAULT_READPERM		(0)
+#define DEFAULT_ERRORTYPE		(0)
+
+/*
+ *  Global values
+ */
+struct camtape_global_data global_data;
+struct error_table *standard_table;
+struct error_table *vendor_table;
+
+/*
+ *  Forward reference
+ */
+int camtape_readpos(void *device, struct tc_position *pos);
+int camtape_rewind(void *device, struct tc_position *pos);
+int camtape_modesense(void *device, const uint8_t page, const TC_MP_PC_TYPE pc, const uint8_t subpage,
+					  unsigned char *buf, const size_t size);
+int camtape_set_key(void *device, const unsigned char * const keyalias, const unsigned char * const key);
+int camtape_set_lbp(void *device, bool enable);
+
+/*
+ *  Local Functions
+ */
+
+/**
+ * Parse Log page contents
+ * @param logdata pointer to logdata buffer to parse. including log sense header is expected
+ * @param param parameter id to fetch
+ * @param param_size size of value to fetch
+ * @param buf pointer to the buffer to filled in teh fetched value. this function will update this value.
+ * @param bufsize size of the buffer
+ * @return 0 on success or negative value on error
+ */
+int parse_logPage(const unsigned char *logdata, const uint16_t param, int *param_size,
+								unsigned char *buf, const size_t bufsize)
+{
+	uint16_t page_len, param_code, param_len;
+	long i;
+
+	page_len = ltfs_betou16(logdata + 2);
+	i = LOG_PAGE_HEADER_SIZE;
+
+	while (i < page_len) {
+		param_code = ltfs_betou16(logdata + i);
+		param_len = (uint16_t) logdata[i + LOG_PAGE_PARAMSIZE_OFFSET];
+		if (param_code == param) {
+			*param_size = param_len;
+			if (bufsize < param_len) {
+				ltfsmsg(LTFS_INFO, 30418I, bufsize, i + LOG_PAGE_PARAM_OFFSET);
+				memcpy(buf, &logdata[i + LOG_PAGE_PARAM_OFFSET], bufsize);
+				return -2;
+			}
+			else {
+				memcpy(buf, &logdata[i + LOG_PAGE_PARAM_OFFSET], param_len);
+				return 0;
+			}
+		}
+		i += param_len + LOG_PAGE_PARAM_OFFSET;
+	}
+
+	return -1;
+}
+
+/**
+ * Parse option for IBM tape driver
+ * @param devname device name of the LTO tape driver
+ * @return a pointer to the camtape backend on success or NULL on error
+ */
+#define IBMTAPE_OPT(templ,offset,value) { templ, offsetof(struct camtape_global_data, offset), value }
+
+static struct fuse_opt camtape_global_opts[] = {
+	IBMTAPE_OPT("autodump",          disable_auto_dump, 0),
+	IBMTAPE_OPT("noautodump",        disable_auto_dump, 1),
+	IBMTAPE_OPT("scsi_lbprotect=%s", str_crc_checking, 0),
+	IBMTAPE_OPT("strict_drive",   strict_drive, 1),
+	IBMTAPE_OPT("nostrict_drive", strict_drive, 0),
+	FUSE_OPT_END
+};
+
+int null_parser(void *priv, const char *arg, int key, struct fuse_args *outargs)
+{
+	return 1;
+}
+
+int camtape_parse_opts(void *device, void *opt_args)
+{
+	struct fuse_args *args = (struct fuse_args *) opt_args;
+	struct camtape_data *softc = device;
+	int ret;
+
+	/* fuse_opt_parse can handle a NULL device parameter just fine */
+	ret = fuse_opt_parse(args, &global_data, camtape_global_opts, null_parser);
+	if (ret < 0) {
+		ltfsmsg(LTFS_ERR, 30419I, ret);
+		ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_PARSEOPTS));
+		return ret;
+	}
+
+	/* Validate scsi logical block protection */
+	if (global_data.str_crc_checking) {
+		if (strcasecmp(global_data.str_crc_checking, "on") == 0)
+			global_data.crc_checking = 1;
+		else if (strcasecmp(global_data.str_crc_checking, "off") == 0)
+			global_data.crc_checking = 0;
+		else {
+			ltfsmsg(LTFS_ERR, 30420E, global_data.str_crc_checking);
+			ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_PARSEOPTS));
+			return -EINVAL;
+		}
+	} else
+		global_data.crc_checking = 0;
+
+	return 0;
+}
+
+/**
+ * Open IBM tape backend.
+ * @param devname device name of the LTO tape driver
+ * @param[out] handle contains the handle to the IBM tape backend on success
+ * @return 0 on success or a negative value on error
+ */
+int camtape_open(const char *devname, void **handle)
+{
+	struct camtape_data *priv;
+	int drive_type = DRIVE_UNSUPPORTED;
+	char vendor[10];
+	char product[20];
+	int ret;
+
+	CHECK_ARG_NULL(handle, -LTFS_NULL_ARG);
+	*handle = NULL;
+
+	/*
+	 * XXX KDM check to see whether the sa(4) driver has required features.
+	 * ret =  camtape_check_lin_tape_version();
+	 * if (ret != DEVICE_GOOD) {
+	 * return ret;
+ 	 *  }	
+	 */
+
+	ltfsmsg(LTFS_INFO, 30423I, devname);
+
+	priv = calloc(1, sizeof(struct camtape_data));
+	if (! priv) {
+		ltfsmsg(LTFS_ERR, 10001E, "camtape_open: device private data");
+		return -EDEV_NO_MEMORY;
+	}
+
+	ret = open_sa_pass(priv, devname);
+	if (ret) {
+		free(priv);
+		return ret;
+	}
+
+	cam_strvis((uint8_t *)product, (uint8_t *)priv->cd->inq_data.product,
+	    sizeof(priv->cd->inq_data.product), sizeof(product));
+	cam_strvis((uint8_t *)vendor, (uint8_t *)priv->cd->inq_data.vendor,
+	    sizeof(priv->cd->inq_data.vendor), sizeof(vendor));
+	ltfsmsg(LTFS_INFO, 30428I, product);
+	ltfsmsg(LTFS_INFO, 30429I, vendor);
+
+
+	/* Check the drive is supportable */
+	struct supported_device **cur = ibm_supported_drives;
+	while(*cur) {
+		if ((! strncmp((char*)priv->cd->inq_data.vendor, (*cur)->vendor_id,
+					   strlen((*cur)->vendor_id)) ) &&
+		   (! strncmp((char*)priv->cd->inq_data.product, (*cur)->product_id,
+					  strlen((*cur)->product_id)) ) ) {
+			drive_type = (*cur)->drive_type;
+			break;
+		}
+		cur++;
+	}
+
+
+	if (drive_type != DRIVE_UNSUPPORTED) {
+		priv->drive_type = drive_type;
+
+		/* Setup IBM tape specific parameters */
+		standard_table = standard_tape_errors;
+		vendor_table   = ibm_tape_errors;
+
+		/* Set specific timeout value based on drive type */
+		ibm_tape_init_timeout(&priv->timeouts, priv->drive_type);
+	} else {
+		ltfsmsg(LTFS_INFO, 30430I, priv->cd->inq_data.product);
+		close(priv->fd_sa);
+		close_cd_pass_device(priv);
+		free(priv);
+		return -EDEV_DEVICE_UNSUPPORTABLE;
+	}
+
+	/* Set drive serial number to private data to put it to the dump file name */
+	memset(priv->drive_serial, 0, sizeof(priv->drive_serial));
+	memcpy(priv->drive_serial, priv->cd->serial_num, priv->cd->serial_num_len);
+
+	ltfsmsg(LTFS_INFO, 30432I, priv->cd->inq_data.revision);
+	if (! ibm_tape_is_supported_firmware(priv->drive_type, (uint8_t *)priv->cd->inq_data.revision)) {
+		ltfsmsg(LTFS_INFO, 30430I, "firmware", priv->cd->inq_data.revision);
+		close(priv->fd_sa);
+		close_cd_pass_device(priv);
+
+		free(priv);
+		return -EDEV_UNSUPPORTED_FIRMWARE;
+	}
+
+	ltfsmsg(LTFS_INFO, 30433I, priv->drive_serial);
+
+	priv->loaded = false; /* Assume tape is not loaded until a successful load call. */
+
+	priv->force_writeperm = DEFAULT_WRITEPERM;
+	priv->force_readperm  = DEFAULT_READPERM;
+	priv->force_errortype = DEFAULT_ERRORTYPE;
+
+	*handle = (void *) priv;
+	return DEVICE_GOOD;
+}
+
+/**
+ * Reopen IBM tape backend
+ * @param devname device name of the LTO tape driver
+ * @param device a pointer to the camtape backend
+ * @return 0 on success or a negative value on error
+ */
+int camtape_reopen(const char *name, void *vstate)
+{
+	/* Do nothing */
+	return 0;
+}
+
+/**
+ * Close IBM tape backend
+ * @param device a pointer to the camtape backend
+ * @return 0 on success or a negative value on error
+ */
+int camtape_close(void *device)
+{
+	struct camtape_data *priv = (struct camtape_data *) device;
+	struct tc_position pos;
+
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_CLOSE));
+	if (priv->loaded)
+		camtape_rewind(device, &pos);
+
+	camtape_set_lbp(device, false);
+
+	close(priv->fd_sa);
+
+	close_cd_pass_device(priv);
+
+	ibm_tape_destroy_timeout(&priv->timeouts);
+
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_CLOSE));
+
+	if (priv->profiler) {
+		fclose(priv->profiler);
+		priv->profiler = NULL;
+	}
+
+	free(priv);
+	return 0;
+}
+
+/**
+ * Close only file descriptor
+ * @param device a pointer to the camtape backend
+ * @return 0 on success or a negative value on error
+ */
+int camtape_close_raw(void *device)
+{
+	struct camtape_data *priv = (struct camtape_data *) device;
+
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_CLOSERAW));
+	close(priv->fd_sa);
+	priv->fd_sa = -1;
+
+	close_cd_pass_device(priv);
+
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_CLOSERAW));
+	return 0;
+}
+
+/**
+ * Test if a given tape device is connected to the host
+ * @param devname device name of the LTO tape driver
+ * @return 0 on success, indicating that the drive is connected to the host,
+ *  or a negative value on error.
+ */
+int camtape_is_connected(const char *devname)
+{
+	struct stat statbuf;
+	int ret = 0;
+
+	/*
+	 * We assume that /dev is handled by a daemon such as Udev and that
+	 * device entries are automatically removed and added upon hotplug events.
+	 */
+	ret = stat(devname, &statbuf);
+	return ret;
+}
+
+int _mt_command(void *device, int cmd, char *cmd_name, int param, char **msg)
+{
+	struct camtape_data *softc = device;
+	int fd = softc->fd_sa;
+	struct mtop mt = {.mt_op = cmd,.mt_count = param };
+	struct scsi_sense_data sense_data;
+	int rc;
+
+start:
+	rc = ioctl(fd, MTIOCTOP, &mt);
+
+	if (rc != 0) {
+		rc = camtape_ioctlrc2err(softc, fd, &sense_data, /*control_cmd*/ 1, msg);
+		if (rc == -EDEV_TIME_STAMP_CHANGED) {
+			ltfsmsg(LTFS_DEBUG, 30411D, cmd_name, cmd, rc);
+			goto start;
+		}
+		ltfsmsg(LTFS_INFO, 30408I, cmd_name, cmd, rc, errno, softc->drive_serial);
+	}
+	else {
+		*msg = NULL;
+		rc = DEVICE_GOOD;
+	}
+
+	return rc;
+}
+
+/**
+ * Read a record from tape
+ * @param device a pointer to the camtape backend
+ * @param buf a pointer to read buffer
+ * @param count read size
+ * @param pos a pointer to position data. This function will update position infomation.
+ * @param unusual_size a flag specified unusual size or not
+ * @return read length on success or a negative value on error
+ */
+int camtape_read(void *device, char *buf, size_t count, struct tc_position *pos,
+				 const bool unusual_size)
+{
+	ssize_t len = -1, read_len;
+	int rc;
+	bool silion = unusual_size;
+	char *msg = NULL;
+	struct camtape_data *priv = (struct camtape_data *) device;
+	int    fd = priv->fd_sa;
+	size_t datacount = count;
+
+	/*
+	 * TODO: Check count is smaller than max of SSIZE_MAX
+	 *       The prototype of read system call is
+	 *       ssize_t read(int fd, void *buf, size_t count);
+	 */
+
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_READ));
+	ltfsmsg(LTFS_DEBUG3, 30595D, "read", count, priv->drive_serial);
+
+	if (priv->force_readperm) {
+		priv->read_counter++;
+		if (priv->read_counter > priv->force_readperm) {
+			ltfsmsg(LTFS_INFO, 30434I, "read");
+			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_READ));
+			if (priv->force_errortype)
+				return -EDEV_NO_SENSE;
+			else
+				return -EDEV_READ_PERM;
+		}
+	}
+
+	read_len = read(fd, buf, datacount);
+
+	if ((!silion && (size_t)read_len != datacount) || (read_len <= 0)) {
+		struct scsi_sense_data sense_data;
+		uint8_t stream_bits;
+
+		/* XXX KDM need to pass back valid length of sense data */
+		rc = camtape_ioctlrc2err(priv, fd , &sense_data, /*control_cmd*/ 0, &msg);
+
+		if (scsi_get_stream_info(&sense_data, sizeof(sense_data), &priv->cd->inq_data,
+								 &stream_bits) != 0) {
+			stream_bits = 0;
+		}
+
+		switch (rc) {
+		case -EDEV_NO_SENSE:
+			if (stream_bits & SSD_FILEMARK) {
+				/* Filemark Detected */
+				ltfsmsg(LTFS_DEBUG, 30436D);
+				rc = DEVICE_GOOD;
+				pos->block++;
+				pos->filemarks++;
+				len = 0;
+			}
+			else if (stream_bits & SSD_ILI) {
+				/* Illegal Length */
+				int64_t diff_len;
+				uint64_t unsigned_diff_len;
+
+				/* XXX KDM need to get the real length of the sense data */
+				if (scsi_get_sense_info(&sense_data, sizeof(sense_data), SSD_DESC_INFO,
+					&unsigned_diff_len, &diff_len) != 0) {
+
+					/* XXX KDM what do we do if there is no info field? */
+					diff_len = 0;
+				}
+
+				if (diff_len < 0) {
+					ltfsmsg(LTFS_INFO, 30437I, diff_len, count - diff_len); // "Detect overrun condition"
+					rc = -EDEV_OVERRUN;
+				}
+				else {
+					ltfsmsg(LTFS_DEBUG, 30438D, diff_len, count - diff_len); // "Detect underrun condition"
+					len = count - diff_len;
+					rc = DEVICE_GOOD;
+					pos->block++;
+				}
+			}
+			else if (errno == EOVERFLOW) {
+				ltfsmsg(LTFS_INFO, 30437I, count - read_len, read_len); // "Detect overrun condition"
+				rc = -EDEV_OVERRUN;
+			}
+			else if ((size_t)read_len < count) {
+				ltfsmsg(LTFS_DEBUG, 30438D, count - read_len, read_len); // "Detect underrun condition"
+				len = read_len;
+				rc = DEVICE_GOOD;
+				pos->block++;
+			}
+			break;
+		case -EDEV_FILEMARK_DETECTED:
+			ltfsmsg(LTFS_DEBUG, 30436D);
+			rc = DEVICE_GOOD;
+			pos->block++;
+			pos->filemarks++;
+			len = 0;
+			break;
+		}
+
+		if (rc != DEVICE_GOOD) {
+			if ((rc != -EDEV_CRYPTO_ERROR && rc != -EDEV_KEY_REQUIRED) || ((struct camtape_data *) device)->is_data_key_set) {
+				ltfsmsg(LTFS_INFO, 30408I, "READ", count, rc, errno, ((struct camtape_data *) device)->drive_serial);
+				camtape_process_errors(device, rc, msg, "read", true);
+			}
+			len = rc;
+		}
+	}
+	else {
+		len = silion ? read_len : (ssize_t)datacount;
+		pos->block++;
+	}
+
+	if(global_data.crc_checking && len > 4) {
+		if (priv->f_crc_check)
+			len = priv->f_crc_check(buf, len - 4);
+		if (len < 0) {
+			ltfsmsg(LTFS_ERR, 30439E);
+			len = -EDEV_LBP_READ_ERROR;
+		}
+	}
+
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_READ));
+	return len;
+}
+
+/**
+ * Write a record to tape
+ * When the drive detect early warning condition, this function will return {-ENOSPC, true}
+ *
+ * @param device a pointer to the camtape backend
+ * @param buf a pointer to read buffer
+ * @param count write size
+ * @param pos a pointer to position data. This function will update position infomation.
+ * @param unusual_size a flag specified unusual size or not
+ * @return rc 0 on success or a negative value on error
+ */
+int camtape_write(void *device, const char *buf, size_t count, struct tc_position *pos)
+{
+	int rc = -1;
+	ssize_t written;
+	char *msg = NULL;
+	struct scsi_sense_data sense_data;
+	int write_retry_done = 0;
+
+	struct camtape_data *priv = (struct camtape_data *) device;
+	int    fd = priv->fd_sa;
+	size_t     datacount = count;
+
+	/*
+	 * TODO: Check count is smaller than max of SSIZE_MAX
+	 *       The prototype of write system call is
+	 *       ssize_t write(int fd, const void *buf, size_t count);
+	 */
+
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_WRITE));
+	ltfsmsg(LTFS_DEBUG, 30595D, "write", count, ((struct camtape_data *) device)->drive_serial);
+
+	if ( priv->force_writeperm ) {
+		priv->write_counter++;
+		if ( priv->write_counter > priv->force_writeperm ) {
+			ltfsmsg(LTFS_INFO, 30434I, "write");
+			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_WRITE));
+			if (priv->force_errortype)
+				return -EDEV_NO_SENSE;
+			else
+				return -EDEV_WRITE_PERM;
+		} else if ( priv->write_counter > (priv->force_writeperm - THRESHOLD_FORCE_WRITE_NO_WRITE)) {
+			ltfsmsg(LTFS_INFO, 30435I);
+			pos->block++;
+			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_WRITE));
+			return DEVICE_GOOD;
+		}
+	}
+
+
+	/* Invoke _ioctl to Write */
+	if(global_data.crc_checking) {
+		if (priv->f_crc_enc)
+			priv->f_crc_enc((void *)buf, count);
+		datacount = count + 4;
+	}
+
+retry_write:
+
+	errno = 0;
+
+	/*
+	 * Note that we assume here that our write cannot be broken into multiple pieces.  If it
+	 * can, then we may have indeterminate results because it isn't possible to get both an
+	 * error and a residual count here.  We get one or the other.
+	 */
+	written = write(fd, buf, datacount);
+	if ((size_t)written != datacount) {
+		ltfsmsg(LTFS_INFO, 30408I, "WRITE", count, written, errno, priv->drive_serial);
+
+		if (written == -1) {
+			/*
+			 * We only get an error when a write actually fails.  The Linux backend also checks
+			 * for ENOMEM and retries a number of times.  Note that ENOMEM is returned for
+			 * memory allocation failures inside the Linux kernel, and isn't returned for I/O
+			 * failures from the tape drive.  In FreeBSD, if any memory allocation is needed in
+			 * the write path, we do a blocking allocation that will sleep until it has memory.
+			 * So, the only failures we'll see here are failures that come from the tape drive.
+			 */
+			rc = camtape_ioctlrc2err(priv, fd , &sense_data, /*control_cmd*/ 0, &msg);
+		} else {
+			/*
+			 * Short write.  This means that we hit early warning.  Grab the position to see
+			 * what actually happened, and then retry the write.  If we've already done one
+			 * retry, try to grab the sense data and return an error from that.
+			 */
+			camtape_readpos(device, pos);
+			if (write_retry_done == 0) {
+				write_retry_done = 1;
+				goto retry_write;
+			} else
+				rc = camtape_ioctlrc2err(priv, fd , &sense_data, /*control_cmd*/ 0, &msg);
+		}
+
+		if (rc != DEVICE_GOOD)
+			camtape_process_errors(device, rc, msg, "write", true);
+
+		if (rc == -EDEV_LBP_WRITE_ERROR)
+			ltfsmsg(LTFS_ERR, 30477E);
+	} else {
+		rc = DEVICE_GOOD;
+		pos->block++;
+	}
+
+	((struct camtape_data *) device)->dirty_acq_loss_w = true;
+
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_WRITE));
+	return rc;
+}
+
+/**
+ * Write filemark(s) to tape
+ * @param device a pointer to the camtape backend
+ * @param count count to write filemark. If 0 only flush.
+ * @param pos a pointer to position data. This function will update position infomation.
+ * @return rc 0 on success or a negative value on error
+ */
+int camtape_writefm(void *device, size_t count, struct tc_position *pos, bool immed)
+{
+	int rc = -1;
+	char *msg = NULL;
+	size_t written_count;
+	tape_filemarks_t cur_fm = pos->filemarks;
+	struct camtape_data *priv = (struct camtape_data *) device;
+
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_WRITEFM));
+	ltfsmsg(LTFS_DEBUG, 30596D, "writefm", count, priv->drive_serial);
+
+start_wfm:
+	errno = 0;
+	rc = _mt_command(device, immed ? MTWEOFI : MTWEOF, "WRITE FM", count, &msg);
+	camtape_readpos(device, pos);
+
+	if (rc != DEVICE_GOOD) {
+		switch (rc) {
+		case -EDEV_EARLY_WARNING:
+			ltfsmsg(LTFS_WARN, 30445W, "writefm");
+			rc = DEVICE_GOOD;
+			pos->early_warning = true;
+			break;
+		case -EDEV_PROG_EARLY_WARNING:
+			ltfsmsg(LTFS_WARN, 30446W, "writefm");
+			rc = DEVICE_GOOD;
+			pos->programmable_early_warning = true;
+			break;
+		case -EDEV_CONFIGURE_CHANGED:
+			written_count = pos->filemarks - cur_fm;
+			if (count != written_count) {
+				/* need to write fm again */
+				count = count - written_count;
+				cur_fm = pos->filemarks;
+				goto start_wfm;
+			}
+			break;
+		default:
+			if (pos->early_warning) {
+				ltfsmsg(LTFS_WARN, 30445W, "writefm");
+				rc = DEVICE_GOOD;
+			}
+			if (pos->programmable_early_warning) {
+				ltfsmsg(LTFS_WARN, 30446W, "writefm");
+				rc = DEVICE_GOOD;
+			}
+			break;
+		}
+
+		if (rc != DEVICE_GOOD) {
+			camtape_process_errors(device, rc, msg, "writefm", true);
+		}
+	} else {
+		if (pos->early_warning) {
+			ltfsmsg(LTFS_WARN, 30445W, "writefm");
+			rc = DEVICE_GOOD;
+		}
+		if (pos->programmable_early_warning) {
+			ltfsmsg(LTFS_WARN, 30446W, "writefm");
+			rc = DEVICE_GOOD;
+		}
+	}
+
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_WRITEFM));
+	return rc;
+}
+
+/**
+ * Rewind tape
+ * @param device a pointer to the camtape backend
+ * @param pos a pointer to position data. This function will update position infomation.
+ * @return 0 on success or a negative value on error
+ */
+int camtape_rewind(void *device, struct tc_position *pos)
+{
+	int rc;
+	char *msg = NULL;
+	struct camtape_data *softc = device;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_REWIND));
+	ltfsmsg(LTFS_DEBUG, 30592D, "rewind", ((struct camtape_data *) device)->drive_serial);
+
+	rc = _mt_command(device, MTREW, "REWIND", 0, &msg);
+	camtape_readpos(device, pos);
+
+	if (rc != DEVICE_GOOD) {
+		camtape_process_errors(device, rc, msg, "rewind", true);
+	}
+
+	softc->force_writeperm = DEFAULT_WRITEPERM;
+	softc->force_readperm  = DEFAULT_READPERM;
+	softc->write_counter = 0;
+	softc->read_counter = 0;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REWIND));
+	return rc;
+}
+
+/**
+ * Locate to position on tape
+ * @param device a pointer to the camtape backend
+ * @param dest a position data of destination.
+ * @param pos a pointer to position data. This function will update position infomation.
+ * @return rc 0 on success or a negative value on error
+ */
+int camtape_locate(void *device, struct tc_position dest, struct tc_position *pos)
+{
+	int rc;
+	char *msg = NULL;
+	struct camtape_data *softc = device;
+	struct scsi_sense_data sense_data;
+	struct mtlocate mtl;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOCATE));
+	ltfsmsg(LTFS_DEBUG, 30597D, "locate", (unsigned long long)dest.partition,
+		(unsigned long long)dest.block, softc->drive_serial);
+
+	bzero(&mtl, sizeof(mtl));
+
+	mtl.dest_type = MT_LOCATE_DEST_OBJECT;
+	mtl.block_address_mode = MT_LOCATE_BAM_IMPLICIT;
+	mtl.logical_id = dest.block;
+	mtl.partition = dest.partition;
+	if (pos->partition != dest.partition) { 
+		mtl.flags |= MT_LOCATE_FLAG_CHANGE_PART;
+
+		softc->force_writeperm = DEFAULT_WRITEPERM;
+		softc->force_readperm  = DEFAULT_READPERM;
+		softc->write_counter = 0;
+		softc->read_counter  = 0;
+	}
+
+	rc = ioctl(softc->fd_sa, MTIOCEXTLOCATE, (caddr_t)&mtl);
+	if (rc != 0) {
+		rc = camtape_ioctlrc2err(softc, softc->fd_sa, &sense_data, /*control_cmd*/ 1, &msg);
+	} else {
+		rc = DEVICE_GOOD;
+	} 	
+
+	if (rc != DEVICE_GOOD) {
+		if ((unsigned long long)dest.block == TAPE_BLOCK_MAX && rc == -EDEV_EOD_DETECTED) {
+			ltfsmsg(LTFS_DEBUG, 30448D, "Locate");
+			rc = DEVICE_GOOD;
+		}
+
+		if (rc != DEVICE_GOOD)
+			camtape_process_errors(device, rc, msg, "locate", true);
+	}
+
+	camtape_readpos(device, pos);
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOCATE));
+	return rc;
+}
+
+/**
+ * Space to position on tape
+ * @param device a pointer to the camtape backend
+ * @param count specify record or fm count to move
+ * @param type specify type of move
+ * @param pos a pointer to position data. This function will update position infomation.
+ * @return rc 0 on success or a negative value on error
+ */
+int camtape_space(void *device, size_t count, TC_SPACE_TYPE type, struct tc_position *pos)
+{
+	int cmd;
+	int rc;
+	char *msg = NULL;
+	struct camtape_data *softc = device;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_SPACE));
+	switch (type) {
+		case TC_SPACE_EOD:
+			ltfsmsg(LTFS_DEBUG, 30592D, "space to EOD", ((struct camtape_data *) device)->drive_serial);
+			cmd = MTEOD;
+			count = 0;
+			break;
+		case TC_SPACE_FM_F:
+			ltfsmsg(LTFS_DEBUG, 30594D, "space forward file marks", (unsigned long long)count,
+					((struct camtape_data *) device)->drive_serial);
+			cmd = MTFSF;
+			break;
+		case TC_SPACE_FM_B:
+			ltfsmsg(LTFS_DEBUG, 30594D, "space back file marks", (unsigned long long)count,
+					((struct camtape_data *) device)->drive_serial);
+			cmd = MTBSF;
+			break;
+		case TC_SPACE_F:
+			ltfsmsg(LTFS_DEBUG, 30594D, "space forward records", (unsigned long long)count,
+					((struct camtape_data *) device)->drive_serial);
+			cmd = MTFSR;
+			break;
+		case TC_SPACE_B:
+			ltfsmsg(LTFS_DEBUG, 30594D, "space back records", (unsigned long long)count,
+					((struct camtape_data *) device)->drive_serial);
+			cmd = MTBSR;
+			break;
+		default:
+			/* unexpected space type */
+			ltfsmsg(LTFS_INFO, 30449I);
+			ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SPACE));
+			return EDEV_INVALID_ARG;
+	}
+
+	if ((unsigned long long)count > 0xFFFFFF) {
+		/* count is too large for SPACE 6 command */
+		ltfsmsg(LTFS_INFO, 30450I, count);
+		ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SPACE));
+		return EDEV_INVALID_ARG;
+	}
+
+	rc = _mt_command(device, cmd, "SPACE", count, &msg);
+	camtape_readpos(device, pos);
+
+	if (rc != DEVICE_GOOD) {
+		camtape_process_errors(device, rc, msg, "space", true);
+	}
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SPACE));
+	return rc;
+}
+
+int camtape_long_erase(void *device)
+{
+	int rc;
+	union ccb *ccb = NULL;
+	struct camtape_data *softc = device;
+	char *msg;
+	int timeout;
+
+	ccb = cam_getccb(softc->cd);
+	if (ccb == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+
+	bzero(&(&ccb->ccb_h)[1],
+		sizeof(struct ccb_scsiio) - sizeof(struct ccb_hdr));
+
+	timeout = camtape_get_timeout(softc->timeouts, ERASE);
+	if (timeout < 0) {
+		rc = -EDEV_UNSUPPORETD_COMMAND;
+		goto bailout;
+	}
+
+	scsi_erase(&ccb->csio,
+			   /*retries*/ 1,
+			   /*cbfcnp*/ NULL,
+			   /*tag_action*/ MSG_SIMPLE_Q_TAG,
+			   /*immediate*/ 1,
+			   /*long_erase*/ 1,
+			   /*sense_len*/ SSD_FULL_SIZE,
+			   /*timeout*/ timeout);
+
+	ccb->ccb_h.flags |= CAM_DEV_QFRZDIS | CAM_PASS_ERR_RECOVER;
+
+	rc = camtape_send_ccb(softc, ccb, &msg);
+
+	if (rc != DEVICE_GOOD)
+		camtape_process_errors(softc, rc, msg, "long erase", true);
+
+bailout:
+	if (ccb != NULL)
+		cam_freeccb(ccb);
+
+	return rc;
+}
+
+/**
+ * Erase tape from current position
+ * @param device a pointer to the camtape backend
+ * @param pos a pointer to position data. This function will update position infomation.
+ * @param long_erase Set long bit and immed bit ON.
+ * @return 0 on success or a negative value on error
+ */
+int camtape_erase(void *device, struct tc_position *pos, bool long_erase)
+{
+	int rc;
+	char *msg = NULL;
+	struct ltfs_timespec ts_start, ts_now;
+	struct camtape_data *softc = device;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_ERASE));
+
+	if (long_erase) {
+		ltfsmsg(LTFS_DEBUG, 30592D, "long erase", softc->drive_serial);
+		get_current_timespec(&ts_start);
+
+		rc = camtape_long_erase(device);
+
+		if (rc == -EDEV_TIME_STAMP_CHANGED) {
+			ltfsmsg(LTFS_DEBUG, 30411D, "erase", -1, rc);
+			rc = camtape_long_erase(device);
+		}
+
+		if (rc != -EDEV_OPERATION_IN_PROGRESS)
+			goto bailout;
+
+		while (true) {
+			struct scsi_sense_data sense_data;
+			int fill_len = 0;
+
+			bzero(&sense_data, sizeof(sense_data));
+			rc = camtape_request_sense(device, &sense_data, sizeof(sense_data), &fill_len);
+			if (rc != -EDEV_OPERATION_IN_PROGRESS)
+				goto bailout;
+
+			if (IS_ENTERPRISE(softc->drive_type)) {
+				get_current_timespec(&ts_now);
+				ltfsmsg(LTFS_INFO, 30451I, (ts_now.tv_sec - ts_start.tv_sec)/60);
+			} else {
+				struct scsi_sense_sks_progress prog;
+
+				bzero(&prog, sizeof(prog));
+				rc = scsi_get_sks(&sense_data, fill_len, (uint8_t *)&prog);
+				if (rc == 0) {
+					int progress;
+
+					progress = scsi_2btoul(prog.progress);
+
+					ltfsmsg(LTFS_INFO, 30452I, progress*100/0xFFFF);
+				} else {
+					rc = 0;
+					goto bailout;
+				}
+			}
+			sleep(60);
+		}
+	} else {
+		ltfsmsg(LTFS_DEBUG, 30592D, "erase", softc->drive_serial);
+		rc = _mt_command(device, MTERASE, "ERASE", 0, &msg);	// param=0 means invoking short erase. (not long erase)
+	}
+
+bailout:
+
+	camtape_readpos(device, pos);
+
+	if (rc != DEVICE_GOOD) {
+		camtape_process_errors(device, rc, msg, "erase", true);
+	}
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_ERASE));
+	return rc;
+}
+
+/**
+ * Load tape or rewind when a tape is already loaded
+ * @param device a pointer to the camtape backend
+ * @param pos a pointer to position data. This function will update position infomation.
+ * @return 0 on success or a negative value on error
+ */
+
+int _camtape_load_unload(void *device, bool load, struct tc_position *pos)
+{
+	int rc;
+	char *msg = NULL;
+	bool take_dump = true;
+	struct camtape_data *priv = ((struct camtape_data *) device);
+
+	if (load) {
+		rc = _mt_command(device, MTLOAD, "LOAD", 0, &msg);
+	}
+	else {
+		rc = _mt_command(device, MTOFFL, "UNLOAD", 0, &msg);
+	}
+
+	if (rc != DEVICE_GOOD) {
+		switch (rc) {
+		case -EDEV_LOAD_UNLOAD_ERROR:
+			if (priv->loadfailed) {
+				take_dump = false;
+			}
+			else {
+				priv->loadfailed = true;
+			}
+			break;
+		case -EDEV_NO_MEDIUM:
+		case -EDEV_BECOMING_READY:
+		case -EDEV_MEDIUM_MAY_BE_CHANGED:
+			take_dump = false;
+			break;
+		default:
+			break;
+		}
+		camtape_readpos(device, pos);
+		camtape_process_errors(device, rc, msg, "load unload", take_dump);
+	}
+	else {
+		if (load) {
+			camtape_readpos(device, pos);
+			priv->tape_alert = 0;
+		}
+		else {
+			pos->partition = 0;
+			pos->block = 0;
+			priv->tape_alert = 0;
+		}
+		priv->loadfailed = false;
+	}
+
+	return rc;
+}
+
+int camtape_load(void *device, struct tc_position *pos)
+{
+	int rc;
+	unsigned char buf[TC_MP_SUPPORTEDPAGE_SIZE];
+	struct camtape_data *softc = device;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOAD));
+	ltfsmsg(LTFS_DEBUG, 30592D, "load", softc->drive_serial);
+
+	rc = _camtape_load_unload(device, true, pos);
+	if (rc < 0) {
+		ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOAD));
+		return rc;
+	}
+
+	/* Check Cartridge type */
+	rc = camtape_modesense(device, TC_MP_SUPPORTEDPAGE, TC_MP_PC_CURRENT, 0x00, buf, sizeof(buf));
+	if (rc < 0) {
+		ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOAD));
+		return rc;
+	}
+
+	softc->loaded = true;
+	softc->is_worm = false;
+
+	softc->force_writeperm = DEFAULT_WRITEPERM;
+	softc->force_readperm  = DEFAULT_READPERM;
+	softc->write_counter = 0;
+	softc->read_counter = 0;
+	softc->cart_type = buf[2];
+	softc->density_code = buf[8];
+
+	if (softc->cart_type == 0x00) {
+		ltfsmsg(LTFS_WARN, 30453W);
+		ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOAD));
+		return 0;
+	}
+
+	rc = ibm_tape_is_supported_tape(softc->cart_type, softc->density_code, &(softc->is_worm));
+	if(rc == -LTFS_UNSUPPORTED_MEDIUM)
+		ltfsmsg(LTFS_INFO, 30455I, softc->cart_type, softc->density_code);
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOAD));
+
+	return rc;
+}
+
+/**
+ * Unload tape
+ * @param device a pointer to the camtape backend
+ * @param pos a pointer to position data. This function will update position infomation.
+ * @return 0 on success or a negative value on error
+ */
+int camtape_unload(void *device, struct tc_position *pos)
+{
+	int rc;
+	struct camtape_data *softc = device;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_UNLOAD));
+	ltfsmsg(LTFS_DEBUG, 30592D, "unload", softc->drive_serial);
+
+	rc = _camtape_load_unload(device, false, pos);
+
+	softc->force_writeperm = DEFAULT_WRITEPERM;
+	softc->force_readperm = DEFAULT_READPERM;
+	softc->write_counter = 0;
+	softc->read_counter = 0;
+
+	if (rc < 0) {
+		ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_UNLOAD));
+		return rc;
+	} else {
+		((struct camtape_data *)device)->loaded = false;
+		((struct camtape_data *)device)->is_worm = false;
+		ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_UNLOAD));
+		return rc;
+	}
+}
+
+/*
+ * Get the number of blocks in the buffer on the tape drive after a write.  Eventually it would
+ * be nice to include this in status information returned from the sa(4) driver.
+ */
+static int camtape_get_block_in_buffer(void *device, uint32_t *block)
+{
+	int rc;
+	union ccb *ccb = NULL;
+	struct camtape_data *softc = device;
+	struct scsi_tape_position_ext_data ext_data;
+	int timeout;
+	char *msg;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_READPOS));
+
+	ccb = cam_getccb(softc->cd);
+	if (ccb == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+	CCB_CLEAR_ALL_EXCEPT_HDR(ccb);
+	bzero(&ext_data, sizeof(ext_data));
+
+	timeout = camtape_get_timeout(softc->timeouts, READ_POSITION);
+	if (timeout < 0) {
+		rc = -EDEV_UNSUPPORETD_COMMAND;
+		goto bailout;
+	}
+
+
+	/*
+	 * XXX KDM should we do any retries here?  Doing retries potentially hides sense data.
+	 */
+	scsi_read_position_10(&ccb->csio,
+						  /*retries*/ 0,
+						  /*cbfcnp*/ NULL,
+						  /*tag_action*/ MSG_SIMPLE_Q_TAG,
+						  /*service_action*/ SA_RPOS_EXTENDED_FORM,
+						  /*data_ptr*/ (uint8_t *)&ext_data,
+						  /*length*/ sizeof(ext_data),
+						  /*sense_len*/ SSD_FULL_SIZE,
+						  /*timeout*/ timeout);
+
+	ccb->ccb_h.flags |= CAM_DEV_QFRZDIS;
+	rc = camtape_send_ccb(softc, ccb, &msg);
+
+	if (rc != DEVICE_GOOD)
+		camtape_process_errors(softc, rc, msg, "READPOS", true);
+	else {
+		*block = scsi_3btoul(ext_data.num_objects);
+		ltfsmsg(LTFS_DEBUG, 30398D, "blocks-in-buffer",
+				(unsigned long long) *block, 0, 0, softc->drive_serial);
+	}
+
+
+bailout:
+	if (ccb != NULL)
+		cam_freeccb(ccb);
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_READPOS));
+
+	return rc;
+}
+
+static int camtape_load_attr(struct mt_status_data *mtinfo, xmlDocPtr doc, xmlAttr *attr,
+    int level, char **msg)
+{
+	struct mt_status_entry *entry;
+	xmlAttr *xattr = NULL;
+	int retval = DEVICE_GOOD;
+
+	entry = mtinfo->cur_entry[mtinfo->level];
+
+	for (xattr = attr; xattr != NULL; xattr = xattr->next) {
+		if (xattr->type == XML_ATTRIBUTE_NODE) {
+			struct mt_status_nv *nv;
+			int need_nv = 0, need_free = 1;
+			char *str;
+
+			str = (char *)xmlNodeListGetString(doc, xattr->children, 1);
+			if (strcmp((char *)xattr->name, "size") == 0) {
+				entry->size = strtoull(str, NULL, 0);
+			} else if (strcmp((char *)xattr->name, "type") == 0) {
+				if (strcmp(str, "int") == 0) {
+					entry->var_type = MT_TYPE_INT;
+				} else if (strcmp(str, "uint") == 0) {
+					entry->var_type = MT_TYPE_UINT;
+				} else if (strcmp(str, "str") == 0) {
+					entry->var_type = MT_TYPE_STRING;
+				} else if (strcmp(str, "node") == 0) {
+					entry->var_type = MT_TYPE_NODE;
+				} else {
+					need_nv = 1;
+				}
+			} else if (strcmp((char *)xattr->name, "fmt") == 0) {
+				entry->fmt = str;
+				need_free = 0;
+			} else if (strcmp((char *)xattr->name, "desc") == 0) {
+				entry->desc = str;
+				need_free = 0;
+			} else {
+				need_nv = 1;
+			}
+			if (need_nv != 0) {
+				nv = malloc(sizeof(*nv));
+				if (nv == NULL) {
+					*msg = strdup("Unable to allocate memory");
+					retval = -EDEV_NO_MEMORY;
+					goto bailout;
+				}
+				bzero(nv, sizeof(*nv));
+				nv->name = strdup((char *)xattr->name);
+				nv->value = str;
+				STAILQ_INSERT_TAIL(&entry->nv_list, nv, links);
+				need_free = 0;
+			}
+			if (need_free != 0)
+				xmlFree(str);
+		}
+	}
+bailout:
+
+	return (retval);
+}
+
+static int camtape_load_elements(struct mt_status_data *mtinfo, xmlDocPtr doc, xmlNode *node,
+    int level, char **msg)
+{
+	struct mt_status_entry *entry;
+	xmlNode *xnode = NULL;
+	int retval = DEVICE_GOOD;
+
+	for (xnode = node; xnode != NULL; xnode = xnode->next) {
+		int created_element = 0;
+
+		if (xnode->type == XML_ELEMENT_NODE) {
+			mtinfo->level++;
+			if ((u_int)mtinfo->level > sizeof(mtinfo->cur_entry) /
+			    sizeof(mtinfo->cur_entry[0])) {
+				*msg = strdup("Too many nesting levels");
+				retval = -EDEV_INVALID_ARG;
+				goto bailout;
+			}
+			created_element = 1;
+			entry = malloc(sizeof(*entry));
+			if (entry == NULL) {
+				*msg = strdup("Unable to allocate memory");
+				retval = -EDEV_NO_MEMORY;
+				goto bailout;
+			}
+			bzero(entry, sizeof(*entry)); 
+			STAILQ_INIT(&entry->nv_list);
+			STAILQ_INIT(&entry->child_entries);
+			entry->entry_name = strdup((char *)xnode->name);
+			mtinfo->cur_entry[mtinfo->level] = entry;
+			if (mtinfo->cur_entry[mtinfo->level - 1] == NULL) {
+				STAILQ_INSERT_TAIL(&mtinfo->entries, entry, links);
+			} else {
+				STAILQ_INSERT_TAIL(
+				    &mtinfo->cur_entry[mtinfo->level - 1]->child_entries,
+				    entry, links);
+				entry->parent = mtinfo->cur_entry[mtinfo->level - 1];
+			}
+		} else if (xnode->type == XML_TEXT_NODE) {
+			char *str;
+
+
+			str = (char *)xmlNodeListGetString(doc, xnode, 1);
+
+			if (xmlIsBlankNode(xnode) != 0)
+				continue;
+
+			entry = mtinfo->cur_entry[mtinfo->level];
+
+			entry->value = str;
+			switch (entry->var_type) {
+			case MT_TYPE_INT:
+				entry->value_signed = strtoll(str, NULL, 0);
+				break;
+			case MT_TYPE_UINT:
+				entry->value_unsigned = strtoull(str, NULL, 0);
+				break;
+			default:
+				break;
+			}
+		}
+		if (xnode->properties != NULL) {
+			retval = camtape_load_attr(mtinfo, doc, xnode->properties, level, msg);
+			if (retval != DEVICE_GOOD)
+				goto bailout;
+		}
+		retval = camtape_load_elements(mtinfo, doc, xnode->children, level + 1, msg);
+		if (retval != DEVICE_GOOD)
+			goto bailout;
+
+		if (created_element != 0) {
+			mtinfo->cur_entry[mtinfo->level] = NULL;
+			mtinfo->level--;
+		}
+	}
+
+bailout:
+	return (retval);
+}
+
+int camtape_get_mtinfo(struct camtape_data *softc, struct mt_status_data *mtinfo, int params,
+    char **msg)
+{
+	struct mtextget extget;
+	int alloc_size = 32768;
+	xmlParserCtxtPtr ctx = NULL;
+	xmlDocPtr doc = NULL;
+	xmlNode *root_element = NULL;
+	char *xml_str = NULL;
+	int retval = DEVICE_GOOD;
+
+extget_retry:
+
+	bzero(&extget, sizeof(extget));
+	xml_str = malloc(alloc_size);
+	if (xml_str == NULL) {
+		*msg = strdup("Unable to allocate memory");
+		retval = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+	extget.status_xml = xml_str;
+	extget.alloc_len = alloc_size;
+
+	if (ioctl(softc->fd_sa, (params != 0) ? MTIOCPARAMGET : MTIOCEXTGET, &extget) == -1) {
+		char tmpstr[512];
+
+		snprintf(tmpstr, sizeof(tmpstr), "ioctl error from sa(4) driver: %s",
+		    strerror(errno));
+		*msg = strdup(tmpstr);
+		retval = -errno;
+		goto bailout;
+	}
+
+	if (extget.status == MT_EXT_GET_NEED_MORE_SPACE) {
+		/*
+		 * The driver needs more space, so double
+		 * our allocation and try again.
+		 */
+		alloc_size *= 2;
+		free(xml_str);
+		xml_str = NULL;
+		goto extget_retry;
+	} else if (extget.status != MT_EXT_GET_OK) {
+		char tmpstr[512];
+
+		retval = -EDEV_DRIVER_ERROR;
+		snprintf(tmpstr, sizeof(tmpstr), "Error getting status data from sa(4) driver: status = %d",
+			extget.status);
+		*msg = strdup(tmpstr);
+		goto bailout;
+	}
+
+	LIBXML_TEST_VERSION;
+
+	ctx = xmlNewParserCtxt();
+	if (ctx == NULL) {
+		*msg = strdup("Unable to create new XML parser context");
+		retval = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+
+	doc = xmlCtxtReadMemory(ctx, xml_str, strlen(xml_str), NULL, NULL, 0);
+	if (doc == NULL) {
+		*msg = strdup("Unable to parse XML");
+		retval = -EDEV_DRIVER_ERROR;
+		goto bailout;
+	} else {
+		if (ctx->valid == 0) {
+			*msg = strdup("XML parsing result is: not valid");
+			retval = -EDEV_INVALID_ARG;
+			goto bailout;
+		}
+	}
+
+	root_element = xmlDocGetRootElement(doc);
+	bzero(mtinfo, sizeof(*mtinfo));
+	mtinfo->level = 1;
+	STAILQ_INIT(&mtinfo->entries);
+	retval = camtape_load_elements(mtinfo, doc, root_element, 0, msg);
+
+bailout:
+
+	if (xml_str != NULL)
+		free(xml_str);
+	if (doc != NULL)
+		xmlFreeDoc(doc);
+	if (ctx != NULL)
+		xmlFreeParserCtxt(ctx);
+
+	return (retval);
+}
+
+int camtape_free_mtinfo(struct camtape_data *softc, struct mt_status_data *mtinfo)
+{
+	mt_status_free(mtinfo);
+
+	return (DEVICE_GOOD);
+}
+
+typedef enum {
+	MT_REPORTED_FILENO 	= 0,
+	MT_REPORTED_BLKNO	= 1,
+	MT_PARTITION		= 2,
+	MT_BOP				= 3,
+	MT_EOP				= 4,
+	MT_BPEW				= 5
+} camtape_status_index;
+
+struct camtape_status_item {
+	const char *name;
+	struct mt_status_entry *entry;
+} req_status_items[] = {
+	{"reported_fileno", NULL },
+	{"reported_blkno", NULL },
+	{"partition", NULL },
+	{"bop", NULL },
+	{"eop", NULL },
+	{"bpew", NULL}
+};
+#define	CT_NUM_STATUS_ITEMS	(sizeof(req_status_items)/sizeof(req_status_items[0]))
+
+int camtape_getstatus(struct camtape_data *softc, struct mt_status_data *mtinfo,
+    struct camtape_status_item *status_items, int num_status_items, char **msg)
+{
+	int retval = DEVICE_GOOD;
+	int i;
+
+	retval = camtape_get_mtinfo(softc, mtinfo, /*params*/ 0, msg);
+	if (retval != DEVICE_GOOD)
+		goto bailout;
+
+	for (i = 0; i < num_status_items; i++) {
+		char *name;
+
+		name = __DECONST(char *, status_items[i].name);
+		status_items[i].entry = mt_status_entry_find(mtinfo, name);
+		if (status_items[i].entry == NULL) {
+			char tmpstr[512];
+
+			snprintf(tmpstr, sizeof(tmpstr), "Unable to fetch sa(4) status item %s", name);
+			*msg = strdup(tmpstr);
+			retval = -EDEV_INVALID_ARG;
+			goto bailout;
+		}
+	}
+
+bailout:
+	return (retval);
+}
+
+/**
+ * Tell the current position
+ * @param device a pointer to the camtape backend
+ * @param pos a pointer to position data. This function will update position infomation.
+ * @return 0 on success or a negative value on error
+ */
+int camtape_readpos(void *device, struct tc_position *pos)
+{
+	struct camtape_data *softc = device;
+	int rc = DEVICE_GOOD;
+	char *msg = NULL;
+	struct camtape_status_item status_items[CT_NUM_STATUS_ITEMS];
+	struct mt_status_data mtinfo;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_READPOS));
+
+	bzero(status_items, sizeof(status_items));
+	bzero(&mtinfo, sizeof(mtinfo));
+	bcopy(req_status_items, status_items, MIN(sizeof(status_items), sizeof(req_status_items)));
+
+	rc = camtape_getstatus(softc, &mtinfo, status_items, CT_NUM_STATUS_ITEMS, &msg);
+	if (rc != DEVICE_GOOD) {
+		camtape_process_errors(device, rc, msg, "readpos", true);
+		goto bailout;
+	}
+
+	if (status_items[MT_EOP].entry->value_signed == 0)
+		pos->early_warning = false;
+	else if (status_items[MT_EOP].entry->value_signed == 1)
+		pos->early_warning = true;
+
+	if (status_items[MT_BPEW].entry->value_signed == 0)
+		pos->programmable_early_warning = false;
+	else if (status_items[MT_BPEW].entry->value_signed == 1)
+		pos->programmable_early_warning = true;
+	pos->partition = status_items[MT_PARTITION].entry->value_signed;
+	pos->block = status_items[MT_REPORTED_BLKNO].entry->value_signed;
+	pos->filemarks = status_items[MT_REPORTED_FILENO].entry->value_signed;
+
+	ltfsmsg(LTFS_DEBUG, 30598D, "readpos", (unsigned long long)pos->partition,
+			(unsigned long long)pos->block, (unsigned long long)pos->filemarks,
+			softc->drive_serial);
+bailout:
+
+	camtape_free_mtinfo(softc, &mtinfo);
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_READPOS));
+
+	return rc;
+}
+
+/**
+ * Make/Unmake partition
+ * @param device a pointer to the camtape backend
+ * @param format specify type of format
+ * @return 0 on success or a negative value on error
+ */
+int camtape_format(void *device, TC_FORMAT_TYPE format)
+{
+	int rc, aux_rc;
+	char *msg = NULL;
+	struct camtape_data *softc = device;
+	unsigned char buf[TC_MP_SUPPORTEDPAGE_SIZE];
+	union ccb *ccb = NULL;
+	int timeout;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_FORMAT));
+	ltfsmsg(LTFS_DEBUG, 30592D, "format", softc->drive_serial);
+
+	if ((unsigned char) format >= (unsigned char) TC_FORMAT_MAX) {
+		ltfsmsg(LTFS_INFO, 30456I, format);
+		ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_FORMAT));
+		return -1;
+	}
+
+	ccb = cam_getccb(softc->cd);
+	if (ccb == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+
+	bzero(&(&ccb->ccb_h)[1],
+		sizeof(struct ccb_scsiio) - sizeof(struct ccb_hdr));
+
+	timeout = camtape_get_timeout(softc->timeouts, FORMAT_MEDIUM);
+	if (timeout < 0) {
+		rc = -EDEV_UNSUPPORETD_COMMAND;
+		goto bailout;
+	}
+
+	scsi_format_medium(&ccb->csio,
+					   /*retries*/ 1,
+					   /*cbfcnp*/ NULL,
+					   /*tag_action*/ MSG_SIMPLE_Q_TAG,
+					   /*byte1*/ 0,
+					   /*byte2*/ format,
+					   /*data_ptr*/ NULL,
+					   /*dxfer_len*/ 0,
+					   /*sense_len*/ SSD_FULL_SIZE,
+					   /*timeout*/ timeout);
+
+	ccb->ccb_h.flags |= CAM_DEV_QFRZDIS | CAM_PASS_ERR_RECOVER;
+
+	rc = camtape_send_ccb(softc, ccb, &msg);
+
+	if (rc != DEVICE_GOOD) {
+		camtape_process_errors(device, rc, msg, "format", true);
+		goto bailout;
+	}
+
+	aux_rc = camtape_modesense(device, TC_MP_SUPPORTEDPAGE, TC_MP_PC_CURRENT, 0x00, buf, sizeof(buf));
+	if (aux_rc == DEVICE_GOOD) {
+		softc->cart_type = buf[2];
+		softc->density_code = buf[8];
+	}
+bailout:
+	if (ccb != NULL)
+		cam_freeccb(ccb);
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_FORMAT));
+	return rc;
+}
+
+/**
+ * Tell log data from the drive
+ * @param device a pointer to the camtape backend
+ * @param page page code of log sense
+ * @param buf pointer to buffer to store log data
+ * @param size length of the buffer
+ * @return 0 on success or a negative value on error
+ */
+#define MAX_UINT16 (0x0000FFFF)
+
+int camtape_logsense_page(struct camtape_data *softc, const uint8_t page, const uint8_t subpage,
+						  unsigned char *buf, const size_t size)
+{
+	int rc = DEVICE_GOOD;
+	char *msg = NULL;
+	struct scsi_log_sense *scsi_cmd;
+	union ccb *ccb = NULL;
+	int timeout;
+
+	ltfsmsg(LTFS_DEBUG3, 30597D, "logsense", (unsigned long long)page, (unsigned long long)subpage,
+			softc->drive_serial);
+
+	ccb = cam_getccb(softc->cd);
+	if (ccb == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+
+	bzero(&(&ccb->ccb_h)[1],
+		sizeof(struct ccb_scsiio) - sizeof(struct ccb_hdr));
+
+	timeout = camtape_get_timeout(softc->timeouts, LOG_SENSE);
+	if (timeout < 0) {
+		rc = -EDEV_UNSUPPORETD_COMMAND;
+		goto bailout;
+	}
+
+	scsi_log_sense(&ccb->csio,
+				   /*retries*/ 1,
+				   /*cbfcnp*/ NULL,
+				   /*tag_action*/ MSG_SIMPLE_Q_TAG,
+				   /*page_code*/ page,
+				   /*page*/ SLS_PAGE_CTRL_CUMULATIVE,
+				   /*save_pages*/ 0,
+				   /*ppc*/ 0,
+				   /*paramptr*/ 0,
+				   /*param_buf*/ buf,
+				   /*param_len*/ size,
+				   /*sense_len*/ SSD_FULL_SIZE,
+				   /*timeout*/ timeout);
+	/*
+	 * XXX KDM need to add subpage to the log sense fill function.
+	 */
+	scsi_cmd = (struct scsi_log_sense *)&ccb->csio.cdb_io.cdb_bytes;
+	scsi_cmd->subpage = subpage;
+
+	ccb->ccb_h.flags |= CAM_DEV_QFRZDIS | CAM_PASS_ERR_RECOVER;
+
+	rc = camtape_send_ccb(softc, ccb, &msg);
+
+	if (rc != DEVICE_GOOD)
+		camtape_process_errors(softc, rc, msg, "logsense page", true);
+
+bailout:
+	if (ccb != NULL)
+		cam_freeccb(ccb);
+
+	return rc;
+}
+
+int camtape_logsense(void *device, const uint8_t page, unsigned char *buf, const size_t size)
+{
+	struct camtape_data *softc = device;
+	int ret = 0;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOGSENSE));
+	ret = camtape_logsense_page(softc, page, 0, buf, size);
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOGSENSE));
+	return ret;
+}
+
+#define PARTITIOIN_REC_HEADER_LEN (4)
+
+int camtape_remaining_capacity(void *device, struct tc_remaining_cap *cap)
+{
+	unsigned char logdata[LOGSENSEPAGE];
+	unsigned char buf[32];
+	struct camtape_data *softc = device;
+	int param_size, i;
+	int length;
+	int offset;
+	uint32_t logcap;
+	int rc;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_REMAINCAP));
+	if (IS_LTO(softc->drive_type) && (DRIVE_GEN(softc->drive_type) == 0x05)) {
+		/* Issue LogPage 0x31 */
+		rc = camtape_logsense(device, LOG_TAPECAPACITY, logdata, LOGSENSEPAGE);
+		if (rc) {
+			ltfsmsg(LTFS_INFO, 30457I, LOG_TAPECAPACITY, rc);
+			ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REMAINCAP));
+			return rc;
+		}
+
+		for(i = TAPECAP_REMAIN_0; i < TAPECAP_SIZE; i++) {
+			if (parse_logPage(logdata, (uint16_t) i, &param_size, buf, sizeof(buf))
+				|| param_size != sizeof(uint32_t)) {
+				ltfsmsg(LTFS_INFO, 30458I);
+				ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REMAINCAP));
+				return -EDEV_NO_MEMORY;
+			}
+
+			logcap = ltfs_betou32(buf);
+
+			switch (i) {
+			case TAPECAP_REMAIN_0:
+				cap->remaining_p0 = logcap;
+				break;
+			case TAPECAP_REMAIN_1:
+				cap->remaining_p1 = logcap;
+				break;
+			case TAPECAP_MAX_0:
+				cap->max_p0 = logcap;
+				break;
+			case TAPECAP_MAX_1:
+				cap->max_p1 = logcap;
+				break;
+			default:
+				ltfsmsg(LTFS_INFO, 30459I, i);
+				ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REMAINCAP));
+				return -EDEV_INVALID_ARG;
+				break;
+			}
+		}
+	}
+	else {
+		/* Issue LogPage 0x17 */
+		rc = camtape_logsense(device, LOG_VOLUMESTATS, logdata, LOGSENSEPAGE);
+		if (rc) {
+			ltfsmsg(LTFS_INFO, 30457I, LOG_VOLUMESTATS, rc);
+			ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REMAINCAP));
+			return rc;
+		}
+
+		/* parse param 0x202 - nominal capacity of the partitions */
+		if (parse_logPage(logdata, (uint16_t)VOLSTATS_PARTITION_CAP, &param_size, buf, sizeof(buf))) {
+			ltfsmsg(LTFS_INFO, 30458I);
+			ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REMAINCAP));
+			return -EDEV_NO_MEMORY;
+		}
+
+		memset(cap, 0, sizeof(struct tc_remaining_cap));
+
+		cap->max_p0 = ltfs_betou32(&buf[PARTITIOIN_REC_HEADER_LEN]);
+		offset = (int)buf[0] + 1;
+		length = (int)buf[offset] + 1;
+
+		if (offset + length <= param_size) {
+			cap->max_p1 = ltfs_betou32(&buf[offset + PARTITIOIN_REC_HEADER_LEN]);
+		}
+
+		/* parse param 0x204 - remaining capacity of the partitions */
+		if (parse_logPage(logdata, (uint16_t)VOLSTATS_PART_REMAIN_CAP, &param_size, buf, sizeof(buf))) {
+			ltfsmsg(LTFS_INFO, 30458I);
+			ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REMAINCAP));
+			return -EDEV_NO_MEMORY;
+		}
+
+		cap->remaining_p0 = ltfs_betou32(&buf[PARTITIOIN_REC_HEADER_LEN]);
+		offset = (int)buf[0] + 1;
+		length = (int)buf[offset] + 1;
+
+		if (offset + length <= param_size) {
+			cap->remaining_p1 = ltfs_betou32(&buf[offset + PARTITIOIN_REC_HEADER_LEN]);
+		}
+
+		/* Convert MB to MiB -- Need to consider about overflow when max cap reaches to 18EB */
+		cap->max_p0 = (cap->max_p0 * 1000 * 1000) >> 20;
+		cap->max_p1 = (cap->max_p1 * 1000 * 1000) >> 20;
+		cap->remaining_p0 = (cap->remaining_p0 * 1000 * 1000) >> 20;
+		cap->remaining_p1 = (cap->remaining_p1 * 1000 * 1000) >> 20;
+	}
+
+	ltfsmsg(LTFS_DEBUG3, 30597D, "capacity part0", (unsigned long long)cap->remaining_p0,
+			(unsigned long long)cap->max_p0, ((struct camtape_data *) device)->drive_serial);
+	ltfsmsg(LTFS_DEBUG3, 30597D, "capacity part1", (unsigned long long)cap->remaining_p1,
+		(unsigned long long)cap->max_p1, ((struct camtape_data *) device)->drive_serial);
+
+	return 0;
+}
+
+
+/**
+ * Get mode data
+ * @param device a pointer to the camtape backend
+ * @param page a page id of mode data
+ * @param pc page control value for mode sense command
+ * @param buf pointer to mode page data. this function will update this data
+ * @param size length of buf
+ * @return 0 on success or a negative value on error
+ */
+int camtape_modesense(void *device, const uint8_t page, const TC_MP_PC_TYPE pc, const uint8_t subpage,
+					  unsigned char *buf, const size_t size)
+{
+	int rc;
+	char *msg = NULL;
+	struct camtape_data *softc = device;
+	union ccb *ccb = NULL;
+	int timeout;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_MODESENSE));
+	ltfsmsg(LTFS_DEBUG3, 30593D, "modesense", page, softc->drive_serial);
+
+	ccb = cam_getccb(softc->cd);
+	if (ccb == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+
+	bzero(&(&ccb->ccb_h)[1],
+		sizeof(struct ccb_scsiio) - sizeof(struct ccb_hdr));
+
+	timeout = camtape_get_timeout(softc->timeouts, MODE_SENSE_10);
+	if (timeout < 0) {
+		rc = -EDEV_UNSUPPORETD_COMMAND;
+		goto bailout;
+	}
+
+	scsi_mode_sense_len(&ccb->csio,
+						/*retries*/ 1,
+						/*cbfcnp*/ NULL,
+						/*tag_action*/ MSG_SIMPLE_Q_TAG,
+						/*dbd*/ 0,
+						/*page_code*/ pc,
+						/*page*/ page,
+						/*param_buf*/ buf,
+						/*param_len*/ MIN(MAX_UINT16, size),
+						/*minimum_cmd_size*/ 10,
+						/*sense_len*/ SSD_FULL_SIZE,
+						/*timeout*/ timeout);
+	/*
+	 * XXX KDM need a version of scsi_mode_sense() that allows setting the subpage.  The offset
+	 * is the same in the 6 and 10 byte versions, so we can just set the same byte here.
+	 */
+	ccb->csio.cdb_io.cdb_bytes[3] = subpage;
+
+	ccb->ccb_h.flags |= CAM_DEV_QFRZDIS | CAM_PASS_ERR_RECOVER;
+
+	rc = camtape_send_ccb(softc, ccb, &msg);
+
+	if (rc != DEVICE_GOOD)
+		camtape_process_errors(softc, rc, msg, "modesense", true);
+
+bailout:
+	if (ccb != NULL)
+		cam_freeccb(ccb);
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_MODESENSE));
+	return rc;
+}
+
+/**
+ * Set mode data
+ * @param device a pointer to the camtape backend
+ * @param buf pointer to mode page data. This data will be sent to the drive
+ * @param size length of buf
+ * @return 0 on success or a negative value on error
+ */
+int camtape_modeselect(void *device, unsigned char *buf, const size_t size)
+{
+	int rc;
+	char *msg = NULL;
+	struct camtape_data *softc = device;
+	union ccb *ccb;
+	int timeout;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_MODESELECT));
+	ltfsmsg(LTFS_DEBUG3, 30592D, "modeselect", softc->drive_serial);
+
+	ccb = cam_getccb(softc->cd);
+	if (ccb == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+
+	bzero(&(&ccb->ccb_h)[1],
+		sizeof(struct ccb_scsiio) - sizeof(struct ccb_hdr));
+
+	timeout = camtape_get_timeout(softc->timeouts, MODE_SELECT_10);
+	if (timeout < 0) {
+		rc = -EDEV_UNSUPPORETD_COMMAND;
+		goto bailout;
+	}
+
+	scsi_mode_select_len(&ccb->csio,
+						 /*retries*/ 1,
+						 /*cbfcnp*/ NULL,
+						 /*tag_action*/ MSG_SIMPLE_Q_TAG,
+						 /*scsi_page_fmt*/ 0,
+						 /*save_pages*/ 0,
+						 /*param_buf*/ buf,
+						 /*param_len*/ size,
+						 /*minimum_cmd_len*/ 10,
+						 /*sense_len*/ SSD_FULL_SIZE,
+						 /*timeout*/ timeout);
+
+	ccb->ccb_h.flags |= CAM_DEV_QFRZDIS | CAM_PASS_ERR_RECOVER;
+
+	rc = camtape_send_ccb(softc, ccb, &msg);
+
+	if (rc != DEVICE_GOOD) {
+		if (rc == -EDEV_MODE_PARAMETER_ROUNDED)
+			rc = DEVICE_GOOD;
+
+		if (rc != DEVICE_GOOD)
+			camtape_process_errors(device, rc, msg, "modeselect", true);
+	}
+bailout:
+	if (ccb != NULL)
+		cam_freeccb(ccb);
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_MODESELECT));
+	return rc;
+}
+
+/**
+ * Prevent medium removal
+ * @param device a pointer to the camtape backend
+ * @return 0 on success or a negative value on error
+ */
+int camtape_prevent_medium_removal(void *device)
+{
+	struct camtape_data *softc = device;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_PREVENTM));
+	ltfsmsg(LTFS_DEBUG, 30592D, "prevent medium removal", softc->drive_serial);
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_PREVENTM));
+
+	/*
+	 * The FreeBSD tape driver issues a prevent medium removal command on open, so we don't
+	 * need to do it again.
+	 */
+	return DEVICE_GOOD;
+}
+
+/**
+ * Allow medium removal
+ * @param device a pointer to the camtape backend
+ * @return 0 on success or a negative value on error
+ */
+int camtape_allow_medium_removal(void *device)
+{
+	struct camtape_data *softc = device;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_ALLOWMREM));
+	ltfsmsg(LTFS_DEBUG, 30592D, "allow medium removal", softc->drive_serial);
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_ALLOWMREM));
+	/*
+	 * The FreeBSD tape driver issues an allow medium removal command on close, so we don't
+	 * need to do it again.
+	 */
+	return DEVICE_GOOD;
+}
+
+/**
+ * Read attribute
+ * @param device a pointer to the camtape backend
+ * @param part partition to read attribute
+ * @param id attribute id to get
+ * @param buf pointer to the attribute buffer. This function will update this value.
+ * @param size length of the buffer
+ * @return 0 on success or a negative value on error
+ */
+int camtape_read_attribute(void *device, const tape_partition_t part, const uint16_t id,
+						   unsigned char *buf, const size_t size)
+{
+	int rc = DEVICE_GOOD;
+	char *msg = NULL;
+	bool take_dump= true;
+	int timeout;
+	struct camtape_data *softc = device;
+	struct scsi_read_attribute_values *attr_header = NULL;
+	size_t attr_size;
+	union ccb *ccb = NULL;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_READATTR));
+	ltfsmsg(LTFS_DEBUG3, 30597D, "readattr", (unsigned long long)part,
+			(unsigned long long)id, softc->drive_serial);
+
+	ccb = cam_getccb(softc->cd);
+	if (ccb == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+
+	bzero(&(&ccb->ccb_h)[1],
+		sizeof(struct ccb_scsiio) - sizeof(struct ccb_hdr));
+
+	/*
+	 * The function interface only includes enough space for the attribute, and doesn't include
+	 * space for the header.  So we need to allocate that here.
+	 */
+	attr_size = size + sizeof(*attr_header);
+	attr_header = calloc(1, attr_size);
+	if (attr_header == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+
+	timeout = camtape_get_timeout(softc->timeouts, READ_ATTRIBUTE);
+	if (timeout < 0) {
+		rc = -EDEV_UNSUPPORETD_COMMAND;
+		goto bailout;
+	}
+
+
+	scsi_read_attribute(&ccb->csio,
+						/*retries*/ 1,
+						/*cbfcnp*/ NULL,
+						/*tag_action*/ MSG_SIMPLE_Q_TAG,
+						/*service_action*/ SRA_SA_ATTR_VALUES,
+						/*element*/ 0,
+						/*elem_type*/ 0,
+						/*logical_volume*/ 0,
+						/*partition*/ part,
+						/*first_attribute*/ id,
+						/*cache*/ 0,
+						/*data_ptr*/ (uint8_t *)attr_header,
+						/*length*/ attr_size,
+						/*sense_len*/ SSD_FULL_SIZE,
+						/*timeout*/ timeout);
+
+	ccb->ccb_h.flags |= CAM_DEV_QFRZDIS | CAM_PASS_ERR_RECOVER;
+
+	rc = camtape_send_ccb(softc, ccb, &msg);
+
+	if (rc != DEVICE_GOOD) {
+		if ( rc == -EDEV_INVALID_FIELD_CDB )
+			take_dump = false;
+
+		camtape_process_errors(device, rc, msg, "readattr", take_dump);
+
+		if (rc < 0 &&
+			id != TC_MAM_PAGE_COHERENCY &&
+			id != TC_MAM_APP_VENDER &&
+			id != TC_MAM_APP_NAME &&
+			id != TC_MAM_APP_VERSION &&
+			id != TC_MAM_USER_MEDIUM_LABEL &&
+			id != TC_MAM_TEXT_LOCALIZATION_IDENTIFIER &&
+			id != TC_MAM_BARCODE &&
+			id != TC_MAM_APP_FORMAT_VERSION)
+			ltfsmsg(LTFS_INFO, 30460I, rc);
+	} else {
+		bcopy(&attr_header[1], buf, size);
+	}
+
+bailout:
+	if (ccb != NULL)
+		cam_freeccb(ccb);
+	if (attr_header != NULL)
+		free(attr_header);
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_READATTR));
+	return rc;
+}
+
+/**
+ * Write attribute
+ * @param device a pointer to the camtape backend
+ * @param part partition to write attribute
+ * @param buf pointer to the attribute buffer as defined in SPC-4 7.4.1
+ * 	  "Attribute Format". The header for the parameter list is created based
+ * 	  on the size of the attribute buffer
+ * @param size length of the attribute buffer
+ * @return 0 on success or a negative value on error
+ */
+int camtape_write_attribute(void *device, const tape_partition_t part, const unsigned char *buf,
+							const size_t size)
+{
+	int rc = DEVICE_GOOD;
+	char *msg = NULL;
+	struct camtape_data *softc = device;
+	struct scsi_read_attribute_values *attr_header = NULL;
+	size_t attr_size;
+	int timeout;
+	union ccb *ccb = NULL;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_WRITEATTR));
+	ltfsmsg(LTFS_DEBUG3, 30594D, "writeattr", (unsigned long long)part,
+			softc->drive_serial);
+
+	ccb = cam_getccb(softc->cd);
+	if (ccb == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+
+	bzero(&(&ccb->ccb_h)[1],
+		sizeof(struct ccb_scsiio) - sizeof(struct ccb_hdr));
+
+	/*
+	 * The function interface only includes enough space for the attribute, and doesn't include
+	 * space for the header.  So we need to allocate that here, fill in the length field in the
+	 * header (which should be ignored by the target) and copy the user's data in.
+	 */
+	attr_size = size + sizeof(*attr_header);
+	attr_header = calloc(1, attr_size);
+	if (attr_header == NULL) {
+		ltfsmsg(LTFS_ERR, 10001E, "camtape_write_attribute: data buffer");
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+	bcopy(buf, &attr_header[1], size);
+	scsi_ulto4b(size, attr_header->length);
+
+	timeout = camtape_get_timeout(softc->timeouts, WRITE_ATTRIBUTE);
+	if (timeout < 0) {
+		rc = -EDEV_UNSUPPORETD_COMMAND;
+		goto bailout;
+	}
+
+	scsi_write_attribute(&ccb->csio,
+						 /*retries*/ 1,
+						 /*cbfcnp*/ NULL,
+						 /*tag_action*/ MSG_SIMPLE_Q_TAG,
+						 /*element*/ 0,
+						 /*logical_volume*/ 0,
+						 /*partition*/ part,
+						 /*wtc*/ 1,
+						 /*data_ptr*/ (uint8_t *)attr_header,
+						 /*length*/ attr_size,
+						 /*sense_len*/ SSD_FULL_SIZE,
+						 /*timeout*/ timeout);
+
+	ccb->ccb_h.flags |= CAM_DEV_QFRZDIS | CAM_PASS_ERR_RECOVER;
+
+	rc = camtape_send_ccb(softc, ccb, &msg);
+
+	if (rc != DEVICE_GOOD)
+		camtape_process_errors(device, rc, msg, "writeattr", true);
+
+bailout:
+	if (ccb != NULL)
+		cam_freeccb(ccb);
+	if (attr_header != NULL)
+		free(attr_header);
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_WRITEATTR));
+	return rc;
+}
+
+int camtape_allow_overwrite(void *device, const struct tc_position pos)
+{
+	int rc;
+	char *msg = NULL;
+	struct camtape_data *softc = device;
+	struct allow_data_overwrite append_pos;
+	int timeout;
+	union ccb *ccb;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_ALLOWOVERW));
+	ltfsmsg(LTFS_DEBUG, 30597D, "allow overwrite", (unsigned long long)pos.partition,
+		(unsigned long long)pos.block, softc->drive_serial);
+
+	ccb = cam_getccb(softc->cd);
+	if (ccb == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+
+	bzero(&(&ccb->ccb_h)[1],
+		sizeof(struct ccb_scsiio) - sizeof(struct ccb_hdr));
+
+	timeout = camtape_get_timeout(softc->timeouts, ALLOW_OVERWRITE);
+	if (timeout < 0) {
+		rc = -EDEV_UNSUPPORETD_COMMAND;
+		goto bailout;
+	}
+
+	memset(&append_pos, 0, sizeof(append_pos));
+
+	scsi_allow_overwrite(&ccb->csio,
+						 /*retries*/ 1,
+						 /*cbfcnp*/ NULL,
+						 /*tag_action*/ MSG_SIMPLE_Q_TAG,
+						 /*allow_overwrite*/ SAO_ALLOW_OVERWRITE_CUR_POS,
+						 /*partition*/ pos.partition,
+						 /*logical_id*/ pos.block,
+						 /*sense_len*/ SSD_FULL_SIZE,
+						 /*timeout*/ timeout);
+
+	ccb->ccb_h.flags |= CAM_DEV_QFRZDIS | CAM_PASS_ERR_RECOVER;
+
+	rc = camtape_send_ccb(softc, ccb, &msg);
+
+	if (rc != DEVICE_GOOD) {
+		if (rc == -EDEV_EOD_DETECTED) {
+			ltfsmsg(LTFS_DEBUG, 30448D, "Allow Overwrite");
+			rc = DEVICE_GOOD;
+		}
+
+		if (rc != DEVICE_GOOD)
+			camtape_process_errors(device, rc, msg, "allow overwrite", true);
+	}
+
+bailout:
+	if (ccb != NULL)
+		cam_freeccb(ccb);
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_ALLOWOVERW));
+	return rc;
+}
+
+/**
+ * Set compression setting
+ * @param device a pointer to the camtape backend
+ * @param enable_compression enable: true, disable: false
+ * @param pos a pointer to position data. This function will update position infomation.
+ * @return 0 on success or a negative value on error
+ */
+int camtape_set_compression(void *device, const bool enable_compression, struct tc_position *pos)
+{
+	int rc;
+	unsigned char buf[TC_MP_COMPRESSION_SIZE];
+	struct camtape_data *softc = device;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_SETCOMPRS));
+	rc = camtape_modesense(device, TC_MP_COMPRESSION, TC_MP_PC_CURRENT, 0, buf, sizeof(buf));
+	if (rc != DEVICE_GOOD) {
+		ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETCOMPRS));
+		return rc;
+	}
+
+	buf[0] = 0x00;
+	buf[1] = 0x00;
+	if(enable_compression)
+		buf[18] |= 0x80; /* Set DCE field*/
+	else
+		buf[18] &= 0x7F; /* Unset DCE field*/
+
+	rc = camtape_modeselect(device, buf, sizeof(buf));
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETCOMPRS));
+	return rc;
+}
+
+/**
+ * Return drive setting in default
+ * @param device a pointer to the camtape backend
+ * @return 0 on success or a negative value on error
+ */
+int camtape_set_default(void *device)
+{
+	struct camtape_data *softc = device;
+	int rc;
+	unsigned char buf[TC_MP_READ_WRITE_CTRL_SIZE];
+	char *msg = NULL;
+	struct mtparamset sili_param;
+	uint32_t eot_model;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_SETDEFAULT));
+	/* Disable Read across EOD on 3592 drive */
+	if (IS_ENTERPRISE(softc->drive_type)) {
+		ltfsmsg(LTFS_DEBUG, 30592D, __FUNCTION__, "Disabling read across EOD");
+		rc = camtape_modesense(device, TC_MP_READ_WRITE_CTRL, TC_MP_PC_CURRENT, 0, buf, sizeof(buf));
+		if (rc != DEVICE_GOOD) {
+			ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETDEFAULT));
+			return rc;
+		}
+
+		buf[0]  = 0x00;
+		buf[1]  = 0x00;
+		buf[24] = 0x0C;
+
+		rc = camtape_modeselect(device, buf, sizeof(buf));
+		if (rc != DEVICE_GOOD)
+			goto bailout;
+	}
+
+	/* set SILI bit */
+	ltfsmsg(LTFS_DEBUG, 30592D, __FUNCTION__, "Setting SILI bit");
+	bzero(&sili_param, sizeof(sili_param));
+	snprintf(sili_param.value_name, sizeof(sili_param.value_name), "sili");
+	sili_param.value_type = MT_PARAM_SET_SIGNED;
+	sili_param.value_len = sizeof(int);
+	sili_param.value.value_signed = 1;
+
+	/*
+	 * XXX KDM the ibmtape backend retries setting the SILI bit 10 times.  Why?  Is this
+	 * something that we need to do here?
+	 */
+	if (ioctl(softc->fd_sa, MTIOCPARAMSET, &sili_param) == -1) {
+		msg = strdup("Error returned from MTIOCPARAMSET ioctl to set the SILI bit");
+		rc = -EDEV_DRIVER_ERROR;
+		camtape_process_errors(device, rc, msg, "set default parameter", true);
+		goto bailout;
+	}
+
+	/* set logical block protection */
+	if (global_data.crc_checking) {
+		ltfsmsg(LTFS_DEBUG, 30592D, __FUNCTION__, "Setting LBP");
+		rc = camtape_set_lbp(device, true);
+	} else {
+		ltfsmsg(LTFS_DEBUG, 30592D, __FUNCTION__, "Resetting LBP");
+		rc = camtape_set_lbp(device, false);
+	}
+	if (rc != DEVICE_GOOD)
+		goto bailout;
+
+	ltfsmsg(LTFS_DEBUG, 30592D, __FUNCTION__, "Setting EOT model to 1FM");
+
+	/*
+	 * We have to set the EOT model to 1 filemark.  By default, FreeBSD uses two filemarks at
+	 * the end of the tape unless the drive has a quirk entry to only use one.  LTFS checks
+	 * (in ltfs_seek_index()) to make sure that the only thing beyond the index is a single
+	 * terminating filemark.  If there is anything else (e.g. a second filemark), it
+	 * thinks that the tape isn't consistent.  We could change this assumption in the code,
+	 * or just live with it.  (We're doing the latter.)
+	 */
+	eot_model = 1;
+	if (ioctl(softc->fd_sa, MTIOCSETEOTMODEL, &eot_model) == -1) {
+		msg = strdup("Error returned from MTIOCSETEOTMODEL ioctl to set the EOT model to 1FM");
+		rc = -EDEV_DRIVER_ERROR;
+		camtape_process_errors(device, rc, msg, "set default parameter", true);
+		goto bailout;
+	}
+
+bailout:
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETDEFAULT));
+	return rc;
+}
+
+/**
+ * Get cartridge health information
+ * @param device a pointer to the camtape backend
+ * @return 0 on success or a negative value on error
+ */
+
+#define LOG_TAPE_ALERT               (0x2E)
+#define LOG_PERFORMANCE              (0x37)
+#define LOG_PERFORMANCE_CAPACITY_SUB (0x64) // Scope(7-6): Mount Values
+                                            // Level(5-4): Return Advanced Counters
+                                            // Group(3-0): Capacity
+
+static uint16_t volstats[] = {
+	VOLSTATS_MOUNTS,
+	VOLSTATS_WRITTEN_DS,
+	VOLSTATS_WRITE_TEMPS,
+	VOLSTATS_WRITE_PERMS,
+	VOLSTATS_READ_DS,
+	VOLSTATS_READ_TEMPS,
+	VOLSTATS_READ_PERMS,
+	VOLSTATS_WRITE_PERMS_PREV,
+	VOLSTATS_READ_PERMS_PREV,
+	VOLSTATS_WRITE_MB,
+	VOLSTATS_READ_MB,
+	VOLSTATS_PASSES_BEGIN,
+	VOLSTATS_PASSES_MIDDLE,
+};
+
+enum {
+	PERF_CART_CONDITION       = 0x0001,	/* < Media Efficiency */
+	PERF_ACTIVE_CQ_LOSS_W     = 0x7113, /* < Active CQ loss Write */
+};
+
+static uint16_t perfstats[] = {
+	PERF_CART_CONDITION,
+};
+
+int camtape_get_cartridge_health(void *device, struct tc_cartridge_health *cart_health)
+{
+	struct camtape_data *softc = device;
+	unsigned char logdata[LOGSENSEPAGE];
+	unsigned char buf[16];
+	int param_size, i;
+	uint64_t loghlt;
+	int rc;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_GETCARTHLTH));
+
+	/* Issue LogPage 0x37 */
+	cart_health->tape_efficiency  = UNSUPPORTED_CARTRIDGE_HEALTH;
+	rc = camtape_logsense(device, LOG_PERFORMANCE, logdata, LOGSENSEPAGE);
+	if (rc)
+		ltfsmsg(LTFS_INFO, 30461I, LOG_PERFORMANCE, rc, "get cart health");
+	else {
+		for(i = 0; i < (int)((sizeof(perfstats)/sizeof(perfstats[0]))); i++) { /* BEAM: loop doesn't iterate - Use loop for future enhancement. */
+			if (parse_logPage(logdata, perfstats[i], &param_size, buf, 16)) {
+				ltfsmsg(LTFS_INFO, 30462I, LOG_PERFORMANCE, "get cart health");
+			} else {
+				switch(param_size) {
+				case sizeof(uint8_t):
+					loghlt = (uint64_t)(buf[0]);
+					break;
+				case sizeof(uint16_t):
+					loghlt = (uint64_t)ltfs_betou16(buf);
+					break;
+				case sizeof(uint32_t):
+					loghlt = (uint32_t)ltfs_betou32(buf);
+					break;
+				case sizeof(uint64_t):
+					loghlt = ltfs_betou64(buf);
+					break;
+				default:
+					loghlt = UNSUPPORTED_CARTRIDGE_HEALTH;
+					break;
+				}
+
+				switch(perfstats[i]) {
+				case PERF_CART_CONDITION:
+					cart_health->tape_efficiency = loghlt;
+					break;
+				default:
+					break;
+				}
+			}
+		}
+	}
+
+	/* Issue LogPage 0x17 */
+	cart_health->mounts           = UNSUPPORTED_CARTRIDGE_HEALTH;
+	cart_health->written_ds       = UNSUPPORTED_CARTRIDGE_HEALTH;
+	cart_health->write_temps      = UNSUPPORTED_CARTRIDGE_HEALTH;
+	cart_health->write_perms      = UNSUPPORTED_CARTRIDGE_HEALTH;
+	cart_health->read_ds          = UNSUPPORTED_CARTRIDGE_HEALTH;
+	cart_health->read_temps       = UNSUPPORTED_CARTRIDGE_HEALTH;
+	cart_health->read_perms       = UNSUPPORTED_CARTRIDGE_HEALTH;
+	cart_health->write_perms_prev = UNSUPPORTED_CARTRIDGE_HEALTH;
+	cart_health->read_perms_prev  = UNSUPPORTED_CARTRIDGE_HEALTH;
+	cart_health->written_mbytes   = UNSUPPORTED_CARTRIDGE_HEALTH;
+	cart_health->read_mbytes      = UNSUPPORTED_CARTRIDGE_HEALTH;
+	cart_health->passes_begin     = UNSUPPORTED_CARTRIDGE_HEALTH;
+	cart_health->passes_middle    = UNSUPPORTED_CARTRIDGE_HEALTH;
+	rc = camtape_logsense(device, LOG_VOLUMESTATS, logdata, LOGSENSEPAGE);
+	if (rc)
+		ltfsmsg(LTFS_INFO, 30461I, LOG_VOLUMESTATS, rc, "get cart health");
+	else {
+		for(i = 0; i < (int)((sizeof(volstats)/sizeof(volstats[0]))); i++) {
+			if (parse_logPage(logdata, volstats[i], &param_size, buf, 16)) {
+				ltfsmsg(LTFS_INFO, 30462I, LOG_VOLUMESTATS, "get cart health");
+			} else {
+				switch(param_size) {
+				case sizeof(uint8_t):
+					loghlt = (uint64_t)(buf[0]);
+					break;
+				case sizeof(uint16_t):
+					loghlt = (uint64_t)ltfs_betou16(buf);
+					break;
+				case sizeof(uint32_t):
+					loghlt = (uint32_t)ltfs_betou32(buf);
+					break;
+				case sizeof(uint64_t):
+					loghlt = ltfs_betou64(buf);
+					break;
+				default:
+					loghlt = UNSUPPORTED_CARTRIDGE_HEALTH;
+					break;
+				}
+
+				switch(volstats[i]) {
+				case VOLSTATS_MOUNTS:
+					cart_health->mounts = loghlt;
+					break;
+				case VOLSTATS_WRITTEN_DS:
+					cart_health->written_ds = loghlt;
+					break;
+				case VOLSTATS_WRITE_TEMPS:
+					cart_health->write_temps = loghlt;
+					break;
+				case VOLSTATS_WRITE_PERMS:
+					cart_health->write_perms = loghlt;
+					break;
+				case VOLSTATS_READ_DS:
+					cart_health->read_ds = loghlt;
+					break;
+				case VOLSTATS_READ_TEMPS:
+					cart_health->read_temps = loghlt;
+					break;
+				case VOLSTATS_READ_PERMS:
+					cart_health->read_perms = loghlt;
+					break;
+				case VOLSTATS_WRITE_PERMS_PREV:
+					cart_health->write_perms_prev = loghlt;
+					break;
+				case VOLSTATS_READ_PERMS_PREV:
+					cart_health->read_perms_prev = loghlt;
+					break;
+				case VOLSTATS_WRITE_MB:
+					cart_health->written_mbytes = loghlt;
+					break;
+				case VOLSTATS_READ_MB:
+					cart_health->read_mbytes = loghlt;
+					break;
+				case VOLSTATS_PASSES_BEGIN:
+					cart_health->passes_begin = loghlt;
+					break;
+				case VOLSTATS_PASSES_MIDDLE:
+					cart_health->passes_middle = loghlt;
+					break;
+				default:
+					break;
+				}
+			}
+		}
+	}
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETCARTHLTH));
+	return 0;
+}
+
+/**
+ * Get tape alert from the drive this value shall be latched by backends and shall be cleard by
+ * clear_tape_alert() on write clear method
+ * @param device Device handle returned by the backend's open().
+ * @param tape alert On success, the backend must fill this value with the tape alert
+ *                    "-1" shows the unsupported value except tape alert.
+ * @return 0 on success or a negative value on error.
+ */
+int camtape_get_tape_alert(void *device, uint64_t *tape_alert)
+{
+	unsigned char logdata[LOGSENSEPAGE];
+	unsigned char buf[16];
+	int param_size, i;
+	int rc;
+	uint64_t ta;
+	struct camtape_data *priv = (struct camtape_data *) device;
+
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_GETTAPEALT));
+	/* Issue LogPage 0x2E */
+	ta = 0;
+	rc = camtape_logsense(device, LOG_TAPE_ALERT, logdata, LOGSENSEPAGE);
+	if (rc)
+		ltfsmsg(LTFS_INFO, 30461I, LOG_TAPE_ALERT, rc, "get tape alert");
+	else {
+		for(i = 1; i <= 64; i++) {
+			if (parse_logPage(logdata, (uint16_t) i, &param_size, buf, 16)
+				|| param_size != sizeof(uint8_t)) {
+				ltfsmsg(LTFS_ERR, 30462E, LOG_TAPE_ALERT, "get tape alert");
+				ta = 0;
+			}
+
+			if(buf[0])
+				ta += (uint64_t)(1) << (i - 1);
+		}
+	}
+
+	priv->tape_alert |= ta;
+	*tape_alert = priv->tape_alert;
+
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETTAPEALT));
+	return rc;
+}
+
+/**
+ * clear latched tape alert from the drive
+ * @param device Device handle returned by the backend's open().
+ * @param tape_alert value to clear tape alert. Backend shall be clear the specicied bits in this value.
+ * @return 0 on success or a negative value on error.
+ */
+int camtape_clear_tape_alert(void *device, uint64_t tape_alert)
+{
+	struct camtape_data *priv = (struct camtape_data *) device;
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_CLRTAPEALT));
+	priv->tape_alert &= ~tape_alert;
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_CLRTAPEALT));
+	return 0;
+}
+
+typedef enum {
+	MT_MAXIO			= 0,
+	MT_CPI_MAXIO		= 1,
+	MT_MAX_BLK			= 2,
+	MT_MAX_EFF_IO_SIZE	= 3,
+} camtape_block_index;
+
+struct camtape_status_item req_block_items[] = {
+	{"maxio", NULL },
+	{"cpi_maxio", NULL },
+	{"max_blk", NULL },
+	{"max_effective_iosize", NULL }
+};
+
+#define	CT_NUM_BLOCK_ITEMS	(sizeof(req_block_items)/sizeof(req_block_items[0]))
+
+/**
+ * Get drive parameter
+ * @param device a pointer to the camtape backend
+ * @param drive_param pointer to the drive parameter infomation. This function will update this value.
+ * @return 0 on success or a negative value on error
+ */
+uint32_t _camtape_get_block_limits(void *device)
+{
+	uint32_t length = 0;
+	struct camtape_data *softc = device;
+	struct camtape_status_item block_items[CT_NUM_BLOCK_ITEMS];
+	struct mt_status_data mtinfo;
+	char *msg;
+	int rc;
+
+	ltfsmsg(LTFS_DEBUG, 30592D, "read block limits", softc->drive_serial);
+
+	bzero(block_items, sizeof(block_items));
+	bzero(&mtinfo, sizeof(mtinfo));
+	bcopy(req_block_items, block_items, MIN(sizeof(block_items), sizeof(req_block_items)));
+
+	rc = camtape_getstatus(softc, &mtinfo, block_items, CT_NUM_BLOCK_ITEMS, &msg);
+
+	if (rc != DEVICE_GOOD) {
+		camtape_process_errors(device, rc, msg, "read block limits", true);
+		goto bailout;
+	}
+
+	/*
+	 * Start off with the maximum block size returned from READ BLOCK LIMITS.
+	 */
+	length = block_items[MT_MAX_BLK].entry->value_unsigned;
+
+	/*
+	 * Limit that by the maximum size supported by the driver and controller.
+	 */
+	length = MIN(length, block_items[MT_MAX_EFF_IO_SIZE].entry->value_unsigned);
+
+bailout:
+	camtape_free_mtinfo(softc, &mtinfo);
+
+	return length;
+}
+
+int camtape_get_parameters(void *device, struct tc_current_param *params)
+{
+	struct camtape_data *softc = device;
+	int rc = DEVICE_GOOD;
+	unsigned char buf[TC_MP_MEDIUM_SENSE_SIZE];
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_GETPARAM));
+
+	memset(params, 0x00, sizeof(*params));
+
+	/*
+	 * This calculation is slightly different than the Linux backend because FreeBSD has a
+	 * different, more variable set of limits.  Depending on the controller, how the user has
+	 * configured MAXPHYS in his kernel config file, and the tape drive, you can get varying
+	 * values out of the _camtape_get_block_limits() function.  It could be as low as 128K,
+	 * or more than 1MB.
+	 *
+	 * If the user has a configuration that allows him to do 1048580 byte transfers, and thus
+	 * do CRC checking on media formatted with a 1MB blocksize, we will let him.  This gives us
+	 * slightly better functionality than the Linux backend, which will let you format a tape
+	 * with a 1MB block size, but then won't let you mount it with CRC checking turned on.
+	 */
+	if (global_data.crc_checking)
+		params->max_blksize = MIN(_camtape_get_block_limits(device) - 4, LINUX_MAX_BLOCK_SIZE);
+	else 
+		params->max_blksize = MIN(_camtape_get_block_limits(device), LINUX_MAX_BLOCK_SIZE);
+
+	if (softc->loaded) {
+		params->write_protected = 0;
+
+		if (IS_ENTERPRISE(softc->drive_type)) {
+			rc = camtape_modesense(device, TC_MP_MEDIUM_SENSE, TC_MP_PC_CURRENT, 0, buf, sizeof(buf));
+			if (rc != DEVICE_GOOD) {
+				ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETPARAM));
+				return rc;
+			}
+
+			char wp_flag = buf[26];
+
+			if (wp_flag & 0x80) {
+				params->write_protected |= VOL_PHYSICAL_WP;
+			} else if (wp_flag & 0x01) {
+				params->write_protected |= VOL_PERM_WP;
+			} else if (wp_flag & 0x10) {
+				params->write_protected |= VOL_PERS_WP;
+			}
+		} else {
+			rc = camtape_modesense(device, 0x00, TC_MP_PC_CURRENT, 0, buf, sizeof(buf));
+			if (rc != DEVICE_GOOD) {
+				ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETPARAM));
+				return rc;
+			}
+
+			if ( (buf[3] & 0x80) )
+				params->write_protected |= VOL_PHYSICAL_WP;
+		}
+
+		params->cart_type = softc->cart_type;
+		params->density   = softc->density_code;
+		/* TODO: Following field shall be implemented in the future */
+		/*
+		params->is_worm = softc->is_worm;
+		if (IS_ENTERPRISE(softc->drive_type)) {
+			if (softc->density_code & TEST_CRYPTO)
+				params->is_encrypted = true;
+		} else {
+			// TODO: Store is_crypto based on LP17:200h
+		}
+		*/
+	}
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETPARAM));
+	return rc;
+}
+
+static const char *generate_product_name(const char *product_id)
+{
+	const char *product_name = "";
+	int i = 0;
+
+	for (i = 0; ibm_supported_drives[i]; ++i) {
+		if (strncmp(ibm_supported_drives[i]->product_id, product_id, strlen(product_id)) == 0) {
+			product_name = ibm_supported_drives[i]->product_name;
+			break;
+		}
+	}
+
+	return product_name;
+}
+
+/**
+ * Get a list of available tape devices for LTFS found in the host. The caller is
+ * responsible from allocating the buffer to contain the tape drive information
+ * by get_device_count() call.
+ * When buf is NULL, this function just returns an available tape device count.
+ * @param[out] buf Pointer to tc_drive_info structure array.
+ *             The backend must fill this structure when this paramater is not NULL.
+ * @param count size of array in buf.
+ * @return on success, available device count on this system or a negative value on error.
+ */
+int camtape_get_device_list(struct tc_drive_info *buf, int count)
+{
+	union ccb ccb;
+	struct dev_match_pattern patterns[2];
+	ssize_t bufsize;
+	int fd, buf_index;
+	unsigned int i;
+
+	fd = open(XPT_DEVICE, O_RDWR);
+	if (fd == -1) {
+		ltfsmsg(LTFS_ERR, 30463E, XPT_DEVICE, errno);
+		return (-EDEV_DEVICE_UNOPENABLE);
+	}
+
+	bzero(&ccb, sizeof(ccb));
+	
+	ccb.ccb_h.path_id = CAM_XPT_PATH_ID;
+	ccb.ccb_h.target_id = CAM_TARGET_WILDCARD;
+	ccb.ccb_h.target_lun = CAM_LUN_WILDCARD;
+
+	ccb.ccb_h.func_code = XPT_DEV_MATCH;
+	bufsize = sizeof(struct dev_match_result) * 100;
+	ccb.cdm.match_buf_len = bufsize;
+	ccb.cdm.matches = (struct dev_match_result *)malloc(bufsize);
+	if (ccb.cdm.matches == NULL) {
+		close(fd);
+		return (-EDEV_NO_MEMORY);
+	}
+
+	ccb.cdm.num_matches = 0;
+
+	bzero(patterns, sizeof(patterns));
+
+	ccb.cdm.num_patterns = 2;
+	ccb.cdm.pattern_buf_len = sizeof(patterns);
+	ccb.cdm.patterns = patterns;
+	patterns[0].type = DEV_MATCH_PERIPH;
+	snprintf(patterns[0].pattern.periph_pattern.periph_name,
+	    sizeof(patterns[0].pattern.periph_pattern.periph_name), "sa");
+	patterns[0].pattern.periph_pattern.flags = PERIPH_MATCH_NAME;
+	patterns[1].type = DEV_MATCH_DEVICE;
+	patterns[1].pattern.device_pattern.flags = DEV_MATCH_INQUIRY;
+	patterns[1].pattern.device_pattern.data.inq_pat.type = T_SEQUENTIAL;
+	patterns[1].pattern.device_pattern.data.inq_pat.media_type = SIP_MEDIA_REMOVABLE;
+	snprintf(patterns[1].pattern.device_pattern.data.inq_pat.vendor,
+	    sizeof(patterns[1].pattern.device_pattern.data.inq_pat.vendor), "*");
+	snprintf(patterns[1].pattern.device_pattern.data.inq_pat.product,
+	    sizeof(patterns[1].pattern.device_pattern.data.inq_pat.product), "*");
+	snprintf(patterns[1].pattern.device_pattern.data.inq_pat.revision,
+	    sizeof(patterns[1].pattern.device_pattern.data.inq_pat.revision), "*");
+
+	buf_index = 0;
+
+	do {
+		if (ioctl(fd, CAMIOCOMMAND, &ccb) == -1)
+			err(1, "error sending CAMIOCOMMAND ioctl to %s",
+			    XPT_DEVICE);
+
+		if ((ccb.ccb_h.status != CAM_REQ_CMP)
+		 || ((ccb.cdm.status != CAM_DEV_MATCH_LAST)
+		    && (ccb.cdm.status != CAM_DEV_MATCH_MORE)))
+			errx(1, "got CAM error %#x, CDM error %d\n",
+			      ccb.ccb_h.status, ccb.cdm.status);
+
+		for (i = 0; i < ccb.cdm.num_matches; i++) {
+			switch (ccb.cdm.matches[i].type) {
+			case DEV_MATCH_DEVICE: {
+				struct device_match_result *dev_result;
+				uint8_t vendor[16], product[48], revision[16];
+
+				dev_result = &ccb.cdm.matches[i].result.device_result;
+
+				if ((dev_result->protocol == PROTO_SCSI) && (buf != NULL)) {
+				    cam_strvis(vendor, (const uint8_t *)dev_result->inq_data.vendor,
+					   sizeof(dev_result->inq_data.vendor), sizeof(vendor));
+				    cam_strvis(product, (const uint8_t *) dev_result->inq_data.product,
+					   sizeof(dev_result->inq_data.product), sizeof(product));
+				    cam_strvis(revision, (const uint8_t *)dev_result->inq_data.revision,
+					  sizeof(dev_result->inq_data.revision), sizeof(revision));
+					snprintf(buf[buf_index].vendor, sizeof(buf[buf_index].vendor), "%s", vendor);
+					snprintf(buf[buf_index].model, sizeof(buf[buf_index].model), "%s", product);
+					snprintf(buf[buf_index].product_name, sizeof(buf[buf_index].product_name), "%s",
+						generate_product_name((const char *)product));
+				} else {
+					/*
+					 * XXX KDM what now?  We have a tape device that isn't SCSI??
+					 */
+				}
+				break;
+			}
+			case DEV_MATCH_PERIPH: {
+				struct periph_match_result *periph_result;
+
+				periph_result =
+				      &ccb.cdm.matches[i].result.periph_result;
+
+				if (buf != NULL) {
+					struct cam_device *dev;
+
+					dev = cam_open_spec_device(
+						periph_result->periph_name,
+						periph_result->unit_number, O_RDWR, NULL);
+					if (dev == NULL) {
+						err(1, "unable to open passthrough "
+						    "device for %s%d",
+						    periph_result->periph_name,
+						    periph_result->unit_number); 
+					}
+					dev->serial_num[dev->serial_num_len] = '\0';
+					snprintf(buf[buf_index].serial_number, sizeof(buf[buf_index].serial_number),
+					    "%s", dev->serial_num);
+					snprintf(buf[buf_index].name, sizeof(buf[buf_index].name), "%s%d",
+						periph_result->periph_name, periph_result->unit_number);
+					cam_close_device(dev);
+				}
+				buf_index++;
+				if (buf != NULL && buf_index >= count)
+					goto bailout;
+				break;
+			}
+			default:
+				break;
+			}
+		}
+
+	} while ((ccb.ccb_h.status == CAM_REQ_CMP)
+		&& (ccb.cdm.status == CAM_DEV_MATCH_MORE));
+
+bailout:
+
+	close(fd);
+	if (ccb.cdm.matches != NULL)
+		free(ccb.cdm.matches);
+
+	return buf_index;
+}
+
+/**
+ * Set the capacity proprotion of the medium
+ * @param device a pointer to the camtape backend
+ * @param proportion specify the proportion
+ * @return 0 on success or a negative value on error
+ */
+int camtape_setcap(void *device, uint16_t proportion)
+{
+	int rc;
+	char *msg = NULL;
+	struct camtape_data *softc = device;
+	unsigned char buf[TC_MP_MEDIUM_SENSE_SIZE];
+	union ccb *ccb = NULL;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_SETCAP));
+	if (IS_ENTERPRISE(softc->drive_type)) {
+		memset(buf, 0, sizeof(buf));
+
+		/* Scale media instead of setcap */
+		rc = camtape_modesense(device, TC_MP_MEDIUM_SENSE, TC_MP_PC_CURRENT, 0, buf, sizeof(buf));
+
+		/* Check Cartridge type */
+		if (rc == 0 &&
+			(buf[2] == TC_MP_JK || buf[2] == TC_MP_JY || buf[2] == TC_MP_JL || buf[2] == TC_MP_JZ)) {
+			/* Short or WORM cartridge cannot be scaled */
+			ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETCAP));
+			return DEVICE_GOOD;
+		}
+
+		buf[0]   = 0x00;
+		buf[1]   = 0x00;
+		buf[27] |= 0x01;
+		buf[28]  = 0x00;
+
+		rc = camtape_modeselect(device, buf, sizeof(buf));
+	} else {
+		int timeout;
+
+		ccb = cam_getccb(softc->cd);
+		if (ccb == NULL) {
+			rc = -EDEV_NO_MEMORY;
+			goto bailout;
+		}
+
+		bzero(&(&ccb->ccb_h)[1],
+			sizeof(struct ccb_scsiio) - sizeof(struct ccb_hdr));
+
+		timeout = camtape_get_timeout(softc->timeouts, SET_CAPACITY);
+		if (timeout < 0) {
+			rc = -EDEV_UNSUPPORETD_COMMAND;
+			goto bailout;
+		}
+ 
+		scsi_set_capacity(&ccb->csio,
+						  /*retries*/ 1,
+						  /*cbfcnp*/ NULL,
+						  /*tag_action*/ MSG_SIMPLE_Q_TAG,
+						  /*byte1*/ 0,
+						  /*proportion*/ proportion,
+						  /*sense_len*/ SSD_FULL_SIZE,
+						  /*timeout*/ timeout);
+
+		ccb->ccb_h.flags |= CAM_DEV_QFRZDIS | CAM_PASS_ERR_RECOVER;
+
+		rc = camtape_send_ccb(softc, ccb, &msg);
+
+		if (rc != DEVICE_GOOD) {
+			camtape_process_errors(device, rc, msg, "modeselect", true);
+		}
+	}
+
+bailout:
+	if (ccb != NULL)
+		cam_freeccb(ccb);
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETCAP));
+	return rc;
+}
+
+/**
+ * Get EOD status of a partition.
+ * @param device Device handle returned by the backend's open().
+ * @param part Partition to read the parameter from.
+ * @return enum eod_status or UNSUPPORTED_FUNCTION if not supported.
+ */
+#define LOG_VOL_STATISTICS         (0x17)
+#define LOG_VOL_USED_CAPACITY      (0x203)
+#define LOG_VOL_PART_HEADER_SIZE   (4)
+
+int camtape_get_eod_status(void *device, int part)
+{
+	/*
+	 * This feature requires new tape drive firmware
+	 * to support logpage 17h correctly
+	 */
+
+	struct camtape_data *softc = device;
+	unsigned char logdata[LOGSENSEPAGE];
+	unsigned char buf[16] = {0};
+	int param_size, rc;
+	unsigned int i;
+	uint32_t part_cap[2] = {EOD_UNKNOWN, EOD_UNKNOWN};
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_GETEODSTAT));
+	/* Issue LogPage 0x17 */
+	rc = camtape_logsense(device, LOG_VOL_STATISTICS, logdata, LOGSENSEPAGE);
+	if (rc) {
+		ltfsmsg(LTFS_WARN, 30464W, LOG_VOL_STATISTICS, rc);
+		ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETEODSTAT));
+		return EOD_UNKNOWN;
+	}
+
+	/* Parse Approximate used native capacity of partitions (0x203)*/
+	if (parse_logPage(logdata, (uint16_t)LOG_VOL_USED_CAPACITY, &param_size, buf, sizeof(buf))
+		|| (param_size != sizeof(buf) ) ) {
+		ltfsmsg(LTFS_WARN, 30465W);
+		ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETEODSTAT));
+		return EOD_UNKNOWN;
+	}
+
+	i = 0;
+	while (i + LOG_VOL_PART_HEADER_SIZE <= sizeof(buf)) {
+		unsigned char len;
+		uint16_t part_buf;
+
+		len = buf[i];
+		part_buf = (uint16_t)(buf[i + 2] << 8) + (uint16_t) buf[i + 3];
+		/* actual length - 1 is stored into len */
+		if ( (len - LOG_VOL_PART_HEADER_SIZE + 1) == sizeof(uint32_t) && part_buf < 2) {
+			part_cap[part_buf] = ((uint32_t) buf[i + 4] << 24) +
+				((uint32_t) buf[i + 5] << 16) +
+				((uint32_t) buf[i + 6] << 8) +
+				(uint32_t) buf[i + 7];
+		} else
+			ltfsmsg(LTFS_WARN, 30466W, i, part_buf, len);
+
+		i += (len + 1);
+	}
+
+	/* Create return value */
+	if(part_cap[part] == 0xFFFFFFFF)
+		rc = EOD_MISSING;
+	else
+		rc = EOD_GOOD;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETEODSTAT));
+	return rc;
+}
+
+/**
+ * Get vendor unique backend xattr
+ * @param device Device handle returned by the backend's open().
+ * @param name   Name of xattr
+ * @param buf    On success, fill this value with the pointer of data buffer for xattr
+ * @return 0 on success or a negative value on error.
+ */
+int camtape_get_xattr(void *device, const char *name, char **buf)
+{
+	struct camtape_data *priv = (struct camtape_data *) device;
+	unsigned char logdata[LOGSENSEPAGE];
+	unsigned char logbuf[16];
+	int param_size;
+	int rc = -LTFS_NO_XATTR;
+	uint32_t value32;
+	struct ltfs_timespec now;
+
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_GETXATTR));
+	if (! strcmp(name, "ltfs.vendor.IBM.mediaCQsLossRate")) {
+		rc = DEVICE_GOOD;
+
+		/* If first fetch or cache value is too old and valuie is dirty, refetch value */
+		get_current_timespec(&now);
+		if ( priv->fetch_sec_acq_loss_w == 0 ||
+			 ((priv->fetch_sec_acq_loss_w + 60 < now.tv_sec) && priv->dirty_acq_loss_w)) {
+			rc = camtape_logsense_page(device, LOG_PERFORMANCE, LOG_PERFORMANCE_CAPACITY_SUB,
+									   logdata, LOGSENSEPAGE);
+			if (rc)
+				ltfsmsg(LTFS_INFO, 30461I, LOG_PERFORMANCE, rc, "get xattr");
+			else {
+				if (parse_logPage(logdata, PERF_ACTIVE_CQ_LOSS_W, &param_size, logbuf, 16)) {
+					ltfsmsg(LTFS_INFO, 30462I, LOG_PERFORMANCE, "get xattr");
+					rc = -LTFS_NO_XATTR;
+				} else {
+					switch(param_size) {
+					case sizeof(uint32_t):
+						value32 = (uint32_t)ltfs_betou32(logbuf);
+						priv->acq_loss_w = (float)value32 / 65536.0;
+						priv->fetch_sec_acq_loss_w = now.tv_sec;
+						priv->dirty_acq_loss_w = false;
+						break;
+					default:
+						ltfsmsg(LTFS_INFO, 30467I, param_size);
+						rc = -LTFS_NO_XATTR;
+						break;
+					}
+				}
+			}
+		}
+
+		if(rc == DEVICE_GOOD) {
+			/* The buf allocated here shall be freed in xattr_get_virtual() */
+			rc = asprintf(buf, "%2.2f", priv->acq_loss_w);
+			if (rc < 0) {
+				rc = -LTFS_NO_MEMORY;
+				ltfsmsg(LTFS_INFO, 30468I, "getting active CQ loss write");
+			}
+			else
+				rc = DEVICE_GOOD;
+		} else
+			priv->fetch_sec_acq_loss_w = 0;
+	}
+
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETXATTR));
+	return rc;
+}
+
+/**
+ * Get vendor unique backend xattr
+ * @param device Device handle returned by the backend's open().
+ * @param name   Name of xattr
+ * @param buf    Data buffer to set the value
+ * @param size   Length of data buffer
+ * @return 0 on success or a negative value on error.
+ */
+int camtape_set_xattr(void *device, const char *name, const char *buf, size_t size)
+{
+	int rc = -LTFS_NO_XATTR;
+	char *null_terminated;
+	struct camtape_data *softc = device;
+
+
+	if (!size)
+		return -LTFS_BAD_ARG;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_SETXATTR));
+
+	null_terminated = malloc(size + 1);
+	if (! null_terminated) {
+		ltfsmsg(LTFS_ERR, 10001E, "lin_tape_ibmtape_set_xattr: null_term");
+		ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETXATTR));
+		return -LTFS_NO_MEMORY;
+	}
+	memcpy(null_terminated, buf, size);
+	null_terminated[size] = '\0';
+
+	if (! strcmp(name, "ltfs.vendor.IBM.forceErrorWrite")) {
+		softc->force_writeperm = strtoull(null_terminated, NULL, 0);
+		if (softc->force_writeperm && softc->force_writeperm < THRESHOLD_FORCE_WRITE_NO_WRITE)
+			softc->force_writeperm = THRESHOLD_FORCE_WRITE_NO_WRITE;
+		rc = DEVICE_GOOD;
+	} else if (! strcmp(name, "ltfs.vendor.IBM.forceErrorType")) {
+		softc->force_errortype = strtol(null_terminated, NULL, 0);
+		rc = DEVICE_GOOD;
+	} else if (! strcmp(name, "ltfs.vendor.IBM.forceErrorRead")) {
+		softc->force_readperm = strtoull(null_terminated, NULL, 0);
+		softc->read_counter = 0;
+		rc = DEVICE_GOOD;
+	}
+	free(null_terminated);
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETXATTR));
+	return rc;
+}
+
+void camtape_help_message(void)
+{
+	ltfsresult(30559I, camtape_default_device);
+}
+
+const char *camtape_default_device_name(void)
+{
+	const char *devname;
+
+	devname = camtape_default_device;
+	return devname;
+}
+
+char *camtape_enc_state_to_str(camtape_encryption_state encryption_state)
+{
+	char *state = NULL;
+
+	switch (encryption_state) {
+	case CT_ENC_STATE_OFF:
+		state = "Off";
+		break;
+	case CT_ENC_STATE_ON:
+		state = "On";
+		break;
+	case CT_ENC_STATE_NA:
+		state = "N/A";
+		break;
+	case CT_ENC_STATE_UNKNOWN:
+	default:
+		state = "Unknown";
+		break;
+	}
+
+	return (state);
+}
+
+char *camtape_enc_method_to_str(camtape_encryption_method encryption_method)
+{
+	char *method = NULL;
+
+	switch (encryption_method) {
+	case CT_ENC_METHOD_NONE:
+		method = "None";
+		break;
+	case CT_ENC_METHOD_SYSTEM:
+		method = "System";
+		break;
+	case CT_ENC_METHOD_CONTROLLER:
+		method = "Controller";
+		break;
+	case CT_ENC_METHOD_APPLICATION:
+		method = "Application";
+		break;
+	case CT_ENC_METHOD_LIBRARY:
+		method = "Library";
+		break;
+	case CT_ENC_METHOD_INTERNAL:
+		method = "Internal";
+		break;
+	case CT_ENC_METHOD_CUSTOM:
+		method = "Custom";
+		break;
+	default:
+		method = "Unknown";
+		break;
+	}
+
+	return (method);
+}
+
+static void ltfsmsg_encryption_state(const struct camtape_encryption_status * const es,
+	const bool set)
+{
+	char s[128] = {'\0'};
+	char *method = NULL;
+	char *state = NULL;
+
+	method = camtape_enc_method_to_str(es->encryption_method);
+
+	state = camtape_enc_state_to_str(es->encryption_state);
+
+	sprintf(s, "Capable = %d, Method = %s(%d), State = %s(%d)", es->encryption_capable,
+			method, es->encryption_method, state, es->encryption_state);
+
+	ltfsmsg(LTFS_DEBUG, 30592D, set ? "set encryption state:" : "get encryption state:", s);
+}
+
+static int camtape_get_encryption_state(void *device, struct camtape_encryption_status * const p,
+	uint8_t *rwc_mode_buf, size_t rwc_buf_len, size_t *rwc_fill_len)
+{
+	int rc = DEVICE_GOOD;
+	struct camtape_encryption_status es;
+	uint8_t *buf = NULL;
+	size_t buf_size = MAX_UINT16;
+	struct scsi_mode_header_10 *mode_hdr;
+	struct camtape_ibm_rw_control_page *rwc_page;
+	struct camtape_ibm_initiator_spec_ext_page *ise_page;
+	char *msg = NULL;
+
+	buf = malloc(buf_size);
+	if (buf == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+	bzero(buf, buf_size);
+	bzero(&es, sizeof(es));
+
+	/*
+	 * XXX KDM
+	 * There is no way with the API for the modesense routine to figure out how much data
+	 * we got in response to our request.  We allocate and ask for buf_size, and we can see how
+	 * much data the target says is there, but we can't see if there is an underrun.  The API
+	 * also always assumes that the function issues a 10 byte mode sense.
+	 */
+	rc = camtape_modesense(device, CT_ISE_PAGE_CODE, TC_MP_PC_CURRENT, 0x00, buf, buf_size);
+	if (rc != DEVICE_GOOD)
+		goto bailout;
+
+	mode_hdr = (struct scsi_mode_header_10 *)buf;
+	ise_page = (struct camtape_ibm_initiator_spec_ext_page *)find_mode_page_10(mode_hdr);
+
+	/*
+	 * We first check to see whether this drive is capable of encryption.  If not, there is
+	 * no point in checking to see whether it is enabled.
+	 */
+	if (ise_page->support_flags & CT_ISE_ENCRYPTION_CAPABLE)
+		es.encryption_capable = CT_ENC_CAPABLE;
+	else
+		es.encryption_capable = CT_ENC_NOT_CAPABLE;
+
+	if (es.encryption_capable == CT_ENC_NOT_CAPABLE) {
+		es.encryption_method = CT_ENC_METHOD_NONE;
+		es.encryption_state = CT_ENC_STATE_OFF;
+		goto bailout;
+	}	
+
+	bzero(buf, buf_size);
+
+	rc = camtape_modesense(device, CT_RWC_PAGE_CODE, TC_MP_PC_CURRENT, 0x00, buf, buf_size);
+
+	if (rc != DEVICE_GOOD)
+		goto bailout;
+
+	/*
+	 * Give the caller a copy of the buffer if he requested it.
+	 */
+	if ((rwc_mode_buf != NULL) && (rwc_buf_len > 0)) {
+		*rwc_fill_len = MIN(buf_size, rwc_buf_len);
+		bcopy(buf, rwc_mode_buf, *rwc_fill_len);
+	}
+	
+	mode_hdr = (struct scsi_mode_header_10 *)buf;
+	rwc_page = (struct camtape_ibm_rw_control_page *)find_mode_page_10(mode_hdr);
+
+	/*
+	 * In the IBM Linux tape driver, the difference between "system" and "application"
+	 * encryption appears to be whether an application requested turning encryption on, or
+	 * whether encryption was enabled when the driver loaded or via a sysfs/procfs request.
+	 *
+	 * The defines for encryption_state in struct encryption_status are the values for the
+	 * bottom 2 bits of the encryption_state byte in the mode page verbatim.
+	 */
+	es.encryption_method = rwc_page->encryption_method;
+	switch (rwc_page->encryption_method) {
+	case CT_RWC_ENC_METHOD_NONE:
+		es.encryption_state = CT_ENC_STATE_OFF;
+		break;
+	case CT_RWC_ENC_METHOD_SYSTEM:
+		es.encryption_state = rwc_page->encryption_state & CT_RWC_ENCRYPTION_STATE_MASK;
+		break;
+	case CT_RWC_ENC_METHOD_APPLICATION:
+		es.encryption_state = rwc_page->encryption_state & CT_RWC_ENCRYPTION_STATE_MASK;
+		break;
+	case CT_RWC_ENC_METHOD_LIBRARY:
+	case CT_RWC_ENC_METHOD_CUSTOM:
+	case CT_RWC_ENC_METHOD_INTERNAL:
+	case CT_RWC_ENC_METHOD_CONTROLLER:
+		es.encryption_state = CT_ENC_STATE_NA;
+		break;
+	default:
+		es.encryption_method = CT_ENC_METHOD_UNKNOWN;
+		es.encryption_state = CT_ENC_STATE_NA;
+		break;
+	}
+
+bailout:
+
+	ltfsmsg_encryption_state(&es, false);
+
+	if (rc != DEVICE_GOOD)
+		camtape_process_errors(device, rc, msg, "get encryption state", true);
+
+	if (p != NULL) {
+		if (rc == DEVICE_GOOD)
+			memcpy(p, &es, sizeof(es));
+		else
+			memset(p, 0, sizeof(es));
+	}
+
+	if (buf != NULL)
+		free(buf);
+
+	return rc;
+}
+
+static int camtape_set_encryption_state(struct camtape_data *softc,
+	camtape_encryption_state encryption_state)
+{
+	int rc = DEVICE_GOOD;
+	struct camtape_encryption_status es;
+	uint8_t *buf = NULL;
+	size_t buf_size = MAX_UINT16, buf_fill_len = 0;
+	struct scsi_mode_header_10 *mode_hdr;
+	struct camtape_ibm_rw_control_page *rwc_page;
+	char *msg = NULL;
+
+	buf = malloc(buf_size);
+	if (buf == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+	bzero(buf, buf_size);
+
+	rc = camtape_get_encryption_state(softc, &es, buf, buf_size, &buf_fill_len);
+	if (rc != DEVICE_GOOD)
+		goto bailout;
+
+	if (es.encryption_capable == CT_ENC_NOT_CAPABLE) {
+		rc = -EDEV_INVALID_ARG;
+		goto bailout;
+	}
+
+	/* Nothing to do if we're already in the requested state. */
+	if (encryption_state == es.encryption_state) {
+		rc = DEVICE_GOOD;
+		goto bailout;
+	}
+
+	mode_hdr = (struct scsi_mode_header_10 *)buf;
+	rwc_page = (struct camtape_ibm_rw_control_page *)find_mode_page_10(mode_hdr);
+
+	scsi_ulto2b(0, mode_hdr->data_length);
+	rwc_page->encryption_state &= ~CT_RWC_ENCRYPTION_STATE_MASK;
+	/*
+	 * Note that this assumes the camtape_encryption_state enumeration and the defines for the
+	 * mode page are the same.
+	 */
+	rwc_page->encryption_state |= encryption_state;
+
+	rc = camtape_modeselect(softc, buf, buf_fill_len);
+
+bailout:
+	if (rc != DEVICE_GOOD)
+		camtape_process_errors(softc, rc, msg, "set encryption state", true);
+	else {
+		es.encryption_state = encryption_state;
+		ltfsmsg_encryption_state(&es, true);
+	}
+
+	if (buf != NULL)
+		free(buf);
+	return rc;
+}
+
+static void ltfsmsg_keyalias(const char * const title, const unsigned char * const keyalias)
+{
+	char s[128] = {'\0'};
+
+	if (keyalias)
+		sprintf(s, "keyalias = %c%c%c%02X%02X%02X%02X%02X%02X%02X%02X%02X", keyalias[0],
+				keyalias[1], keyalias[2], keyalias[3], keyalias[4], keyalias[5], keyalias[6],
+				keyalias[7], keyalias[8], keyalias[9], keyalias[10], keyalias[11]);
+	else
+		sprintf(s, "keyalias: NULL");
+
+	ltfsmsg(LTFS_DEBUG, 30592D, title, s);
+}
+
+/*
+ * Determine whether we're using Application Managed Encryption or some other method.
+ */
+static bool is_ame(struct camtape_data *softc)
+{
+	unsigned char buf[TC_MP_READ_WRITE_CTRL_SIZE] = {0};
+	const int rc = camtape_modesense(softc, TC_MP_READ_WRITE_CTRL, TC_MP_PC_CURRENT, 0, buf, sizeof(buf));
+
+	if (rc != 0) {
+		char message[100] = {0};
+		sprintf(message, "failed to get MP %02Xh (%d)", TC_MP_READ_WRITE_CTRL, rc);
+		ltfsmsg(LTFS_DEBUG, 30592D, __FUNCTION__, message);
+
+		return false; /* Consider that the encryption method is not AME */
+	} else {
+		struct scsi_mode_header_10 *mode_hdr;
+		struct camtape_ibm_rw_control_page *rwc_page;
+		char message[100] = {0};
+		char *method = NULL;
+
+		mode_hdr = (struct scsi_mode_header_10 *)buf;
+		rwc_page = (struct camtape_ibm_rw_control_page *)find_mode_page_10(mode_hdr);
+
+		method = camtape_enc_method_to_str(rwc_page->encryption_method);
+		
+		sprintf(message, "Encryption Method is %s (0x%02X)", method, rwc_page->encryption_method);
+		ltfsmsg(LTFS_DEBUG, 30592D, __FUNCTION__, message);
+
+		if (rwc_page->encryption_method != CT_RWC_ENC_METHOD_APPLICATION) {
+			ltfsmsg(LTFS_ERR, 30469E, method, rwc_page->encryption_method);
+		}
+		return rwc_page->encryption_method == CT_RWC_ENC_METHOD_APPLICATION;
+	}
+}
+
+static int is_encryption_capable(struct camtape_data *softc)
+{
+
+	/*
+	 * XXX KDM why does this only support encryption, or at least Application Managed Encryption,
+	 * on LTO drives and not on TS drives?
+	 */
+	if (IS_ENTERPRISE(softc->drive_type)) {
+		ltfsmsg(LTFS_ERR, 30470E, softc->drive_type);
+		return -EDEV_INTERNAL_ERROR;
+	}
+
+	if (! is_ame(softc))
+		return -EDEV_INTERNAL_ERROR;
+
+	return DEVICE_GOOD;
+}
+
+/*
+ * See the comments in the mode page declaration.  This subpage is IBM-proprietary.  They don't
+ * document it in any public documents, and the IBM Linux tape driver obfuscates all of the
+ * functionality.  The only obvious parameters are the key and key alias/key index.
+ */
+static void camtape_fill_enc_subpage(struct camtape_ibm_enc_param_subpage *enc_sp,
+	int key_index_set, const uint8_t *key, const uint8_t *key_index)
+{
+	int subpage_length;
+
+	if (key_index_set != 0)
+		subpage_length = CT_ENC_PARAM_KI_EXTRA_LENGTH;
+	else
+		subpage_length = CT_ENC_PARAM_NO_KI_EXTRA_LENGTH;	
+	scsi_ulto2b(subpage_length, enc_sp->page_length);
+
+	enc_sp->desc1[0] = CT_ENC_PARAM_DESC_1_BYTE_0_VAL;
+	enc_sp->desc1[1] = CT_ENC_PARAM_DESC_1_BYTE_1_VAL;
+	enc_sp->desc1_length = subpage_length - CT_ENC_PARAM_DESC_1_ADDL_LENGTH_SUB;
+	enc_sp->desc2_length = subpage_length - CT_ENC_PARAM_DESC_2_ADDL_LENGTH_SUB;
+	enc_sp->desc3_length = subpage_length - CT_ENC_PARAM_DESC_3_ADDL_LENGTH_SUB;
+	enc_sp->desc4[57] = CT_ENC_PARAM_DESC_4_BYTE_57_VAL;
+	enc_sp->desc4[58] = CT_ENC_PARAM_DESC_4_BYTE_58_VAL;
+	enc_sp->desc4_length = subpage_length - CT_ENC_PARAM_DESC_4_ADDL_LENGTH_SUB;
+	enc_sp->byte76 &= CT_ENC_PARAM_BYTE_76_MASK;
+	enc_sp->byte79 = CT_ENC_PARAM_BYTE_79_VALUE;
+	enc_sp->byte80 = CT_ENC_PARAM_BYTE_80_VALUE;
+	enc_sp->byte83 = CT_ENC_PARAM_BYTE_83_VALUE;
+	bcopy(key, enc_sp->data_key, CT_ENC_PARAM_DATA_KEY_LEN);
+	enc_sp->byte116 = CT_ENC_PARAM_BYTE_116_VALUE;
+	if (key_index_set != 0)
+		enc_sp->byte119 = CT_ENC_PARAM_BYTE_119_VALUE_1;
+	else
+		enc_sp->byte119 = CT_ENC_PARAM_BYTE_119_VALUE_2;
+	enc_sp->byte121 = CT_ENC_PARAM_BYTE_121_VALUE;
+	enc_sp->byte124 = CT_ENC_PARAM_BYTE_124_VALUE;
+	if (key_index_set != 0) {
+		enc_sp->ki_or_not.ki_is_set.byte127 = CT_ENC_PARAM_BYTE127_KI_VALUE;
+		bcopy(key_index, enc_sp->ki_or_not.ki_is_set.key_index,
+			sizeof(enc_sp->ki_or_not.ki_is_set.key_index));
+		enc_sp->ki_or_not.ki_is_set.byte144 = CT_ENC_PARAM_BYTE144_KI_VALUE;
+	} else {
+		enc_sp->ki_or_not.ki_not_set.byte132 = CT_ENC_PARAM_BYTE132_NO_KI_VALUE;
+	}
+}
+
+int camtape_set_key(void *device, const unsigned char * const keyalias, const unsigned char * const key)
+{
+	struct camtape_data *softc = device;
+	camtape_encryption_state encryption_state = CT_ENC_STATE_OFF;
+	struct scsi_mode_header_10 *mode_hdr;
+	struct camtape_ibm_enc_param_subpage *enc_sp;
+	const char * const title = "set key:";
+	struct data_key dk = {{0}};
+	uint8_t *buf = NULL;
+	size_t bufsize = MAX_UINT16;
+	char *msg = NULL;
+	int rc;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_SETKEY));
+
+	rc = is_encryption_capable(softc);
+	if (rc < 0) {
+		goto bailout;
+	}
+
+	buf = malloc(bufsize);
+	if (buf == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+	bzero(buf, bufsize);
+
+	if (keyalias != NULL) {
+		CHECK_ARG_NULL(key, -LTFS_NULL_ARG);
+		encryption_state = CT_ENC_STATE_ON;
+		memcpy(dk.data_key_index, keyalias, sizeof(dk.data_key_index));
+		memcpy(dk.data_key, key, sizeof(dk.data_key));
+	}
+	dk.data_key_index_length = sizeof(dk.data_key_index);
+
+	rc = camtape_set_encryption_state(device, encryption_state);
+	if (rc != DEVICE_GOOD) {
+		ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETKEY));
+		return rc;
+	}
+
+	softc->is_data_key_set = keyalias != NULL;
+
+	ltfsmsg_keyalias(title, keyalias);
+
+	rc = camtape_modesense(device, CT_ENC_PARAM_SUBPAGE_PAGE_CODE, TC_MP_PC_CURRENT,
+		CT_ENC_PARAM_SUBPAGE_CODE, buf, bufsize);
+
+	if (rc != DEVICE_GOOD)
+		goto bailout;
+
+	mode_hdr = (struct scsi_mode_header_10 *)buf;
+	enc_sp = (struct camtape_ibm_enc_param_subpage *)find_mode_page_10(mode_hdr);
+
+	camtape_fill_enc_subpage(enc_sp, dk.data_key_index_length != 0, key, keyalias);
+
+	scsi_ulto2b(0, mode_hdr->data_length);
+
+	rc = camtape_modeselect(device, buf, bufsize);
+
+bailout:
+	if (rc != DEVICE_GOOD)
+		camtape_process_errors(device, rc, msg, "set data key", true);
+
+	if (buf != NULL)
+		free(buf);
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETKEY));
+
+	return rc;
+}
+
+static void show_hex_dump(const char * const title, const unsigned char * const buf, const uint size)
+{
+	/*
+	 * "         1         2         3         4         5         6         7         8"
+	 * "12345678901234567890123456789012345678901234567890123456789012345678901234567890"
+	 * "xxxxxx  00 01 02 03 04 05 06 07  08 09 0A 0B 0C 0D 0E 0F  0123456789ABCDEF\n" < 100
+	 */
+	char * const s = calloc((size / 0x10 + 1) * 100, sizeof(char));
+	char *p = s;
+	uint i = 0;
+	int j = 0;
+	int k = 0;
+
+	if (p == NULL)
+		return;
+
+	for (i = 0; i < size; ++i) {
+		if (i % 0x10 == 0) {
+			if (i) {
+				for (j = 0x10; 0 < j; --j) {
+					p += sprintf(p, "%c", isprint(buf[i-j]) ? buf[i-j] : '.');
+				}
+			}
+			p += sprintf(p, "\n%06X  ", i);
+		}
+		p += sprintf(p, "%02X %s", buf[i] & 0xFF, i % 8 == 7 ? " " : "");
+	}
+	for (; (i + k) % 0x10; ++k) {
+		p += sprintf(p, "   %s", (i + k) % 8 == 7 ? " " : "");
+	}
+	for (j = 0x10 - k; 0 < j; --j) {
+		p += sprintf(p, "%c", isprint(buf[i-j]) ? buf[i-j] : '.');
+	}
+
+	ltfsmsg(LTFS_DEBUG, 30592D, title, s);
+}
+
+int camtape_get_keyalias(void *device, unsigned char **keyalias) /* This is not IBM method but T10 method. */
+{
+	struct camtape_data *softc = device;
+	struct tde_next_block_enc_status_page *status_page;
+	int page_header_length = 4;
+	int buffer_length = page_header_length;
+	uint8_t enc_status;
+	union ccb *ccb = NULL;
+	uint8_t *buf = NULL;
+	char *msg = NULL;
+	int i, rc = DEVICE_GOOD;
+	int timeout;
+	
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_GETKEYALIAS));
+
+	rc = is_encryption_capable(device);
+	if (rc < 0) {
+		ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETKEYALIAS));
+		return rc;
+	}
+	memset(((struct camtape_data*) device)->dki, 0, sizeof(((struct camtape_data*) device)->dki));
+	*keyalias = NULL;
+
+	ccb = cam_getccb(softc->cd);
+	if (ccb == NULL) {
+		rc = -EDEV_NO_MEMORY;
+		goto bailout;
+	}
+
+	timeout = camtape_get_timeout(softc->timeouts, SECURITY_PROTOCOL_IN);
+	if (timeout < 0) {
+		rc = -EDEV_UNSUPPORETD_COMMAND;
+		goto bailout;
+	}
+
+	/*
+	 * 1st loop: Get the page length.
+	 * 2nd loop: Get full data in the page.
+	 */
+	for (i = 0; i < 2; ++i) {
+
+		/* Prepare Data Buffer */
+		if (buf != NULL) {
+			free(buf);
+			buf = NULL;
+		}
+		buf = (uint8_t *) calloc(buffer_length, sizeof(uint8_t));
+		if (buf == NULL) {
+			ltfsmsg(LTFS_ERR, 10001E, "camtape_get_keyalias: data buffer");
+			rc = -EDEV_NO_MEMORY;
+			goto bailout;
+		}
+
+		scsi_security_protocol_in(&ccb->csio,
+								  /*retries*/ 1,
+								  /*cbfcnp*/ NULL,
+								  /*tag_action*/ MSG_SIMPLE_Q_TAG,
+								  /*security_protocol*/ SPI_PROT_TAPE_DATA_ENC,
+								  /*sps*/ TDE_NEXT_BLOCK_ENC_STATUS_PAGE,
+								  /*byte4*/ 0,
+								  /*data_ptr*/ buf,
+								  /*dxfer_len*/ buffer_length,
+								  /*sense_len*/ SSD_FULL_SIZE,
+								  /*timeout*/ timeout);
+
+		ccb->ccb_h.flags |= CAM_DEV_QFRZDIS | CAM_PASS_ERR_RECOVER;
+
+		rc = camtape_send_ccb(softc, ccb, &msg);
+		if (rc != DEVICE_GOOD) {
+			camtape_process_errors(device, rc, msg, "get key-alias", true);
+			goto bailout;
+		}
+
+		show_hex_dump("SPIN:", buf, buffer_length);
+
+		status_page = (struct tde_next_block_enc_status_page *)buf;
+		buffer_length = page_header_length + scsi_2btoul(status_page->page_length);
+	}
+
+	
+	enc_status = status_page->status & TDE_NBES_ENC_STATUS_MASK;
+	switch (enc_status) {
+	case TDE_NBES_ENC_ALG_NOT_SUPPORTED:
+	case TDE_NBES_ENC_SUPPORTED_ALG:
+	case TDE_NBES_ENC_NO_KEY: {
+		struct tde_data_enc_desc *desc;
+		uint8_t *next_desc;
+
+		for (desc = (struct tde_data_enc_desc *)&status_page[1];
+			((((uint8_t *)desc - buf) + 4) <= buffer_length);
+			desc = (struct tde_data_enc_desc *)next_desc) {
+			uint32_t key_length;
+
+			next_desc = (uint8_t *)desc;
+			key_length = scsi_2btoul(desc->key_desc_length);
+			next_desc += key_length + __offsetof(struct tde_data_enc_desc, key_desc);
+
+			/*
+			 * We're looking for the Authenticated Key-Associated Data descriptor.
+			 */
+			if (desc->key_desc_type != TDE_KEY_DESC_A_KAD)
+				continue;
+
+			/*
+			 * Make sure that we aren't going off the end of the buffer.
+			 */
+			if ((next_desc - buf) > buffer_length)
+				break;
+
+			/*
+			 * Copy the key into the softc and let the caller know we got it.
+			 */
+			memcpy(softc->dki, desc->key_desc, MIN(key_length, sizeof(softc->dki)));
+			*keyalias = softc->dki;
+
+			break;
+		}
+		break;
+	}
+	default:
+		break;
+	}
+
+	const char * const title = "get key-alias:";
+	ltfsmsg_keyalias(title, softc->dki);
+
+bailout:
+
+	if (ccb != NULL)
+		cam_freeccb(ccb);
+	if (buf != NULL)
+		free(buf);
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETKEYALIAS));
+	return rc;
+}
+
+typedef enum {
+	CT_PP_LBP_R,
+	CT_PP_LBP_W,
+	CT_PP_RBDP,
+	CT_PP_PI_LENGTH,
+	CT_PP_PROT_METHOD
+} ct_protect_param;
+                        
+struct ct_protect_info {
+	const char *name;
+	struct mt_status_entry *entry;
+	uint32_t value;
+} ct_protect_list[] = {
+	{ "lbp_r", NULL, 0 },
+	{ "lbp_w", NULL, 0 },
+	{ "rbdp", NULL, 0 },
+	{ "pi_length", NULL, 0 },
+	{ "prot_method", NULL, 0 }
+};
+
+#define CT_NUM_PROTECT_PARAMS   (sizeof(ct_protect_list)/sizeof(ct_protect_list[0]))
+#define TC_MP_INIT_EXT_LBP_RS         (0x40)
+#define TC_MP_INIT_EXT_LBP_CRC32C     (0x20)
+
+int camtape_set_lbp(void *device, bool enable)
+{
+	struct camtape_data *softc = device;
+	struct mt_status_data mtinfo;
+	struct mt_status_entry *entry, *prot_entry;
+	struct ct_protect_info protect_list[CT_NUM_PROTECT_PARAMS];
+	struct mtparamset params[CT_NUM_PROTECT_PARAMS];
+	struct mtsetlist param_list;
+	char tmpname[64];
+	char *msg = NULL;
+	unsigned char lbp_method = LBP_DISABLE;
+	unsigned char buf[TC_MP_INIT_EXT_SIZE];
+	int rc = DEVICE_GOOD;
+	unsigned int i;
+
+	bzero(buf, sizeof(buf));
+
+	/* Check logical block protection capability */
+	rc = camtape_modesense(device, TC_MP_INIT_EXT, TC_MP_PC_CURRENT, 0x00, buf, sizeof(buf));
+	if (rc < 0)
+		return rc;
+
+	if (buf[0x12] & TC_MP_INIT_EXT_LBP_CRC32C)
+		lbp_method = CRC32C_CRC;
+	else
+		lbp_method = REED_SOLOMON_CRC;
+
+
+	/*
+	 * First grab all available parameter data.
+	 */
+	bzero(&mtinfo, sizeof(mtinfo));
+	rc = camtape_get_mtinfo(softc, &mtinfo, /*params*/ 1, &msg);
+	if (rc != DEVICE_GOOD)
+		goto bailout;
+
+	/*
+	 * Check to see whether protection is supported.
+	 */
+	snprintf(tmpname, sizeof(tmpname), "%s.protection_supported", MT_PROTECTION_NAME);
+	entry = mt_status_entry_find(&mtinfo, tmpname);
+	if (entry == NULL) {
+		msg = strdup("Cannot find sa(4) protection.protection_supported parameter");
+		rc = -EDEV_INVALID_ARG;
+		camtape_process_errors(device, rc, msg, "get lbp", true);
+		goto bailout;
+	}
+
+	if (entry->value_signed != 1) {
+		/*
+		 * This device doesn't support logical block protection.  Nothing else to do here.
+		 */
+		ltfsmsg(LTFS_INFO, 30472I);
+		goto bailout;
+	}
+
+	/*
+	 * Get the base protection node.
+	 */
+	prot_entry = mt_status_entry_find(&mtinfo, MT_PROTECTION_NAME);
+	if (prot_entry == NULL) {
+		msg = strdup("Cannot find sa(4) protection node!");
+		rc = -EDEV_INVALID_ARG;
+		camtape_process_errors(device, rc, msg, "get lbp", true);
+		goto bailout;
+	}
+
+	/* set logical block protection */
+	ltfsmsg(LTFS_DEBUG, 30593D, "LBP Enable", enable, "");
+	ltfsmsg(LTFS_DEBUG, 30593D, "LBP Method", lbp_method, "");
+
+	bcopy(ct_protect_list, protect_list, MIN(sizeof(protect_list), sizeof(ct_protect_list)));
+
+	if (enable) {
+		protect_list[CT_PP_LBP_R].value = 1;
+		protect_list[CT_PP_LBP_W].value = 1;
+		/* IBM drives at least don't support RBDP */
+		protect_list[CT_PP_RBDP].value = 0;
+		/*
+		 * XXX KDM add sa(4) defines for CRC32
+		 */
+		protect_list[CT_PP_PI_LENGTH].value = SA_CTRL_DP_RS_LENGTH;
+		protect_list[CT_PP_PROT_METHOD].value = lbp_method;
+	} else {
+		protect_list[CT_PP_LBP_R].value = 0;
+		protect_list[CT_PP_LBP_W].value = 0;
+		protect_list[CT_PP_RBDP].value = 0;
+		protect_list[CT_PP_PI_LENGTH].value = 0;
+		protect_list[CT_PP_PROT_METHOD].value = 0;
+	}
+
+	for (i = 0; i < CT_NUM_PROTECT_PARAMS; i++) {
+		entry = mt_entry_find(prot_entry, __DECONST(char *, protect_list[i].name));
+		if (entry == NULL) {
+			msg = strdup("Cannot find all protection information entries");
+			rc = -EDEV_INVALID_ARG;
+			camtape_process_errors(device, rc, msg, "get lbp", true);
+			goto bailout;
+		}
+		protect_list[i].entry = entry;
+		snprintf(params[i].value_name, sizeof(params[i].value_name), "%s.%s", MT_PROTECTION_NAME,
+		    protect_list[i].name);
+		params[i].value_type = MT_PARAM_SET_UNSIGNED;
+		params[i].value_len = sizeof(protect_list[i].value);
+		params[i].value.value_unsigned = protect_list[i].value;
+	}
+
+	param_list.num_params = CT_NUM_PROTECT_PARAMS;
+	param_list.param_len = sizeof(params);
+	param_list.params = params;
+
+	if (ioctl(softc->fd_sa, MTIOCSETLIST, &param_list) == -1) {
+		char tmpstr[512];
+
+		snprintf(tmpstr, sizeof(tmpstr), "Error returned from MTIOCSETLIST ioctl to set "
+			"protection parameters: %s", strerror(errno));
+		msg = strdup(tmpstr);
+		rc = -errno;
+		camtape_process_errors(device, rc, msg, "get lbp", true);
+		goto bailout;	
+	}
+
+	for (i = 0; i < CT_NUM_PROTECT_PARAMS; i++) {
+		if (params[i].status != MT_PARAM_STATUS_OK) {
+			rc = -EDEV_DRIVER_ERROR;
+			camtape_process_errors(device, rc, params[i].error_str, "get lbp", true);
+			goto bailout;	
+		}
+	}
+
+	if (enable) {
+		switch (lbp_method) {
+		case CRC32C_CRC:
+			softc->f_crc_enc = crc32c_enc;
+			softc->f_crc_check = crc32c_check;
+			break;
+		case REED_SOLOMON_CRC:
+			softc->f_crc_enc = rs_gf256_enc;
+			softc->f_crc_check = rs_gf256_check;
+			break;
+		default:
+			softc->f_crc_enc   = NULL;
+			softc->f_crc_check = NULL;
+			break;
+		}
+		ltfsmsg(LTFS_INFO, 30471I);
+	} else {
+		ltfsmsg(LTFS_INFO, 30472I);
+	}
+
+bailout:
+	camtape_free_mtinfo(softc, &mtinfo);
+
+	return rc;
+}
+
+int camtape_is_mountable(void *device, const char *barcode, const unsigned char cart_type, 
+						 const unsigned char density)
+{
+	int ret;
+	struct camtape_data *softc = device;
+        
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_ISMOUNTABLE));
+
+	ret = ibm_tape_is_mountable(softc->drive_type,
+							   barcode,
+							   cart_type,
+							   density,
+							   global_data.strict_drive);
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_ISMOUNTABLE));
+        
+	return ret;
+}
+        
+bool camtape_is_readonly(void *device)
+{
+	int ret;
+	struct camtape_data *softc = device;
+
+	ret = ibm_tape_is_mountable(softc->drive_type,
+							   NULL,
+							   softc->cart_type,
+							   softc->density_code,
+							   global_data.strict_drive);
+
+	if (ret == MEDIUM_READONLY)
+		return true;
+	else
+		return false;
+}
+
+/* This function should be called after the cartridge is loaded. */
+int camtape_get_worm_status(void *device, bool *is_worm)
+{
+	int rc = 0;
+	struct camtape_data *priv = ((struct camtape_data *) device);
+
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_GETWORMSTAT));
+	if (priv->loaded) {
+		*is_worm = priv->is_worm;
+	}
+	else {
+		ltfsmsg(LTFS_INFO, 30489I);
+		*is_worm = false;
+		rc = -1;
+	}
+
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETWORMSTAT));
+	return rc;
+}
+
+struct tape_ops camtape_drive_handler = {
+	.open                   = camtape_open,
+	.reopen                 = camtape_reopen,
+	.close                  = camtape_close,
+	.close_raw              = camtape_close_raw,
+	.is_connected           = camtape_is_connected,
+	.inquiry                = camtape_inquiry,
+	.inquiry_page           = camtape_inquiry_page,
+	.test_unit_ready        = camtape_test_unit_ready,
+	.read                   = camtape_read,
+	.write                  = camtape_write,
+	.writefm                = camtape_writefm,
+	.rewind                 = camtape_rewind,
+	.locate                 = camtape_locate,
+	.space                  = camtape_space,
+	.erase                  = camtape_erase,
+	.load                   = camtape_load,
+	.unload                 = camtape_unload,
+	.readpos                = camtape_readpos,
+	.setcap                 = camtape_setcap,
+	.format                 = camtape_format,
+	.remaining_capacity     = camtape_remaining_capacity,
+	.logsense               = camtape_logsense,
+	.modesense              = camtape_modesense,
+	.modeselect             = camtape_modeselect,
+	.reserve_unit           = camtape_reserve_unit,
+	.release_unit           = camtape_release_unit,
+	.prevent_medium_removal = camtape_prevent_medium_removal,
+	.allow_medium_removal   = camtape_allow_medium_removal,
+	.write_attribute        = camtape_write_attribute,
+	.read_attribute         = camtape_read_attribute,
+	.allow_overwrite        = camtape_allow_overwrite,
+	// May be command combination
+	.set_compression        = camtape_set_compression,
+	.set_default            = camtape_set_default,
+	.get_cartridge_health   = camtape_get_cartridge_health,
+	.get_tape_alert         = camtape_get_tape_alert,
+	.clear_tape_alert       = camtape_clear_tape_alert,
+	.get_xattr              = camtape_get_xattr,
+	.set_xattr              = camtape_set_xattr,
+	.get_parameters         = camtape_get_parameters,
+	.get_eod_status         = camtape_get_eod_status,
+	.get_device_list        = camtape_get_device_list,
+	.help_message           = camtape_help_message,
+	.parse_opts             = camtape_parse_opts,
+	.default_device_name    = camtape_default_device_name,
+	.set_key                = camtape_set_key,
+	.get_keyalias           = camtape_get_keyalias,
+	.takedump_drive         = camtape_takedump_drive,
+	.is_mountable           = camtape_is_mountable,
+	.get_worm_status		= camtape_get_worm_status,
+	.get_serialnumber		= camtape_get_serialnumber,
+	.set_profiler			= camtape_set_profiler,
+	.get_block_in_buffer	= camtape_get_block_in_buffer,
+	.is_readonly			= camtape_is_readonly
+};
+
+struct tape_ops *tape_dev_get_ops(void)
+{
+	return &camtape_drive_handler;
+}
+
+extern char tape_freebsd_camtape_dat[];
+
+const char *tape_dev_get_message_bundle_name(void **message_data)
+{
+	*message_data = tape_freebsd_camtape_dat;
+	return "tape_freebsd_camtape";
+}
+
+/**
+ * Given the SA device, opens the SA and Pass Thru devices for 
+ * the specified tape drive. 
+ *  
+ * @author Ryan Guthrie (ryang@spectralogic.com) (5/2/2013)
+ * 
+ * @param priv the IBM struct containing persistent information. 
+ *  						It is where the file descriptors for the pass
+ *  						and SA are stored.
+ * @param saDeviceName the SA (Sequential Access) device for the
+ *  								   tape driver
+ * 
+ * @return int 0 on success, or a negative value on error 
+ *  			 opening either the SA or PASS devices.
+ */
+int open_sa_pass(struct camtape_data *priv, const char *saDeviceName)
+{
+	int ret = 0;
+
+	struct cam_device *cd_pass = cam_open_device(saDeviceName, O_RDWR);
+
+	if (cd_pass == NULL) {
+		ltfsmsg(LTFS_INFO, 30425I, saDeviceName, errno);
+		return -EDEV_DEVICE_UNOPENABLE;
+	}
+
+	char passDeviceName[MAXPATHLEN+1];
+	snprintf(passDeviceName, MAXPATHLEN, "/dev/%s%d", cd_pass->device_name, cd_pass->dev_unit_num);
+
+	ret = open_sa_device(priv, saDeviceName);
+	if (ret) {
+		cam_close_device(cd_pass);
+		ltfsmsg(LTFS_INFO, 30425I, saDeviceName, errno);
+		return ret;
+	}
+
+	priv->cd = cd_pass;
+
+	return 0;
+}
+
+int open_sa_device(struct camtape_data *priv, const char* saDeviceName)
+{
+	int ret = 0;
+
+	priv->fd_sa = open(saDeviceName, O_RDWR | O_NDELAY);
+	if (priv->fd_sa < 0) {
+		priv->fd_sa = open(saDeviceName, O_RDONLY | O_NDELAY);
+		if (priv->fd_sa < 0) {
+			if (errno == EAGAIN) {
+				ltfsmsg(LTFS_ERR, 30424E, saDeviceName);
+				ret = -EDEV_DEVICE_BUSY;
+			} else {
+				ltfsmsg(LTFS_INFO, 30425I, saDeviceName, errno);
+				ret = -EDEV_DEVICE_UNOPENABLE;
+			}
+			return ret;
+		}
+		ltfsmsg(LTFS_WARN, 30426W, saDeviceName);
+	}
+
+	return ret;
+}
+
+void close_sa_device(struct camtape_data *priv)
+{
+	if (priv->fd_sa > 0) {
+		close(priv->fd_sa);
+		priv->fd_sa = 0;
+	}
+}
+void close_cd_pass_device(struct camtape_data *priv)
+{
+	if (priv->cd != NULL) {
+		cam_close_device(priv->cd);
+		priv->cd = NULL;
+	}
+}
+
+#undef __camtape_tc_c

--- a/src/tape_drivers/ibm_tape.c
+++ b/src/tape_drivers/ibm_tape.c
@@ -48,6 +48,11 @@
 */
 
 #ifndef mingw_PLATFORM
+#ifdef __FreeBSD__
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#endif /* __FreeBSD__ */ 
 #include <netdb.h>
 #include <ifaddrs.h>
 #include <unistd.h>


### PR DESCRIPTION
# Summary of changes

This brings in a FreeBSD support for LTFS.

# Description
This brings in FreeBSD support for LTFS.  This requires the FreeBSD tape improvements checked in to FreeBSD in February 2015.  Specifically, it will work on FreeBSD 10.2 or 11.0 or newer releases.

The port was modeled on the lin_tape backend.  It uses a combination of the FreeBSD sa(4) tape driver and the pass(4) SCSI passthrough driver to send commands to the tape drive.

The encryption support has not been tested, but the rest of the functionality has been in production on Spectra Logic Black Pearl products since 2013.  The port also passed LTO Consortium LTFS Compliance Verification:

https://www.lto.org/technology/ltfs/ltfs-compliance-verification/

There is currently no failover support in the FreeBSD backend.  It could be done at some point if someone wants to do it.

This also includes a different mrsw lock implementation for FreeBSD only to resolve some deadlocks that we experienced with the default implementation.  One of my co-workers mentioned it in this issue:

https://github.com/LinearTapeFileSystem/ltfs/issues/8

I am working on a second pull request with most of the rest of Spectra Logic's changes to LTFS.  That one isn't ready yet.  It is mostly independent of this change, but there may be some minor dependencies.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
