### PR TITLE
Handle read-only combination of tape and drive

### DIFF
--- a/messages/bin_ltfs/root.txt
+++ b/messages/bin_ltfs/root.txt
@@ -117,7 +117,7 @@ root:table {
 		14075E:string { "Cannot set up tape drive." }
 		14076I:string { "Attempting to mount the cartridge without EOD existence check." }
 		14077I:string { "The cartridge will be mounted as read-only." }
-		// unused 14078E:string { "CM in the cartridge might be corrupted. Try to run ltfs with the \"-o force_mount_no_eod\" option." }
+		14078I:string { "Medium is Read-Only in this device." }
 		14079E:string { "Invalid uid \'%s\' (must be a positive integer or valid user name)." }
 		14080E:string { "Invalid gid \'%s\' (must be a positive integer or valid group name)." }
 		//unused 14081E:string { "Failed to create a dentry cache view for cartridge \"%s\"." }


### PR DESCRIPTION
# Summary of changes

Currently ltfs falis to mount LTO5 tape on LTO7 drive. I enbugged this corruption from 2.2.2.0 to 2.4.0.0.

This pull request includes following changes or fixes. 

- Fix of issue #33 

# Description

Currently ltfs falis to mount LTO5 tape on LTO7 drive.  This is a basic functionality breakage. I want to fix as soon as possible.

Following tests are made

- Mount LTO5 tape on LTO7 drive as read-only mode
- Mount LTO6 tape on LTO6 drive as read-write  mode

Fixes #33

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
