### PR TITLE
Handle read-only combination of tape and drive (#34)

### DIFF
--- a/messages/bin_ltfs/root.txt
+++ b/messages/bin_ltfs/root.txt
@@ -117,7 +117,7 @@ root:table {
 		14075E:string { "Cannot set up tape drive." }
 		14076I:string { "Attempting to mount the cartridge without EOD existence check." }
 		14077I:string { "The cartridge will be mounted as read-only." }
-		// unused 14078E:string { "CM in the cartridge might be corrupted. Try to run ltfs with the \"-o force_mount_no_eod\" option." }
+		14078I:string { "Medium is Read-Only in this device." }
 		14079E:string { "Invalid uid \'%s\' (must be a positive integer or valid user name)." }
 		14080E:string { "Invalid gid \'%s\' (must be a positive integer or valid group name)." }
 		//unused 14081E:string { "Failed to create a dentry cache view for cartridge \"%s\"." }

--- a/src/libltfs/plugin.c
+++ b/src/libltfs/plugin.c
@@ -199,7 +199,7 @@ static void print_help_message(void *ops, const char * const type)
 		if (ret < 0) {
 			ltfsmsg(LTFS_ERR, 11316E);
 		}
-	} else if (! strcmp(type, "driver"))
+	} else if (! strcmp(type, "tape"))
 		tape_print_help_message(ops);
 	else
 		ltfsmsg(LTFS_ERR, 11317E, type);
@@ -213,7 +213,7 @@ void plugin_usage(const char *type, struct config_file *config)
 
 	backends = config_file_get_plugins(type, config);
 	if (! backends) {
-		if (! strcmp(type, "driver"))
+		if (! strcmp(type, "tape"))
 			ltfsresult(14403I); /* -o devname=<dev> */
 		return;
 	}


### PR DESCRIPTION
Handle read-only combination of tape and drive correctly like LTO5 tape
and LTO7 drive. I enbugged this corruption from 2.2.2.0 to 2.4.0.0.

The fix of issue #33. And this fix was already merged into v2.4.0 branch.

# Summary of changes

This pull request includes following changes or fixes. 

- Fix of issue #issue_no
- Add foo
- Change bar

# Description

Please include relevant motivation and context. List any dependencies that are required for this change.

Fixes #issue_no

## Type of change

Please delete items that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works
