### PR TITLE
Tiny fix of plugin help print

### DIFF
--- a/src/libltfs/plugin.c
+++ b/src/libltfs/plugin.c
@@ -199,7 +199,7 @@ static void print_help_message(void *ops, const char * const type)
 		if (ret < 0) {
 			ltfsmsg(LTFS_ERR, 11316E);
 		}
-	} else if (! strcmp(type, "driver"))
+	} else if (! strcmp(type, "tape"))
 		tape_print_help_message(ops);
 	else
 		ltfsmsg(LTFS_ERR, 11317E, type);
@@ -213,7 +213,7 @@ void plugin_usage(const char *type, struct config_file *config)
 
 	backends = config_file_get_plugins(type, config);
 	if (! backends) {
-		if (! strcmp(type, "driver"))
+		if (! strcmp(type, "tape"))
 			ltfsresult(14403I); /* -o devname=<dev> */
 		return;
 	}


### PR DESCRIPTION
Fix to print plugin help correctly. It is broken when teh tape backend
name prefix from "driver" to "tape".

This fix is a part of the freebsd patch provided by Spectra Logic (Nor merged yet!!). I will backport this portion to v2.4.0 branch.

# Summary of changes

Small correction to print help text correctly. No issue is reported yet.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
