### PR TITLE
Add a file for syslog on macOS

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,10 @@
+# Files in this directory
+
+- CODE_OF_CONDUCT.md: Coding Style guide for LTFS
+- ltfs-log.conf: Configuration for rsyslog
+- ltfslog: Configuration of syslog-ng
+- com.ibm.ltfs: Configuration of log system on macOS (ASL)
+- ltfs.conf.example: Example of ltfs.conf
+- ltfs.conf.local.example: Example of ltfs.conf.local
+- ltfs.service: Service file for init.d to have clean unmount at shutdown/reboot
+- filedebug_tc_conf.xml: Tape configuration sample for the file backend

--- a/docs/com.ibm.ltfs
+++ b/docs/com.ibm.ltfs
@@ -1,0 +1,3 @@
+# For LTFS
+> /var/log/ltfs.log mode=0640 compress format=std rotate=seq file_max=5M all_max=100M
+? [CA= Sender ltfs] file /var/log/ltfs.log


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Add a configuration file for syslog on macOS

# Description

The commands in this project put the messages via syslog. But almost all support OS don't put the messages by default. 

There are the configuration files put the message to /var/log/ltfs.log under doc directory for rsyslog and syslog-ng. But the ASL for mac is not existed. 

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
