### PR TITLE
Make retry_count an integer to avoid incrementing a boolean expression.

### DIFF
--- a/src/tape_drivers/linux/sg-ibmtape/sg_scsi_tape.c
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_scsi_tape.c
@@ -183,7 +183,7 @@ int sg_issue_cdb_command(struct sg_tape *device, sg_io_hdr_t *req, char **msg)
 	uint32_t sense = 0;
 	unsigned short d_suggest = 0, d_status;
 	unsigned char masked_status = 0;
-	bool retry_count = 0;
+	unsigned int retry_count = 0;
 
 	CHECK_ARG_NULL(req, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(msg, -LTFS_NULL_ARG);


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Changes the data type of `retry_count` to unsigned integer, as we are not supposed to increment/decrement booleans.

# Description

Fixes incrementing a boolean, which is non-compliant with recent versions of the C standard.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works
