### PR TITLE
 Update version number to 2.4.0.2 (10071) 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@
 dnl
 dnl LTFS configure.ac.
 dnl
-AC_INIT([LTFS], [2.4.0.1 (10062)], IBM corporation.)
+AC_INIT([LTFS], [2.4.0.2 (10071)], IBM corporation.)
 AC_CONFIG_SRCDIR([src/main.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIRS([m4])

--- a/src/libltfs/ltfs.h
+++ b/src/libltfs/ltfs.h
@@ -154,7 +154,7 @@ struct device_data;
 
 #ifdef __APPLE_MAKEFILE__
 #define PACKAGE_NAME                  "LTFS"
-#define PACKAGE_VERSION               "2.4.0.1"
+#define PACKAGE_VERSION               "2.4.0.2"
 #else
 #include "config.h"
 #endif


### PR DESCRIPTION
# Summary of changes

Version number is updated to 2.4.0.2 (10071) 

# Description

IBM released IBM Spectrum Archive SDE 2.4.0.2 (10071) in 2018/04/13. It is good to have a  equivalent version in this project. 

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
