### PR TITLE
Move plugin to lib/ltfs on install-exec-hook

### DIFF
--- a/src/iosched/Makefile.am
+++ b/src/iosched/Makefile.am
@@ -34,7 +34,7 @@
 #
 
 lib_LTLIBRARIES = libiosched-fcfs.la libiosched-unified.la
-libdir = @libdir@/ltfs
+BASENAMES = libiosched-fcfs libiosched-unified
 
 AM_LIBTOOLFLAGS = --tag=disable-static
 
@@ -51,4 +51,6 @@ libiosched_unified_la_LIBADD = ../libltfs/libltfs.la
 libiosched_unified_la_CPPFLAGS = @AM_CPPFLAGS@ -I ..
 
 install-exec-hook:
+	mkdir -p $(libdir)/ltfs
 	for f in $(lib_LTLIBRARIES); do rm -f $(libdir)/$$f; done
+	for f in $(BASENAMES); do mv $(libdir)/$$f* $(libdir)/ltfs; done

--- a/src/kmi/Makefile.am
+++ b/src/kmi/Makefile.am
@@ -34,7 +34,7 @@
 #
 
 lib_LTLIBRARIES = libkmi-simple.la libkmi-flatfile.la
-libdir = @libdir@/ltfs
+BASENAMES = libkmi-simple libkmi-flatfile
 
 AM_LIBTOOLFLAGS = --tag=disable-static
 
@@ -51,4 +51,6 @@ libkmi_flatfile_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ -L../../message
 libkmi_flatfile_la_CPPFLAGS = @AM_CPPFLAGS@ -I ..
 
 install-exec-hook:
+	mkdir -p $(libdir)/ltfs
 	for f in $(lib_LTLIBRARIES); do rm -f $(libdir)/$$f; done
+	for f in $(BASENAMES); do mv $(libdir)/$$f* $(libdir)/ltfs; done

--- a/src/tape_drivers/freebsd/cam/Makefile.am
+++ b/src/tape_drivers/freebsd/cam/Makefile.am
@@ -36,7 +36,7 @@
 
 
 lib_LTLIBRARIES = libtape-cam.la
-libdir = @libdir@/ltfs
+BASENAMES = libtape-cam
 
 AM_LIBTOOLFLAGS = --tag=disable-static
 
@@ -56,4 +56,6 @@ libtape_cam_la-ibm_tape.lo: ../../ibm_tape.c
 	$(LIBTOOL)  --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libtape_cam_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) $(CRC_OPTIMIZE) -MT libtape_cam_la-ibm_tape.lo -MD -MP -c -o libtape_cam_la-ibm_tape.lo ../../ibm_tape.c
 
 install-exec-hook:
+	mkdir -p $(libdir)/ltfs
 	for f in $(lib_LTLIBRARIES); do rm -f $(libdir)/$$f; done
+	for f in $(BASENAMES); do mv $(libdir)/$$f* $(libdir)/ltfs; done

--- a/src/tape_drivers/generic/file/Makefile.am
+++ b/src/tape_drivers/generic/file/Makefile.am
@@ -34,7 +34,7 @@
 #
 
 lib_LTLIBRARIES = libtape-file.la
-libdir = @libdir@/ltfs
+BASENAMES = libtape-file
 
 AM_LIBTOOLFLAGS = --tag=disable-static
 
@@ -51,4 +51,6 @@ clean-local:
 	rm -f ibm_tape.c
 
 install-exec-hook:
+	mkdir -p $(libdir)/ltfs
 	for f in $(lib_LTLIBRARIES); do rm -f $(libdir)/$$f; done
+	for f in $(BASENAMES); do mv $(libdir)/$$f* $(libdir)/ltfs; done

--- a/src/tape_drivers/generic/itdtimg/Makefile.am
+++ b/src/tape_drivers/generic/itdtimg/Makefile.am
@@ -34,7 +34,7 @@
 #
 
 lib_LTLIBRARIES = libtape-itdtimg.la
-libdir = @libdir@/ltfs
+BASENAMES = libtape-itdtimg
 
 AM_LIBTOOLFLAGS = --tag=disable-static
 
@@ -45,4 +45,6 @@ libtape_itdtimg_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ -L../../../../m
 libtape_itdtimg_la_CPPFLAGS = @AM_CPPFLAGS@ -I ../../..
 
 install-exec-hook:
+	mkdir -p $(libdir)/ltfs
 	for f in $(lib_LTLIBRARIES); do rm -f $(libdir)/$$f; done
+	for f in $(BASENAMES); do mv $(libdir)/$$f* $(libdir)/ltfs; done

--- a/src/tape_drivers/linux/lin_tape/Makefile.am
+++ b/src/tape_drivers/linux/lin_tape/Makefile.am
@@ -34,7 +34,7 @@
 #
 
 lib_LTLIBRARIES = libtape-lin_tape.la
-libdir = @libdir@/ltfs
+BASENAMES = libtape-lin_tape
 
 AM_LIBTOOLFLAGS = --tag=disable-static
 
@@ -57,4 +57,6 @@ libtape_lin_tape_la-crc32c_crc.lo: ../../crc32c_crc.c
 	$(LIBTOOL)  --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libtape_lin_tape_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) $(CRC_OPTIMIZE) -MT libtape_lin_tape_la-crc32c_crc.lo -MD -MP -c -o libtape_lin_tape_la-crc32c_crc.lo $<
 
 install-exec-hook:
+	mkdir -p $(libdir)/ltfs
 	for f in $(lib_LTLIBRARIES); do rm -f $(libdir)/$$f; done
+	for f in $(BASENAMES); do mv $(libdir)/$$f* $(libdir)/ltfs; done

--- a/src/tape_drivers/linux/sg-ibmtape/Makefile.am
+++ b/src/tape_drivers/linux/sg-ibmtape/Makefile.am
@@ -34,7 +34,7 @@
 #
 
 lib_LTLIBRARIES = libtape-sg-ibmtape.la
-libdir = @libdir@/ltfs
+BASENAMES = libtape-sg-ibmtape
 
 AM_LIBTOOLFLAGS = --tag=disable-static
 
@@ -57,4 +57,6 @@ libtape_sg_ibmtape_la-crc32c_crc.lo: ../../crc32c_crc.c
 	$(LIBTOOL)  --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libtape_sg_ibmtape_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) $(CRC_OPTIMIZE) -MT libtape_sg_ibmtape_la-crc32c_crc.lo -MD -MP -c -o libtape_sg_ibmtape_la-crc32c_crc.lo $<
 
 install-exec-hook:
+	mkdir -p $(libdir)/ltfs
 	for f in $(lib_LTLIBRARIES); do rm -f $(libdir)/$$f; done
+	for f in $(BASENAMES); do mv $(libdir)/$$f* $(libdir)/ltfs; done

--- a/src/tape_drivers/osx/iokit-ibmtape/Makefile.am
+++ b/src/tape_drivers/osx/iokit-ibmtape/Makefile.am
@@ -34,7 +34,7 @@
 #
 
 lib_LTLIBRARIES = libtape-iokit-ibmtape.la
-libdir = @libdir@/ltfs
+BASENAMES = libtape-iokit-ibmtape
 
 AM_LIBTOOLFLAGS = --tag=disable-static
 
@@ -57,4 +57,6 @@ libtape_iokit_ibmtape_la-crc32c_crc.lo: ../../crc32c_crc.c
 	$(LIBTOOL)  --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libtape_iokit_ibmtape_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) $(CRC_OPTIMIZE) -MT libtape_iokit_ibmtape_la-crc32c_crc.lo -MD -MP -c -o libtape_iokit_ibmtape_la-crc32c_crc.lo $<
 
 install-exec-hook:
+	mkdir -p $(libdir)/ltfs
 	for f in $(lib_LTLIBRARIES); do rm -f $(libdir)/$$f; done
+	for f in $(BASENAMES); do mv $(libdir)/$$f* $(libdir)/ltfs; done


### PR DESCRIPTION
# Summary of changes

Changes for creating rpm package cleanly.

# Description

Previously move plugin files to lib/ltfs by overwriting libdir. But this
is not a good way from creating rpm point of view. The libtool rejects
install modules to non-standard directory.

This patch make following changes
1. Once install plugin into lib directory by install-exec target
2. Remove .la files in lib directory by install-exec-hook
3. Move plugin, so files, to lib/ltfs directory ny install-exec-hook

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
