### PR TITLE
Support pseudo error on the sg backend for debug

### DIFF
--- a/messages/tape_linux_sg_ibmtape/root.txt
+++ b/messages/tape_linux_sg_ibmtape/root.txt
@@ -113,6 +113,9 @@ root:table {
 		30271I:string { "Successfully reopen the drive %s with same path." }
 		30272I:string { "Drive %s is reserved successfully." }
 		30273I:string { "Cannot %s device flag (%d)." }
+		30274I:string { "Pseudo-error on %s." }
+		30275I:string { "Pseudo-error on write. Good return code, but a record to emulate a write error did not get sent to the drive." }
+
 
 		30392D:string { "Backend %s %s." }
 		30393D:string { "Backend %s: %d %s." }


### PR DESCRIPTION
# Summary of changes

Support pseudo I/O error for debugging error path for the sg backend. 

# Description

This feature is already available in the file backend and lin_tape backend.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
