### PR TITLE
ltfs: Makefile.am enhancement supporting DESTDIR

### DIFF
--- a/src/iosched/Makefile.am
+++ b/src/iosched/Makefile.am
@@ -51,6 +51,6 @@ libiosched_unified_la_LIBADD = ../libltfs/libltfs.la
 libiosched_unified_la_CPPFLAGS = @AM_CPPFLAGS@ -I ..
 
 install-exec-hook:
-	mkdir -p $(libdir)/ltfs
-	for f in $(lib_LTLIBRARIES); do rm -f $(libdir)/$$f; done
-	for f in $(BASENAMES); do mv $(libdir)/$$f* $(libdir)/ltfs; done
+	mkdir -p $(DESTDIR)$(libdir)/ltfs
+	for f in $(lib_LTLIBRARIES); do rm -f $(DESTDIR)$(libdir)/$$f; done
+	for f in $(BASENAMES); do mv $(DESTDIR)$(libdir)/$$f* $(DESTDIR)$(libdir)/ltfs; done

--- a/src/kmi/Makefile.am
+++ b/src/kmi/Makefile.am
@@ -51,6 +51,6 @@ libkmi_flatfile_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ -L../../message
 libkmi_flatfile_la_CPPFLAGS = @AM_CPPFLAGS@ -I ..
 
 install-exec-hook:
-	mkdir -p $(libdir)/ltfs
-	for f in $(lib_LTLIBRARIES); do rm -f $(libdir)/$$f; done
-	for f in $(BASENAMES); do mv $(libdir)/$$f* $(libdir)/ltfs; done
+	mkdir -p $(DESTDIR)$(libdir)/ltfs
+	for f in $(lib_LTLIBRARIES); do rm -f $(DESTDIR)$(libdir)/$$f; done
+	for f in $(BASENAMES); do mv $(DESTDIR)$(libdir)/$$f* $(DESTDIR)$(libdir)/ltfs; done

--- a/src/tape_drivers/generic/file/Makefile.am
+++ b/src/tape_drivers/generic/file/Makefile.am
@@ -51,6 +51,6 @@ clean-local:
 	rm -f ibm_tape.c
 
 install-exec-hook:
-	mkdir -p $(libdir)/ltfs
-	for f in $(lib_LTLIBRARIES); do rm -f $(libdir)/$$f; done
-	for f in $(BASENAMES); do mv $(libdir)/$$f* $(libdir)/ltfs; done
+	mkdir -p $(DESTDIR)$(libdir)/ltfs
+	for f in $(lib_LTLIBRARIES); do rm -f $(DESTDIR)$(libdir)/$$f; done
+	for f in $(BASENAMES); do mv $(DESTDIR)$(libdir)/$$f* $(DESTDIR)$(libdir)/ltfs; done

--- a/src/tape_drivers/generic/itdtimg/Makefile.am
+++ b/src/tape_drivers/generic/itdtimg/Makefile.am
@@ -45,6 +45,6 @@ libtape_itdtimg_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ -L../../../../m
 libtape_itdtimg_la_CPPFLAGS = @AM_CPPFLAGS@ -I ../../..
 
 install-exec-hook:
-	mkdir -p $(libdir)/ltfs
-	for f in $(lib_LTLIBRARIES); do rm -f $(libdir)/$$f; done
-	for f in $(BASENAMES); do mv $(libdir)/$$f* $(libdir)/ltfs; done
+	mkdir -p $(DESTDIR)$(libdir)/ltfs
+	for f in $(lib_LTLIBRARIES); do rm -f $(DESTDIR)$(libdir)/$$f; done
+	for f in $(BASENAMES); do mv $(DESTDIR)$(libdir)/$$f* $(DESTDIR)$(libdir)/ltfs; done

--- a/src/tape_drivers/linux/lin_tape/Makefile.am
+++ b/src/tape_drivers/linux/lin_tape/Makefile.am
@@ -57,6 +57,6 @@ libtape_lin_tape_la-crc32c_crc.lo: ../../crc32c_crc.c
 	$(LIBTOOL)  --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libtape_lin_tape_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) $(CRC_OPTIMIZE) -MT libtape_lin_tape_la-crc32c_crc.lo -MD -MP -c -o libtape_lin_tape_la-crc32c_crc.lo $<
 
 install-exec-hook:
-	mkdir -p $(libdir)/ltfs
-	for f in $(lib_LTLIBRARIES); do rm -f $(libdir)/$$f; done
-	for f in $(BASENAMES); do mv $(libdir)/$$f* $(libdir)/ltfs; done
+	mkdir -p $(DESTDIR)$(libdir)/ltfs
+	for f in $(lib_LTLIBRARIES); do rm -f $(DESTDIR)$(libdir)/$$f; done
+	for f in $(BASENAMES); do mv $(DESTDIR)$(libdir)/$$f* $(DESTDIR)$(libdir)/ltfs; done

--- a/src/tape_drivers/linux/sg-ibmtape/Makefile.am
+++ b/src/tape_drivers/linux/sg-ibmtape/Makefile.am
@@ -57,6 +57,6 @@ libtape_sg_ibmtape_la-crc32c_crc.lo: ../../crc32c_crc.c
 	$(LIBTOOL)  --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libtape_sg_ibmtape_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) $(CRC_OPTIMIZE) -MT libtape_sg_ibmtape_la-crc32c_crc.lo -MD -MP -c -o libtape_sg_ibmtape_la-crc32c_crc.lo $<
 
 install-exec-hook:
-	mkdir -p $(libdir)/ltfs
-	for f in $(lib_LTLIBRARIES); do rm -f $(libdir)/$$f; done
-	for f in $(BASENAMES); do mv $(libdir)/$$f* $(libdir)/ltfs; done
+	mkdir -p $(DESTDIR)$(libdir)/ltfs
+	for f in $(lib_LTLIBRARIES); do rm -f $(DESTDIR)$(libdir)/$$f; done
+	for f in $(BASENAMES); do mv $(DESTDIR)$(libdir)/$$f* $(DESTDIR)$(libdir)/ltfs; done


### PR DESCRIPTION
o support autotools $(DESTDIR)
o install-hook now suport to copy compiled libraries
  to a given destination directory, thus use it
  for packaging tools (ubuntu, debian, arch-linux)

# Summary of changes

This pull request includes following changes or fixes. 

- support autotools $(DESTDIR)
-  install-hook now suport to copy compiled libraries
   to a given destination directory, thus use it
   for packaging tools (ubuntu, debian, arch-linux)

# Description

I'd like to use LTFS on Ubuntu and Arch-Linux.
I found your OpenSource project here an Github and tried to compile it on the actual LTO Release of Ubuntu (bionic). I cloaned it and build an initial debian subdir with needed build rules etc.
After some work and triggering I resolved needed dependency packages and incorporated that to the debian package build. Now it is compiling and I got an installable package.

## Type of change

The PR is only uploading the needed changes in the Makefiles.am. Now i can use a DESTDIR variable in the package-build process to ramp up the final installation package as a .deb

## Example output form Ubuntu Machine 
obviously, this is not working since i have no IBM Drive. I try to make it run for an ULTRIUM-HH7

Host: scsi2 Channel: 00 Id: 00 Lun: 00
 Vendor: IBM      Model: ULTRIUM-HH7      Rev: FA17

### using ltfs
ltfs -d /dev/st0
a70 LTFS14000I LTFS starting, LTFS version 2.4.0.1 (10062), log level 2.
a70 LTFS14058I LTFS Format Specification version 2.4.0.
a70 LTFS14104I Launched by "ltfs -d /dev/st0".
a70 LTFS14105I This binary is built for Linux (x86_64).
a70 LTFS14106I GCC version is 7.3.0.
a70 LTFS17087I Kernel version: Linux version 4.11.0-14-generic (buildd@lcy01-08) (gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4) ) #20~16.04.1-Ubuntu SMP Wed Aug 9 09:06:22 UTC 2017 i386.
a70 LTFS17089I Distribution: NAME="Ubuntu".
a70 LTFS17089I Distribution: DISTRIB_ID=Ubuntu.
a70 LTFS14063I Sync type is "time", Sync time is 300 sec.
a70 LTFS17085I Plugin: Loading "lin_tape" tape backend.
a70 LTFS17085I Plugin: Loading "unified" iosched backend.
a70 LTFS14095I Set the tape device write-anywhere mode to avoid cartridge ejection.
a70 LTFS30415W Cannot detect lin_tape version.
a70 LTFS30417E Old lin_tape version is detected.
a70 LTFS12012E Cannot open device: failed backend open call.
a70 LTFS10004E Cannot open device '/dev/IBMtape0'.

### using mkltfs
mkltfs --device=/dev/tape/by-id/scsi-35005076312143950 --rules="size=1M" --tape-serial=DWS009 --volume-name="DWS LTFS 009"
LTFS15000I Starting mkltfs, LTFS version 2.4.0.1 (10062), log level 2.
LTFS15041I Launched by "mkltfs --device=/dev/tape/by-id/scsi-35005076312143950 --rules=size=1M --tape-serial=DWS009 --volume-name=DWS LTFS 009".
LTFS15042I This binary is built for Linux (x86_64).
LTFS15043I GCC version is 7.3.0.
LTFS17087I Kernel version: Linux version 4.11.0-14-generic (buildd@lcy01-08) (gcc version 5.4.0 20160609 (Ubuntu 5.4.0-6ubuntu1~16.04.4) ) #20~16.04.1-Ubuntu SMP Wed Aug 9 09:06:22 UTC 2017 i386.
LTFS17089I Distribution: NAME="Ubuntu".
LTFS17089I Distribution: DISTRIB_ID=Ubuntu.
LTFS15003I Formatting device '/dev/tape/by-id/scsi-35005076312143950'.
LTFS15004I LTFS volume blocksize: 524288.
LTFS15005I Index partition placement policy: size=1M.

LTFS11337I Update index-dirty flag (1) - DWS009 (0x0xe88b0c4b10).
LTFS17085I Plugin: Loading "lin_tape" tape backend.
LTFS30415W Cannot detect lin_tape version.
LTFS30417E Old lin_tape version is detected.
LTFS12012E Cannot open device: failed backend open call.
LTFS15009E Cannot open device '/dev/tape/by-id/scsi-35005076312143950' (-21701).
LTFS15023I Formatting failed.