### PR TITLE
compile tape_driver with buggy I/Fs support   

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -149,6 +149,34 @@ AC_ARG_ENABLE([lintape],
 AC_MSG_RESULT([$lintape])
 
 dnl
+dnl Handle --enable-buggy-ifs (default:no, Linux/OSx Only)
+dnl
+AC_MSG_CHECKING([whether to enable handling of buggy I/Fs or not (Linux/OSx Only)])
+AC_ARG_ENABLE([buggy_ifs],
+    [AS_HELP_STRING([--enable-buggy-ifs],[Support handling of buggy I/Fs for tape drivers])],
+    [buggy_ifs=$enableval],
+    [buggy_ifs=no]
+)
+AC_MSG_RESULT([$buggy_ifs])
+
+dnl
+dnl Handle extra compile flags for tape driver
+dnl
+if test "x${buggy_ifs}" = "xyes"
+then
+    if test "x${host_linux}" = "xyes"
+    then
+        AM_EXTRA_CPPFLAGS="${AM_EXTRA_CPPFLAGS} -DSUPPORT_BUGGY_IFS"
+	AC_ARG_VAR([buggy_ifs], [compile with SUPPORT_BUGGY_IFS enabled])
+    fi
+    if test "x${host_mac}" = "xyes"
+    then
+        AM_EXTRA_CPPFLAGS="${AM_EXTRA_CPPFLAGS} -DSUPPORT_BUGGY_IFS"
+	AC_ARG_VAR([buggy_ifs], [compile with SUPPORT_BUGGY_IFS enabled])
+    fi
+fi
+
+dnl
 dnl Handle default backends
 dnl
 if test -z "$DEFAULT_TAPE"
@@ -390,6 +418,11 @@ then
     AM_CPPFLAGS="${AM_CPPFLAGS} -DPOSIXLINK_ONLY"
 fi
 
+if test "x$livelink" = "xno"
+then
+    AM_CPPFLAGS="${AM_CPPFLAGS} -DPOSIXLINK_ONLY"
+fi
+
 dnl
 dnl Specify CPU specific optimizer options for CRC calculation
 dnl
@@ -477,6 +510,7 @@ AM_CONDITIONAL([CHK_MESSAGE], [test "x${use_msg_check}" = "xyes"])
 AC_SUBST(CFLAGS)
 AC_SUBST(CRC_OPTIMIZE)
 AC_SUBST(AM_CPPFLAGS)
+AC_SUBST(AM_EXTRA_CPPFLAGS)
 AC_SUBST(AM_CFLAGS)
 AC_SUBST(AM_LDFLAGS)
 

--- a/configure.ac
+++ b/configure.ac
@@ -296,6 +296,13 @@ then
     PKG_CHECK_MODULES([ICU_MODULE], [icu >= 0.21])
 fi
 
+AC_MSG_CHECKING(for ICU version)
+ICU_MODULE_VERSION="`icu-config --version 2> /dev/null`";
+AC_MSG_RESULT([$ICU_MODULE_VERSION])
+AX_COMPARE_VERSION([$ICU_MODULE_VERSION], [ge], [60.1],
+   [AM_EXTRA_CPPFLAGS="${AM_EXTRA_CPPFLAGS} -DUNORM2"]
+)
+
 dnl
 dnl Check for SNMP
 dnl

--- a/src/libltfs/Makefile.am
+++ b/src/libltfs/Makefile.am
@@ -70,7 +70,7 @@ libltfs_la_SOURCES = \
 
 libltfs_la_DEPENDENCIES = ../../messages/liblibltfs_dat.a ../../messages/libinternal_error_dat.a ../../messages/libtape_common_dat.a
 libltfs_la_LIBADD =
-libltfs_la_CPPFLAGS = @AM_CPPFLAGS@ -I ..
+libltfs_la_CPPFLAGS = @AM_CPPFLAGS@ @AM_EXTRA_CPPFLAGS@ -I ..
 libltfs_la_LDFLAGS = @AM_LDFLAGS@ -L../../messages -llibltfs_dat -linternal_error_dat -ltape_common_dat
 
 install-data-local:

--- a/src/libltfs/pathname.c
+++ b/src/libltfs/pathname.c
@@ -57,13 +57,21 @@
 #include <ICU/unicode/ustring.h>
 #include <ICU/unicode/utypes.h>
 #include <ICU/unicode/ucnv.h>
+#ifdef UNORM2
 #include <ICU/unicode/unorm.h>
+#else
+#include <ICU/unicode/unorm2.h>
+#endif
 #else
 #include <unicode/uchar.h>
 #include <unicode/ustring.h>
 #include <unicode/utypes.h>
 #include <unicode/ucnv.h>
+#ifdef UNORM2
 #include <unicode/unorm.h>
+#else
+#include <unicode/unorm2.h>
+#endif
 #endif
 
 #include "ltfs.h"
@@ -509,7 +517,7 @@ int _pathname_format_icu(const char *src, char **dest, bool validate, bool allow
 	return 0;
 }
 
-int pathname_nfd_normaize(const char *name, char **new_name)
+int pathname_nfd_normalize(const char *name, char **new_name)
 {
 	int ret;
 	CHECK_ARG_NULL(name, -LTFS_NULL_ARG);
@@ -656,14 +664,30 @@ int _pathname_normalize_nfc_icu(const UChar *src, UChar **dest)
 {
 	UErrorCode err = U_ZERO_ERROR;
 	int32_t destlen;
+#ifdef UNORM2
+	const UNormalizer2 *n2;
+	UChar *dest;
+#endif
 
 	/* Do a quick check to decide whether this string is already normalized. */
-	if (unorm_quickCheck(src, -1, UNORM_NFC, &err) == UNORM_YES) {
+#ifdef UNORM2
+	if (unorm2_quickCheck(n2, src, -1, &err) == UNORM_YES) {
+#else
+	if (unorm_quickCheck(src, -1, UNORM_NFD, &err) == UNORM_YES) {
+#endif
 		*dest = (UChar *)src;
 		return 0;
 	}
 	err = U_ZERO_ERROR;
 
+#ifdef UNORM2
+	destlen = unorm2_normalize(n2, src, -1, dest, NULL, &err);
+	if (U_FAILURE(err) && err != U_BUFFER_OVERFLOW_ERROR) {
+		ltfsmsg(LTFS_ERR, 11238E, err);
+		return -LTFS_ICU_ERROR;
+	}
+	err = U_ZERO_ERROR;
+#else
 	destlen = unorm_normalize(src, -1, UNORM_NFC, 0, NULL, 0, &err);
 	if (U_FAILURE(err) && err != U_BUFFER_OVERFLOW_ERROR) {
 		ltfsmsg(LTFS_ERR, 11238E, err);
@@ -684,6 +708,7 @@ int _pathname_normalize_nfc_icu(const UChar *src, UChar **dest)
 		*dest = NULL;
 		return -LTFS_ICU_ERROR;
 	}
+#endif
 
 	return 0;
 }
@@ -699,13 +724,63 @@ int _pathname_normalize_nfd_icu(const UChar *src, UChar **dest)
 	UErrorCode err = U_ZERO_ERROR;
 	int32_t destlen;
 
+        /**
+	 * unorm2_quickCheck
+	 * Tests if the string is normalized.
+	 * Internally, in cases where the quickCheck() method would return "maybe"
+	 * (which is only possible for the two COMPOSE modes) this method
+	 * resolves to "yes" or "no" to provide a definitive result,
+	 * at the cost of doing more work in those cases.
+	 * @param norm2 UNormalizer2 instance
+	 * @param s input string
+	 * @param length length of the string, or -1 if NUL-terminated
+	 * @param pErrorCode Standard ICU error code. Its input value must
+	 *                   pass the U_SUCCESS() test, or else the function returns
+	 *                   immediately. Check for U_FAILURE() on output or use with
+	 *                   function chaining. (See User Guide for details.)
+	 * @return TRUE if s is normalized
+	 * @stable ICU 4.4
+	 */
+	const UNormalizer2 *n2;
+	UChar *dest;
+
+	/**
+	 * unorm2_normalize
+	 * Writes the normalized form of the source string to the destination string
+	 * (replacing its contents) and returns the length of the destination string.
+	 * The source and destination strings must be different buffers.
+	 * @param norm2 UNormalizer2 instance
+	 * @param src source string
+	 * @param length length of the source string, or -1 if NUL-terminated
+	 * @param dest destination string; its contents is replaced with normalized src
+	 * @param capacity number of UChars that can be written to dest
+	 * @param pErrorCode Standard ICU error code. Its input value must
+	 *                   pass the U_SUCCESS() test, or else the function returns
+	 *                   immediately. Check for U_FAILURE() on output or use with
+	 *                   function chaining. (See User Guide for details.)
+	 * @return dest
+	 * @stable ICU 4.4
+	 */
+
 	/* Do a quick check to decide whether this string is already normalized. */
+#ifdef UNORM2
+	if (unorm2_quickCheck(n2, src, -1, &err) == UNORM_YES) {
+#else
 	if (unorm_quickCheck(src, -1, UNORM_NFD, &err) == UNORM_YES) {
+#endif
 		*dest = (UChar *)src;
 		return 0;
 	}
 	err = U_ZERO_ERROR;
 
+#ifdef UNORM2
+	destlen = unorm2_normalize(n2, src, -1, dest, NULL, &err);
+	if (U_FAILURE(err) && err != U_BUFFER_OVERFLOW_ERROR) {
+		ltfsmsg(LTFS_ERR, 11240E, err);
+		return -LTFS_ICU_ERROR;
+	}
+	err = U_ZERO_ERROR;
+#else
 	destlen = unorm_normalize(src, -1, UNORM_NFD, 0, NULL, 0, &err);
 	if (U_FAILURE(err) && err != U_BUFFER_OVERFLOW_ERROR) {
 		ltfsmsg(LTFS_ERR, 11240E, err);
@@ -726,6 +801,7 @@ int _pathname_normalize_nfd_icu(const UChar *src, UChar **dest)
 		*dest = NULL;
 		return -LTFS_ICU_ERROR;
 	}
+#endif
 
 	return 0;
 }

--- a/src/tape_drivers/linux/sg-ibmtape/Makefile.am
+++ b/src/tape_drivers/linux/sg-ibmtape/Makefile.am
@@ -42,7 +42,7 @@ libtape_sg_ibmtape_la_SOURCES = sg_scsi_tape.c sg_ibmtape.c ibm_tape.c
 libtape_sg_ibmtape_la_DEPENDENCIES = ../../../../messages/libtape_linux_sg_ibmtape_dat.a ../../../libltfs/libltfs.la ./libtape_sg_ibmtape_la-reed_solomon_crc.lo ./libtape_sg_ibmtape_la-crc32c_crc.lo
 libtape_sg_ibmtape_la_LIBADD = ../../../libltfs/libltfs.la ./libtape_sg_ibmtape_la-reed_solomon_crc.lo ./libtape_sg_ibmtape_la-crc32c_crc.lo
 libtape_sg_ibmtape_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ -L../../../../messages -ltape_linux_sg_ibmtape_dat
-libtape_sg_ibmtape_la_CPPFLAGS = @AM_CPPFLAGS@ -I ../../.. -I ../..
+libtape_sg_ibmtape_la_CPPFLAGS = @AM_CPPFLAGS@ @AM_EXTRA_CPPFLAGS@ -I ../../.. -I ../..
 
 ibm_tape.c:
 	ln -s ../../ibm_tape.c ./ibm_tape.c

--- a/src/tape_drivers/osx/iokit-ibmtape/Makefile.am
+++ b/src/tape_drivers/osx/iokit-ibmtape/Makefile.am
@@ -42,7 +42,7 @@ libtape_iokit_ibmtape_la_SOURCES = iokit_ibmtape.c iokit_scsi.c iokit_service.c 
 libtape_iokit_ibmtape_la_DEPENDENCIES = ../../../../messages/libtape_iokit_ibmtape_dat.a ../../../libltfs/libltfs.la ./libtape_iokit_ibmtape_la-reed_solomon_crc.lo ./libtape_iokit_ibmtape_la-crc32c_crc.lo
 libtape_iokit_ibmtape_la_LIBADD = ../../../libltfs/libltfs.la ./libtape_iokit_ibmtape_la-reed_solomon_crc.lo ./libtape_iokit_ibmtape_la-crc32c_crc.lo
 libtape_iokit_ibmtape_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ -L../../../../messages -ltape_iokit_ibmtape_dat
-libtape_iokit_ibmtape_la_CPPFLAGS = @AM_CPPFLAGS@ -I ../../.. -I ../..
+libtape_iokit_ibmtape_la_CPPFLAGS = @AM_CPPFLAGS@ @AM_EXTRA_CPPFLAGS@ -I ../../.. -I ../..
 
 ibm_tape.c:
 	ln -s ../../ibm_tape.c ./ibm_tape.c

--- a/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
+++ b/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
@@ -1147,7 +1147,7 @@ static int _cdb_read(void *device, char *buf, size_t size, boolean_t sili)
 						((int32_t)sense_data->INFORMATION_4);
 
 					if (!req.actual_xfered || diff_len != req.resid) {
-#if SUPPORT_BUGGY_IF
+#if SUPPORT_BUGGY_IFS
 						/*
 						 * A few I/Fs, like thunderbolt/SAS converter or USB/SAS converter,
 						 * cannot handle actual transfer length and residual length correctly


### PR DESCRIPTION
# enable compilation with selectalbe flag to support buggy I/Fs

some HBAs do not return correct  transfer length and residual length.
This patch introduces the needed build-system flags to select patching the drivers for OSx and Linux.
If set, the Makefiles will include an extra preprocessor flag and compile with a workarround.

