### PR TITLE
supporting ICU 6x functions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -296,6 +296,25 @@ then
     PKG_CHECK_MODULES([ICU_MODULE], [icu >= 0.21])
 fi
 
+AC_MSG_CHECKING([use latest ICU])
+AC_ARG_ENABLE([icu_6x],
+    [AS_HELP_STRING([--enable-icu-6x],[Support handling of ICU 6x functions])],
+    [icu_6x=$enableval],
+    [icu_6x=no]
+)
+AC_MSG_RESULT([$icu_6x])
+
+if test "x${icu_6x}" = "xyes"
+then
+    AC_MSG_CHECKING(for ICU version)
+    ICU_MODULE_VERSION="`icu-config --version 2> /dev/null`";
+    if test "${ICU_MODULE_VERSION%%.*}" -ge "60"
+    then
+	AM_EXTRA_CPPFLAGS="${AM_EXTRA_CPPFLAGS} -D ICU6x"
+    fi
+    AC_MSG_RESULT([$ICU_MODULE_VERSION])
+fi
+
 dnl
 dnl Check for SNMP
 dnl

--- a/src/libltfs/Makefile.am
+++ b/src/libltfs/Makefile.am
@@ -70,7 +70,7 @@ libltfs_la_SOURCES = \
 
 libltfs_la_DEPENDENCIES = ../../messages/liblibltfs_dat.a ../../messages/libinternal_error_dat.a ../../messages/libtape_common_dat.a
 libltfs_la_LIBADD =
-libltfs_la_CPPFLAGS = @AM_CPPFLAGS@ -I ..
+libltfs_la_CPPFLAGS = @AM_CPPFLAGS@ @AM_EXTRA_CPPFLAGS@ -I ..
 libltfs_la_LDFLAGS = @AM_LDFLAGS@ -L../../messages -llibltfs_dat -linternal_error_dat -ltape_common_dat
 
 install-data-local:


### PR DESCRIPTION
o overcome warnings for depreciated old ICU function-calls (<=v60.1)
o support new normalization functions (unorm2.h)

# Summary of changes

This pull request is a rework of #52 
Please subtitute! This is still WIP and doesn't solve the issue.
Per default configure rule will compile with old unorm.h functions offering complete functionality asa before.

# Results
It offers a configure switch to enable ICU 6x
With this option enabled, the code compliles.
But if you are going to mount a tape I have seen a memory allocaton error.
So, this has to be addressed. 

# Error
I do think it is concerned with the nature of the new function-call to unorm2_normalize()
This function requires a "capacity number" as 5th field.
I have no clue, on howto determin the needed size, since it has to take into account the size of the source string (2nd field). 
Right now i hardcoded the capacity with 1024 which might be inadequate.
