### PR TITLE
update ICU version handling

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -296,12 +296,24 @@ then
     PKG_CHECK_MODULES([ICU_MODULE], [icu >= 0.21])
 fi
 
-AC_MSG_CHECKING(for ICU version)
-ICU_MODULE_VERSION="`icu-config --version 2> /dev/null`";
-AC_MSG_RESULT([$ICU_MODULE_VERSION])
-AX_COMPARE_VERSION([$ICU_MODULE_VERSION], [ge], [60.1],
-   [AM_EXTRA_CPPFLAGS="${AM_EXTRA_CPPFLAGS} -DUNORM2"]
+AC_MSG_CHECKING([use latest ICU])
+AC_ARG_ENABLE([icu_6x],
+    [AS_HELP_STRING([--enable-icu-6x],[Support handling of ICU 6x functions])],
+    [icu_6x=$enableval],
+    [icu_6x=no]
 )
+AC_MSG_RESULT([$icu_6x])
+
+if test "x${icu_6x}" = "xyes"
+then
+    AC_MSG_CHECKING(for ICU version)
+    ICU_MODULE_VERSION="`icu-config --version 2> /dev/null`";
+    if test "${ICU_MODULE_VERSION%%.*}" -ge "60"
+    then
+	AM_EXTRA_CPPFLAGS="${AM_EXTRA_CPPFLAGS} -D ICU6x"
+    fi
+    AC_MSG_RESULT([$ICU_MODULE_VERSION])
+fi
 
 dnl
 dnl Check for SNMP

--- a/src/libltfs/Makefile.am
+++ b/src/libltfs/Makefile.am
@@ -70,7 +70,7 @@ libltfs_la_SOURCES = \
 
 libltfs_la_DEPENDENCIES = ../../messages/liblibltfs_dat.a ../../messages/libinternal_error_dat.a ../../messages/libtape_common_dat.a
 libltfs_la_LIBADD =
-libltfs_la_CPPFLAGS = @AM_CPPFLAGS@ @AM_EXTRA_CPPFLAGS@ -I ..
+libltfs_la_CPPFLAGS = @AM_CPPFLAGS@ @AM_EXTRA_CPPFLAGS@ @AM_EXTRA_CPPFLAGS@ -I ..
 libltfs_la_LDFLAGS = @AM_LDFLAGS@ -L../../messages -llibltfs_dat -linternal_error_dat -ltape_common_dat
 
 install-data-local:

--- a/src/libltfs/pathname.c
+++ b/src/libltfs/pathname.c
@@ -57,7 +57,7 @@
 #include <ICU/unicode/ustring.h>
 #include <ICU/unicode/utypes.h>
 #include <ICU/unicode/ucnv.h>
-#ifdef UNORM2
+#ifdef ICU6x
 #include <ICU/unicode/unorm.h>
 #else
 #include <ICU/unicode/unorm2.h>
@@ -67,7 +67,7 @@
 #include <unicode/ustring.h>
 #include <unicode/utypes.h>
 #include <unicode/ucnv.h>
-#ifdef UNORM2
+#ifdef ICU6x
 #include <unicode/unorm.h>
 #else
 #include <unicode/unorm2.h>
@@ -664,13 +664,8 @@ int _pathname_normalize_nfc_icu(const UChar *src, UChar **dest)
 {
 	UErrorCode err = U_ZERO_ERROR;
 	int32_t destlen;
-#ifdef UNORM2
+#ifdef ICU6x
 	const UNormalizer2 *n2;
-	UChar *dest;
-#endif
-
-	/* Do a quick check to decide whether this string is already normalized. */
-#ifdef UNORM2
 	if (unorm2_quickCheck(n2, src, -1, &err) == UNORM_YES) {
 #else
 	if (unorm_quickCheck(src, -1, UNORM_NFD, &err) == UNORM_YES) {
@@ -680,14 +675,15 @@ int _pathname_normalize_nfc_icu(const UChar *src, UChar **dest)
 	}
 	err = U_ZERO_ERROR;
 
-#ifdef UNORM2
-	destlen = unorm2_normalize(n2, src, -1, dest, NULL, &err);
+#ifdef ICU6x
+	unorm2_normalize(n2, src, -1, *dest, 1024, &err);
 	if (U_FAILURE(err) && err != U_BUFFER_OVERFLOW_ERROR) {
 		ltfsmsg(LTFS_ERR, 11238E, err);
 		return -LTFS_ICU_ERROR;
 	}
 	err = U_ZERO_ERROR;
 #else
+	int32_t destlen;
 	destlen = unorm_normalize(src, -1, UNORM_NFC, 0, NULL, 0, &err);
 	if (U_FAILURE(err) && err != U_BUFFER_OVERFLOW_ERROR) {
 		ltfsmsg(LTFS_ERR, 11238E, err);
@@ -722,7 +718,6 @@ int _pathname_normalize_nfc_icu(const UChar *src, UChar **dest)
 int _pathname_normalize_nfd_icu(const UChar *src, UChar **dest)
 {
 	UErrorCode err = U_ZERO_ERROR;
-	int32_t destlen;
 
         /**
 	 * unorm2_quickCheck
@@ -741,8 +736,6 @@ int _pathname_normalize_nfd_icu(const UChar *src, UChar **dest)
 	 * @return TRUE if s is normalized
 	 * @stable ICU 4.4
 	 */
-	const UNormalizer2 *n2;
-	UChar *dest;
 
 	/**
 	 * unorm2_normalize
@@ -763,7 +756,8 @@ int _pathname_normalize_nfd_icu(const UChar *src, UChar **dest)
 	 */
 
 	/* Do a quick check to decide whether this string is already normalized. */
-#ifdef UNORM2
+#ifdef ICU6x
+	const UNormalizer2 *n2;
 	if (unorm2_quickCheck(n2, src, -1, &err) == UNORM_YES) {
 #else
 	if (unorm_quickCheck(src, -1, UNORM_NFD, &err) == UNORM_YES) {
@@ -773,14 +767,15 @@ int _pathname_normalize_nfd_icu(const UChar *src, UChar **dest)
 	}
 	err = U_ZERO_ERROR;
 
-#ifdef UNORM2
-	destlen = unorm2_normalize(n2, src, -1, dest, NULL, &err);
+#ifdef ICU6x
+	unorm2_normalize(n2, src, -1, *dest, 1024, &err);
 	if (U_FAILURE(err) && err != U_BUFFER_OVERFLOW_ERROR) {
 		ltfsmsg(LTFS_ERR, 11240E, err);
 		return -LTFS_ICU_ERROR;
 	}
 	err = U_ZERO_ERROR;
 #else
+	int32_t destlen;
 	destlen = unorm_normalize(src, -1, UNORM_NFD, 0, NULL, 0, &err);
 	if (U_FAILURE(err) && err != U_BUFFER_OVERFLOW_ERROR) {
 		ltfsmsg(LTFS_ERR, 11240E, err);


### PR DESCRIPTION
# Summary of changes

This pull request includes following updates:

o update autotools to make ICU version test selectable (>= v60)
o change preprocessor lable (ICU6x)
o select correct ICU unorm functions based on given preprocessor flag

# Description

Since AX_COMPARE_VERSION macro isn't available on all plattforms, i have choosen to use a simple bash string comparison. Not as flexible, but does the trick.
