### PR TITLE
Unorm2

### DIFF
--- a/src/libltfs/pathname.c
+++ b/src/libltfs/pathname.c
@@ -663,9 +663,8 @@ int _pathname_foldcase_icu(const UChar *src, UChar **dest)
 int _pathname_normalize_nfc_icu(const UChar *src, UChar **dest)
 {
 	UErrorCode err = U_ZERO_ERROR;
-
 #ifdef ICU6x
-	const UNormalizer2 *n2;
+	const UNormalizer2 *n2 = unorm2_getInstance(NULL, "nfc", UNORM2_DECOMPOSE, &err);
 	if (unorm2_quickCheck(n2, src, -1, &err) == UNORM_YES) {
 #else
 	if (unorm_quickCheck(src, -1, UNORM_NFD, &err) == UNORM_YES) {
@@ -717,9 +716,7 @@ int _pathname_normalize_nfc_icu(const UChar *src, UChar **dest)
  */
 int _pathname_normalize_nfd_icu(const UChar *src, UChar **dest)
 {
-	UErrorCode err = U_ZERO_ERROR;
-
-        /**
+	/**
 	 * unorm2_quickCheck
 	 * Tests if the string is normalized.
 	 * Internally, in cases where the quickCheck() method would return "maybe"
@@ -756,8 +753,9 @@ int _pathname_normalize_nfd_icu(const UChar *src, UChar **dest)
 	 */
 
 	/* Do a quick check to decide whether this string is already normalized. */
+	UErrorCode err = U_ZERO_ERROR;
 #ifdef ICU6x
-	const UNormalizer2 *n2;
+	const UNormalizer2 *n2 = unorm2_getInstance(NULL, "nfc", UNORM2_DECOMPOSE, &err);
 	if (unorm2_quickCheck(n2, src, -1, &err) == UNORM_YES) {
 #else
 	if (unorm_quickCheck(src, -1, UNORM_NFD, &err) == UNORM_YES) {


### PR DESCRIPTION
# Summary of changes

This pull request includes the following changes or fixes. 

- Fixes missing initialization of the UNormalizer2 handle
- Fixes swapped use of UNORM_NFC and UNORM_NFD
- Fixes incomplete normalization when ICU6x is set

# Description

This commit finishes adding support to ICU 6x (first introduced  with 2473a32f66292afe8).
References #45 and #52.

## Type of change

Please delete items that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works
