### PR TITLE
Fix memory leak at backtrace_info()

### DIFF
--- a/src/libltfs/ltfs_locking.h
+++ b/src/libltfs/ltfs_locking.h
@@ -91,7 +91,7 @@ static inline void backtrace_info(void)
 	char **funcs;
 	size_t back_num, i;
 
-	back_num = backtrace( address, 50);
+	back_num = backtrace(address, 50);
 	funcs = backtrace_symbols( address, back_num);
 
 	for( i = 0; i < back_num; ++i ) {
@@ -100,6 +100,8 @@ static inline void backtrace_info(void)
 		else
 			ltfsmsg(LTFS_INFO, 17194I, (int)i, address[i]);
 	}
+
+	if (funcs) free(funcs);
 
 	return;
 }


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Fix memory leak at backtrace_info()

# Description

Currently, memory shall be leaked at backtrace_info(). Because it doesn't free the allocated memory by backtrace_symbols().

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
