### PR TITLE
Support to build on Fedora28

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -38,7 +38,7 @@ bin_PROGRAMS = ltfs
 
 ltfs_SOURCES = main.c ltfs_fuse.c
 ltfs_DEPENDENCIES = libltfs/libltfs.la ../messages/libbin_ltfs_dat.a
-ltfs_CPPFLAGS = @AM_CPPFLAGS@ -I ../ltfs-sde/src
+ltfs_CPPFLAGS = @AM_CPPFLAGS@ -I ../ltfs-sde/src -fPIC
 ltfs_LDADD = libltfs/libltfs.la
 ltfs_LDFLAGS = @AM_LDFLAGS@ -L../messages -lbin_ltfs_dat
 endif

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -41,10 +41,10 @@ mkltfs_SOURCES = mkltfs.c
 mkltfs_DEPENDENCIES = ../libltfs/libltfs.la ../../messages/libbin_mkltfs_dat.a
 mkltfs_LDADD = ../libltfs/libltfs.la
 mkltfs_LDFLAGS = @AM_LDFLAGS@ -L../../messages -lbin_mkltfs_dat
-mkltfs_CPPFLAGS = @AM_CPPFLAGS@ -I ..
+mkltfs_CPPFLAGS = @AM_CPPFLAGS@ -I .. -fPIC
 
 ltfsck_SOURCES = ltfsck.c
 ltfsck_DEPENDENCIES = ../libltfs/libltfs.la ../../messages/libbin_ltfsck_dat.a
 ltfsck_LDADD = ../libltfs/libltfs.la
 ltfsck_LDFLAGS = @AM_LDFLAGS@ -L../../messages -lbin_ltfsck_dat
-ltfsck_CPPFLAGS = @AM_CPPFLAGS@ -I ..
+ltfsck_CPPFLAGS = @AM_CPPFLAGS@ -I .. -fPIC


### PR DESCRIPTION
# Summary of changes

Support to build the tree on Fedora28

- Fix of issue #67

# Description

Support to build on Fedora28. The tools chains on Fedora28 requires `-fPIC` object for linking commands like mkltfs.

Add `-fPIC` option into *_CPPFLAGS of ltfs, mkltfs and ltfsck.

Fixes #67 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
