### PR TITLE
Fix build break in macOS

### DIFF
--- a/src/libltfs/pathname.h
+++ b/src/libltfs/pathname.h
@@ -78,7 +78,7 @@ int pathname_validate_xattr_name(const char *name);
 int pathname_validate_xattr_value(const char *name, size_t size);
 int pathname_strlen(const char *name);
 int pathname_truncate(char *name, size_t size);
-int pathname_nfd_normaize(const char *name, char **new_name);
+int pathname_nfd_normalize(const char *name, char **new_name);
 #ifdef __cplusplus
 }
 #endif

--- a/src/ltfs_fuse.c
+++ b/src/ltfs_fuse.c
@@ -843,7 +843,7 @@ int _ltfs_fuse_filldir(void *buf, const char *name, void *priv)
 #ifdef __APPLE__
 	free(new_name);
 
-	ret = pathname_nfd_normaize(name, &new_name);
+	ret = pathname_nfd_normalize(name, &new_name);
 	if (ret < 0) {
 		ltfsmsg(LTFS_ERR, 14027E, "nfd", ret);
 		return ret;


### PR DESCRIPTION
# Summary of changes

Rename `pathname_nfd_normaize()` to `pathname_nfd_normalize()` in pathname.h and ltfs_fuse.c to avoid a build break in macOS.

# Description

Current source cannot be built on macOS because `pathname_nfd_normaize()` is called from `ltfs_fuse.c` (when `__APPLE__` is defined) but actually `z()` was renamed to `pathname_nfd_normalize()` in #52 . (#52 is incomplete. Only function name in the definition was changed but prototype and caller were not changed.)

I can't detect this issue when I merged the #52 because old code is installed into `/usr/local/lib` and the linker in macOS detects `pathname_nfd_normaize()` from `/usr/local/lib/libltfs.dylib`. But actually build break is there on the clean system.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
