### PR TITLE
Correction about roll back mount as R/O mount

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -1173,6 +1173,7 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 			default:
 				/* Rollback mount is specified */
 				ltfsmsg(LTFS_INFO, 14072I, priv->rollback_gen);
+				is_ro = true;
 				break;
 		}
 


### PR DESCRIPTION
# Summary of changes

I introduced a bug at #73 to make R/W mount at roll back mount. It shall be R/O mount.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
