### PR TITLE
Correct R/O handling in format

### DIFF
--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -2714,7 +2714,7 @@ int ltfs_format_tape(struct ltfs_volume *vol, int density_code)
 	ret = ltfs_get_partition_readonly(ltfs_ip_id(vol), vol);
 	if (! ret || ret == -LTFS_NO_SPACE || ret == -LTFS_LESS_SPACE || ret == -LTFS_RDONLY_DEN_DRV)
 		ret = ltfs_get_partition_readonly(ltfs_dp_id(vol), vol);
-	if (ret < 0 && ret != -LTFS_NO_SPACE && ret != -LTFS_LESS_SPACE && ret == -LTFS_RDONLY_DEN_DRV) {
+	if (ret < 0 && ret != -LTFS_NO_SPACE && ret != -LTFS_LESS_SPACE && ret != -LTFS_RDONLY_DEN_DRV) {
 		ltfsmsg(LTFS_ERR, 11095E);
 		return ret;
 	}


### PR DESCRIPTION
# Summary of changes

Fix reject condition of format.

# Description

Currently LTFS over rejects format operation in the IBM enterprise tape. (Readonly format-drive combination even if cartridge-drive combination is writable with reformat)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
