### PR TITLE
 Add a feature to create various error condition tape 

### DIFF
--- a/messages/tape_iokit_ibmtape/root.txt
+++ b/messages/tape_iokit_ibmtape/root.txt
@@ -88,6 +88,8 @@ root:table {
 		30843E:string { "Invalid scsi_lbprotect option: %s." }
 		30844E:string { "Encryption method of the drive is not AME but %s (0x%02X)." }
 		30845E:string { "Encryption feature is not supported on the drive: %d." }
+		30846I:string { "Pseudo-error on %s." }
+		30847I:string { "Pseudo-error on write. Good return code, but a record to emulate a write error did not get sent to the drive." }
 		//unused 30846
 		//unused 30847
 		//unused 30848

--- a/messages/tape_linux_sg_ibmtape/root.txt
+++ b/messages/tape_linux_sg_ibmtape/root.txt
@@ -116,7 +116,6 @@ root:table {
 		30274I:string { "Pseudo-error on %s." }
 		30275I:string { "Pseudo-error on write. Good return code, but a record to emulate a write error did not get sent to the drive." }
 
-
 		30392D:string { "Backend %s %s." }
 		30393D:string { "Backend %s: %d %s." }
 		30394D:string { "Backend %s: %zu %s." }

--- a/src/libltfs/xml_writer_libltfs.c
+++ b/src/libltfs/xml_writer_libltfs.c
@@ -318,7 +318,7 @@ static int _xml_write_file(xmlTextWriterPtr writer, struct dentry *file, struct 
 	} else {
 		/* Write file offset cache */
 		if (offset_c->fp) {
-			fprintf(offset_c->fp, "%s,%"PRIu64"\n", file->name.name, (uint64_t)0);
+			fprintf(offset_c->fp, "%s,0,0\n", file->name.name);
 			offset_c->count++;
 		}
 	}

--- a/src/tape_drivers/freebsd/cam/cam_cmn.h
+++ b/src/tape_drivers/freebsd/cam/cam_cmn.h
@@ -393,6 +393,7 @@ struct camtape_data {
 	uint64_t      tape_alert;        /**< Latched tape alert flag */
 	bool          is_data_key_set;   /**< Is a valid data key set? */
 	unsigned char dki[12];           /**< key-alias */
+	bool          clear_by_pc;       /**< clear pseudo write perm by partition change */
 	uint64_t      force_writeperm;   /**< pseudo write perm threshold */
 	uint64_t      force_readperm;    /**< pseudo read perm threashold */
 	uint64_t      write_counter;     /**< write call counter for pseudo write perm */

--- a/src/tape_drivers/freebsd/cam/cam_tc.c
+++ b/src/tape_drivers/freebsd/cam/cam_tc.c
@@ -621,7 +621,7 @@ int camtape_write(void *device, const char *buf, size_t count, struct tc_positio
 				return -EDEV_NO_SENSE;
 			else
 				return -EDEV_WRITE_PERM;
-		} else if ( softc->write_counter > (softc->force_writeperm - THREASHOLD_FORCE_WRITE_NO_WRITE)) {
+		} else if ( softc->write_counter > (softc->force_writeperm - THRESHOLD_FORCE_WRITE_NO_WRITE)) {
 			ltfsmsg(LTFS_INFO, 31235I);
 			pos->block++;
 			ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_WRITE));
@@ -3173,8 +3173,8 @@ int camtape_set_xattr(void *device, const char *name, const char *buf, size_t si
 
 	if (! strcmp(name, "ltfs.vendor.IBM.forceErrorWrite")) {
 		softc->force_writeperm = strtoull(null_terminated, NULL, 0);
-		if (softc->force_writeperm && softc->force_writeperm < THREASHOLD_FORCE_WRITE_NO_WRITE)
-			softc->force_writeperm = THREASHOLD_FORCE_WRITE_NO_WRITE;
+		if (softc->force_writeperm && softc->force_writeperm < THRESHOLD_FORCE_WRITE_NO_WRITE)
+			softc->force_writeperm = THRESHOLD_FORCE_WRITE_NO_WRITE;
 		rc = DEVICE_GOOD;
 	} else if (! strcmp(name, "ltfs.vendor.IBM.forceErrorType")) {
 		softc->force_errortype = strtol(null_terminated, NULL, 0);

--- a/src/tape_drivers/freebsd/cam/cam_tc.c
+++ b/src/tape_drivers/freebsd/cam/cam_tc.c
@@ -621,7 +621,7 @@ int camtape_write(void *device, const char *buf, size_t count, struct tc_positio
 				return -EDEV_NO_SENSE;
 			else
 				return -EDEV_WRITE_PERM;
-		} else if ( softc->write_counter > (softc->force_writeperm - THRESHOLD_FORCE_WRITE_NO_WRITE)) {
+		} else if ( softc->write_counter > (softc->force_writeperm - THREASHOLD_FORCE_WRITE_NO_WRITE)) {
 			ltfsmsg(LTFS_INFO, 31235I);
 			pos->block++;
 			ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_WRITE));
@@ -3173,8 +3173,8 @@ int camtape_set_xattr(void *device, const char *name, const char *buf, size_t si
 
 	if (! strcmp(name, "ltfs.vendor.IBM.forceErrorWrite")) {
 		softc->force_writeperm = strtoull(null_terminated, NULL, 0);
-		if (softc->force_writeperm && softc->force_writeperm < THRESHOLD_FORCE_WRITE_NO_WRITE)
-			softc->force_writeperm = THRESHOLD_FORCE_WRITE_NO_WRITE;
+		if (softc->force_writeperm && softc->force_writeperm < THREASHOLD_FORCE_WRITE_NO_WRITE)
+			softc->force_writeperm = THREASHOLD_FORCE_WRITE_NO_WRITE;
 		rc = DEVICE_GOOD;
 	} else if (! strcmp(name, "ltfs.vendor.IBM.forceErrorType")) {
 		softc->force_errortype = strtol(null_terminated, NULL, 0);

--- a/src/tape_drivers/generic/file/filedebug_tc.c
+++ b/src/tape_drivers/generic/file/filedebug_tc.c
@@ -762,7 +762,7 @@ int filedebug_write(void *device, const char *buf, size_t count, struct tc_posit
 				return -EDEV_NO_SENSE;
 			else
 				return -EDEV_WRITE_PERM;
-		} else if ( state->write_counter > (state->force_writeperm - THREASHOLD_FORCE_WRITE_NO_WRITE) ) {
+		} else if ( state->write_counter > (state->force_writeperm - THRESHOLD_FORCE_WRITE_NO_WRITE) ) {
 			ltfsmsg(LTFS_INFO, 30019I);
 			pos->block++;
 			return DEVICE_GOOD;
@@ -1775,8 +1775,8 @@ int filedebug_set_xattr(void *device, const char *name, const char *buf, size_t 
 			state->force_writeperm = perm_count;
 			state->clear_by_pc     = false;
 		}
-		if (state->force_writeperm && state->force_writeperm < THREASHOLD_FORCE_WRITE_NO_WRITE)
-			state->force_writeperm = THREASHOLD_FORCE_WRITE_NO_WRITE;
+		if (state->force_writeperm && state->force_writeperm < THRESHOLD_FORCE_WRITE_NO_WRITE)
+			state->force_writeperm = THRESHOLD_FORCE_WRITE_NO_WRITE;
 		state->write_counter = 0;
 		ret = DEVICE_GOOD;
 	} else if (! strcmp(name, "ltfs.vendor.IBM.forceErrorType")) {

--- a/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
+++ b/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
@@ -136,8 +136,6 @@ volatile char *copyright = LTFS_COPYRIGHT_0"\n"LTFS_COPYRIGHT_1"\n"LTFS_COPYRIGH
 #define DK_LENGTH 32
 #define DKI_LENGTH 12
 
-#define THREASHOLD_FORCE_WRITE_NO_WRITE (5)
-
 #define CRC32C_CRC (0x02)
 
 #define MAX_WRITE_RETRY (100)
@@ -1428,7 +1426,7 @@ int lin_tape_ibmtape_write(void *device, const char *buf, size_t count, struct t
 				return -EDEV_NO_SENSE;
 			else
 				return -EDEV_WRITE_PERM;
-		} else if ( priv->write_counter > (priv->force_writeperm - THREASHOLD_FORCE_WRITE_NO_WRITE) ) {
+		} else if ( priv->write_counter > (priv->force_writeperm - THRESHOLD_FORCE_WRITE_NO_WRITE) ) {
 			ltfsmsg(LTFS_INFO, 30435I);
 			pos->block++;
 			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_WRITE));
@@ -3451,8 +3449,8 @@ int lin_tape_ibmtape_set_xattr(void *device, const char *name, const char *buf, 
 			priv->force_writeperm = perm_count;
 			priv->clear_by_pc     = false;
 		}
-		if (priv->force_writeperm && priv->force_writeperm < THREASHOLD_FORCE_WRITE_NO_WRITE)
-			priv->force_writeperm = THREASHOLD_FORCE_WRITE_NO_WRITE;
+		if (priv->force_writeperm && priv->force_writeperm < THRESHOLD_FORCE_WRITE_NO_WRITE)
+			priv->force_writeperm = THRESHOLD_FORCE_WRITE_NO_WRITE;
 		priv->write_counter = 0;
 		rc = DEVICE_GOOD;
 	} else if (! strcmp(name, "ltfs.vendor.IBM.forceErrorType")) {

--- a/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
@@ -1623,7 +1623,7 @@ int sg_ibmtape_write(void *device, const char *buf, size_t count, struct tc_posi
 				return -EDEV_NO_SENSE;
 			else
 				return -EDEV_WRITE_PERM;
-		} else if ( priv->write_counter > (priv->force_writeperm - THREASHOLD_FORCE_WRITE_NO_WRITE) ) {
+		} else if ( priv->write_counter > (priv->force_writeperm - THRESHOLD_FORCE_WRITE_NO_WRITE) ) {
 			ltfsmsg(LTFS_INFO, 30275I);
 			pos->block++;
 			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_WRITE));
@@ -3569,8 +3569,8 @@ int sg_ibmtape_set_xattr(void *device, const char *name, const char *buf, size_t
 			priv->force_writeperm = perm_count;
 			priv->clear_by_pc     = false;
 		}
-		if (priv->force_writeperm && priv->force_writeperm < THREASHOLD_FORCE_WRITE_NO_WRITE)
-			priv->force_writeperm = THREASHOLD_FORCE_WRITE_NO_WRITE;
+		if (priv->force_writeperm && priv->force_writeperm < THRESHOLD_FORCE_WRITE_NO_WRITE)
+			priv->force_writeperm = THRESHOLD_FORCE_WRITE_NO_WRITE;
 		priv->write_counter = 0;
 		ret = DEVICE_GOOD;
 	} else if (! strcmp(name, "ltfs.vendor.IBM.forceErrorType")) {

--- a/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.h
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.h
@@ -65,8 +65,9 @@ struct sg_ibmtape_data {
 	unsigned char        dki[12];              /**< key-alias */
 	bool                 use_sili;             /**< Default true, false for USB drives */
 	int                  drive_type;           /**< drive type defined by ltfs */
+	bool                 clear_by_pc;          /**< clear pseudo write perm by partition change */
 	uint64_t             force_writeperm;      /**< pseudo write perm threshold */
-	uint64_t             force_readperm;       /**< pseudo read perm threashold */
+	uint64_t             force_readperm;       /**< pseudo read perm threshold */
 	uint64_t             write_counter;        /**< write call counter for pseudo write perm */
 	uint64_t             read_counter;         /**< read call counter for pseudo write perm */
 	int                  force_errortype;      /**< 0 is R/W Perm, otherwise no sense */

--- a/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
+++ b/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
@@ -806,6 +806,12 @@ int iokit_ibmtape_open(const char *devname, void **handle)
 	ibm_tape_genkey(priv->key);
 	_register_key(priv, priv->key);
 
+	/* Initial setting of force perm */
+	priv->clear_by_pc     = false;
+	priv->force_writeperm = DEFAULT_WRITEPERM;
+	priv->force_readperm  = DEFAULT_READPERM;
+	priv->force_errortype = DEFAULT_ERRORTYPE;
+
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_OPEN));
 
 	*handle = (void *)priv;
@@ -1502,6 +1508,13 @@ int iokit_ibmtape_rewind(void *device, struct tc_position *pos)
 	}
 
 	if(ret == DEVICE_GOOD) {
+		/* Clear force perm setting */
+		priv->clear_by_pc     = false;
+		priv->force_writeperm = DEFAULT_WRITEPERM;
+		priv->force_readperm  = DEFAULT_READPERM;
+		priv->write_counter   = 0;
+		priv->read_counter    = 0;
+
 		ret = iokit_ibmtape_readpos(device, pos);
 
 		if(ret == DEVICE_GOOD) {
@@ -1527,16 +1540,30 @@ int iokit_ibmtape_locate(void *device, struct tc_position dest, struct tc_positi
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "LOCATE";
 	char *msg = NULL;
+	bool pc = false;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOCATE));
 	ltfsmsg(LTFS_DEBUG, 30997D, "locate", dest.partition, dest.block, priv->drive_serial);
+
+	if (pos->partition != dest.partition) {
+		if (priv->clear_by_pc) {
+			/* Clear force perm setting */
+			priv->clear_by_pc     = false;
+			priv->force_writeperm = DEFAULT_WRITEPERM;
+			priv->force_readperm  = DEFAULT_READPERM;
+			priv->write_counter   = 0;
+			priv->read_counter    = 0;
+		}
+		pc = true;
+	}
 
 	// Zero out the CDB and the result buffer
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
 	cdb[0]  = LOCATE16;
-	cdb[1]  = 0x02; /* Set Change partition(CP) flag */
+	if (pc)
+		cdb[1]  = 0x02; /* Set Change partition(CP) flag */
 	cdb[3]  = (unsigned char)(dest.partition & 0xff);
 	ltfs_u64tobe(cdb + 4, dest.block);
 
@@ -1820,6 +1847,14 @@ static int _cdb_load_unload(void *device, bool load)
 	req.desc            = cmd_desc;
 
 	ret = iokit_issue_cdb_command(&priv->dev, &req, &msg);
+
+	/* Clear force perm setting */
+	priv->clear_by_pc     = false;
+	priv->force_writeperm = DEFAULT_WRITEPERM;
+	priv->force_readperm  = DEFAULT_READPERM;
+	priv->write_counter   = 0;
+	priv->read_counter    = 0;
+
 	if (ret < 0){
 		_process_errors(device, ret, msg, cmd_desc, true);
 	}
@@ -1837,6 +1872,14 @@ int iokit_ibmtape_load(void *device, struct tc_position *pos)
 	ltfsmsg(LTFS_DEBUG, 30992D, "load", priv->drive_serial);
 
 	ret = _cdb_load_unload(device, true);
+
+	/* Clear force perm setting */
+	priv->clear_by_pc     = false;
+	priv->force_writeperm = DEFAULT_WRITEPERM;
+	priv->force_readperm  = DEFAULT_READPERM;
+	priv->write_counter   = 0;
+	priv->read_counter    = 0;
+
 	iokit_ibmtape_readpos(device, pos);
 	if (ret < 0) {
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOAD));
@@ -3117,9 +3160,44 @@ int iokit_ibmtape_get_xattr(void *device, const char *name, char **buf)
 
 int iokit_ibmtape_set_xattr(void *device, const char *name, const char *buf, size_t size)
 {
+	int ret = -LTFS_NO_XATTR;
+	char *null_terminated;
 	struct iokit_ibmtape_data *priv = (struct iokit_ibmtape_data*)device;
+	int64_t wp_count = 0;
+
+	if (!size)
+		return -LTFS_BAD_ARG;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_SETXATTR));
+
+	null_terminated = malloc(size + 1);
+	if (! null_terminated) {
+		ltfsmsg(LTFS_ERR, 10001E, "iokit_ibmtape_set_xattr: null_term");
+		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETXATTR));
+		return -LTFS_NO_MEMORY;
+	}
+	memcpy(null_terminated, buf, size);
+	null_terminated[size] = '\0';
+
+	if (! strcmp(name, "ltfs.vendor.IBM.forceErrorWrite")) {
+		wp_count = strtoll(null_terminated, NULL, 0);
+		if (wp_count < 0) {
+			priv->force_writeperm = -wp_count;
+			priv->clear_by_pc     = true;
+		}
+		if (priv->force_writeperm && priv->force_writeperm < THREASHOLD_FORCE_WRITE_NO_WRITE)
+			priv->force_writeperm = THREASHOLD_FORCE_WRITE_NO_WRITE;
+		ret = DEVICE_GOOD;
+	} else if (! strcmp(name, "ltfs.vendor.IBM.forceErrorType")) {
+		priv->force_errortype = strtol(null_terminated, NULL, 0);
+		ret = DEVICE_GOOD;
+	} else if (! strcmp(name, "ltfs.vendor.IBM.forceErrorRead")) {
+		priv->force_readperm = strtoull(null_terminated, NULL, 0);
+		priv->read_counter = 0;
+		ret = DEVICE_GOOD;
+	}
+	free(null_terminated);
+
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETXATTR));
 	return -LTFS_NO_XATTR;
 }

--- a/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.h
+++ b/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.h
@@ -66,6 +66,7 @@ struct iokit_ibmtape_data {
 	unsigned char       dki[12];              /**< key-alias */
 	bool                use_sili;             /**< Default true, false for USB drives */
 	int                 drive_type;           /**< drive type defined by ltfs */
+	bool                clear_by_pc;          /**< clear pseudo write perm by partition change */
 	uint64_t            force_writeperm;      /**< pseudo write perm threshold */
 	uint64_t            force_readperm;       /**< pseudo read perm threashold */
 	uint64_t            write_counter;        /**< write call counter for pseudo write perm */

--- a/src/tape_drivers/tape_drivers.h
+++ b/src/tape_drivers/tape_drivers.h
@@ -78,7 +78,7 @@ typedef int   (*crc_check)(void *buf, size_t n);
 typedef void* (*memcpy_crc_enc)(void *dest, const void *src, size_t n);
 typedef int   (*memcpy_crc_check)(void *dest, const void *src, size_t n);
 
-#define THREASHOLD_FORCE_WRITE_NO_WRITE (5)
+#define THRESHOLD_FORCE_WRITE_NO_WRITE  (5)
 #define DEFAULT_WRITEPERM               (0)
 #define DEFAULT_READPERM                (0)
 #define DEFAULT_ERRORTYPE               (0)

--- a/src/tape_drivers/tape_drivers.h
+++ b/src/tape_drivers/tape_drivers.h
@@ -78,6 +78,11 @@ typedef int   (*crc_check)(void *buf, size_t n);
 typedef void* (*memcpy_crc_enc)(void *dest, const void *src, size_t n);
 typedef int   (*memcpy_crc_check)(void *dest, const void *src, size_t n);
 
+#define THREASHOLD_FORCE_WRITE_NO_WRITE (5)
+#define DEFAULT_WRITEPERM               (0)
+#define DEFAULT_READPERM                (0)
+#define DEFAULT_ERRORTYPE               (0)
+
 struct timeout_tape {
 	int  op_code;     /**< SCSI op code */
 	int  timeout;     /**< SCSI timeout */


### PR DESCRIPTION
# Summary of changes

Provide a complete feature to create following error condition tape.

 1. Write fenced tape (set nagative value to write error trigger)
 2. Write error tape (set positive value to write error trigger)
 3. Read error tape (set positive value to read error trigger)

# Description

When a negative value is set to ltfs.vendor.IBM.forceErrorWrite, LTFS will clear pseudo write error condition in the following conditions.

 - Load
 - Unload
 - Rewind
 - Open
 - Locate to another partition

When a positive value is set to ltfs.vendor.IBM.forceErrorWrite, LTFS will clear pseudo write error condition in the following conditions.

 - Load
 - Unload
 - Rewind
 - Open

ltfs.vendor.IBM.forceErrorRead accept only positive value. LTFS will clear pseudo read error condition in the following conditions.

 - Load
 - Unload
 - Open

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
