### PR TITLE
Introduce macros to test cartridge type

### DIFF
--- a/src/tape_drivers/freebsd/cam/cam_tc.c
+++ b/src/tape_drivers/freebsd/cam/cam_tc.c
@@ -2947,10 +2947,13 @@ int camtape_setcap(void *device, uint16_t proportion)
 
 		/* Scale media instead of setcap */
 		rc = camtape_modesense(device, TC_MP_MEDIUM_SENSE, TC_MP_PC_CURRENT, 0, buf, sizeof(buf));
+		if (rc < 0) {
+			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETCAP));
+			return rc;
+		}
 
 		/* Check Cartridge type */
-		if (rc == 0 &&
-			(buf[2] == TC_MP_JK || buf[2] == TC_MP_JY || buf[2] == TC_MP_JL || buf[2] == TC_MP_JZ)) {
+		if (IS_SHORT_MEDIUM(buf[2]) || IS_WORM_MEDIUM(buf[2])) {
 			/* Short or WORM cartridge cannot be scaled */
 			ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETCAP));
 			return DEVICE_GOOD;

--- a/src/tape_drivers/freebsd/cam/cam_tc.c
+++ b/src/tape_drivers/freebsd/cam/cam_tc.c
@@ -2948,7 +2948,7 @@ int camtape_setcap(void *device, uint16_t proportion)
 		/* Scale media instead of setcap */
 		rc = camtape_modesense(device, TC_MP_MEDIUM_SENSE, TC_MP_PC_CURRENT, 0, buf, sizeof(buf));
 		if (rc < 0) {
-			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETCAP));
+			ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETCAP));
 			return rc;
 		}
 

--- a/src/tape_drivers/ibm_tape.h
+++ b/src/tape_drivers/ibm_tape.h
@@ -228,6 +228,9 @@ enum pro_action {
 	PRO_ACT_REGISTER_MOVE   = 0x07
 };
 
+#define IS_SHORT_MEDIUM(m) (m == TC_MP_JK || m == TC_MP_JL)
+#define IS_WORM_MEDIUM(m)  (m == TC_MP_JY || m == TC_MP_JZ)
+
 extern DRIVE_DENSITY_SUPPORT_MAP jaguar_drive_density[];
 extern DRIVE_DENSITY_SUPPORT_MAP jaguar_drive_density_strict[];
 extern DRIVE_DENSITY_SUPPORT_MAP lto_drive_density[];

--- a/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
@@ -2397,8 +2397,8 @@ int sg_ibmtape_setcap(void *device, uint16_t proportion)
 			return ret;
 		}
 
-		if (buf[2] == TC_MP_JK || buf[2] == TC_MP_JL) {
-			/* JK media cannot be scaled */
+		if (IS_SHORT_MEDIUM(buf[2]) || IS_WORM_MEDIUM(buf[2])) {
+			/* Short or WORM cartridge cannot be scaled */
 			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETCAP));
 			return ret;
 		}

--- a/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
+++ b/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
@@ -2052,7 +2052,7 @@ int iokit_ibmtape_setcap(void *device, uint16_t proportion)
 			return ret;
 		}
 
-		if (buf[2] == TC_MP_JK || buf[2] == TC_MP_JL) {
+		if (IS_SHORT_MEDIUM(buf[2]) || IS_WORM_MEDIUM(buf[2])) {
 			/* JK media cannot be scaled */
 			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_SETCAP));
 			return ret;


### PR DESCRIPTION
# Summary of changes

Introduce following 2 macros to test cartridge type

- Short tape for IBM enterprise tape
- WORM tape

# Description

To reduce to add new code when new tape is added.

After this change you need to add new cartridge type only to ibm_tape.h

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
