### PR TITLE
Handle an error at readpos after locate correctly

### DIFF
--- a/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
+++ b/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
@@ -1649,8 +1649,7 @@ int lin_tape_ibmtape_locate(void *device, struct tc_position dest, struct tc_pos
 		}
 
 		rc = _sioc_stioc_command(device, STIOC_SET_ACTIVE_PARTITION, "LOCATE(PART)", &set_part, &msg);
-	}
-	else {
+	} else {
 		memset(&setpos, 0, sizeof(struct set_tape_position));
 		setpos.logical_id = dest.block;
 		setpos.logical_id_type = LOGICAL_ID_BLOCK_TYPE;

--- a/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
@@ -1839,6 +1839,7 @@ int sg_ibmtape_locate(void *device, struct tc_position dest, struct tc_position 
 {
 	int ret = -EDEV_UNKNOWN;
 	int ret_ep = DEVICE_GOOD;
+	int ret_rp = DEVICE_GOOD;
 	struct sg_ibmtape_data *priv = (struct sg_ibmtape_data*)device;
 
 	sg_io_hdr_t req;
@@ -1907,13 +1908,15 @@ int sg_ibmtape_locate(void *device, struct tc_position dest, struct tc_position 
 		}
 	}
 
-	ret = sg_ibmtape_readpos(device, pos);
-
-	if(ret == DEVICE_GOOD) {
+	ret_rp = sg_ibmtape_readpos(device, pos);
+	if (ret_rp == DEVICE_GOOD) {
 		if(pos->early_warning)
 			ltfsmsg(LTFS_WARN, 30222W, "locate");
 		else if(pos->programmable_early_warning)
 			ltfsmsg(LTFS_WARN, 30223W, "locate");
+	} else {
+		if (!ret)
+			ret = ret_rp;
 	}
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOCATE));

--- a/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
+++ b/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
@@ -1562,7 +1562,6 @@ int iokit_ibmtape_rewind(void *device, struct tc_position *pos)
 int iokit_ibmtape_locate(void *device, struct tc_position dest, struct tc_position *pos)
 {
 	int ret = -EDEV_UNKNOWN;
-	int ret_ep = DEVICE_GOOD;
 	int ret_rp = DEVICE_GOOD;
 	struct iokit_ibmtape_data *priv = (struct iokit_ibmtape_data*)device;
 
@@ -1617,9 +1616,7 @@ int iokit_ibmtape_locate(void *device, struct tc_position dest, struct tc_positi
 			ltfsmsg(LTFS_DEBUG, 30827D, "Locate");
 			ret = DEVICE_GOOD;
 		} else {
-			ret_ep = _process_errors(device, ret, msg, cmd_desc, true);
-			if (ret_ep < 0)
-				ret = ret_ep;
+			_process_errors(device, ret, msg, cmd_desc, true);
 		}
 	}
 


### PR DESCRIPTION
# Summary of changes

Handle an error at readpos after locate correctly

# Description

Current code returns a good when readpos after locate is successfully done even if locate is failed. This behavior is wrong. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
