### PR TITLE
Correct i-node information pass to FUSE

### DIFF
--- a/src/ltfs_fuse.c
+++ b/src/ltfs_fuse.c
@@ -328,9 +328,9 @@ int ltfs_fuse_statfs(const char *path, struct statvfs *buf)
 	stats->f_blocks = blockstat.total_dp;           /* Total tape capacity */
 	stats->f_bfree = blockstat.remaining_dp;        /* Remaining tape capacity */
 	stats->f_bavail = stats->f_bfree;               /* Blocks available for normal user (ignored) */
-	stats->f_files = ltfs_get_file_count(priv->data);
 
-	stats->f_ffree = UINT32_MAX - stats->f_files;   /* Assuming file count fits in 32 bits. */
+	stats->f_files = UINT64_MAX;
+	stats->f_ffree = UINT64_MAX - ltfs_get_file_count(priv->data);
 	memcpy(buf, stats, sizeof(struct statvfs));
 
 #ifdef __APPLE__


### PR DESCRIPTION
# Summary of changes

Pass correct i-node info to the statvfs structure

# Description

statvfs::f_files shall have a count of max i-nodes
statvfs::f_ffree shall have a count of free i-nodes

The 'f_favail', 'f_fsid' and 'f_flag' fields are ignored 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
