### PR TITLE
Kick ltfs_sync() by reading ltfs.sync VEA

### DIFF
--- a/src/libltfs/xattr.c
+++ b/src/libltfs/xattr.c
@@ -1131,7 +1131,7 @@ int _xattr_get_virtual(struct dentry *d, char *buf, size_t buf_size, const char 
 				ret = _xattr_get_vendorunique_xattr(&val, name, vol);
 			}
 		} else if (! strcmp(name, "ltfs.sync")) {
-			ret = -LTFS_RDONLY_XATTR;
+			ret = ltfs_sync_index(SYNC_EA, false, vol);
 		}
 	}
 


### PR DESCRIPTION
# Summary of changes

Kick ltfs_sync by reading "ltfs.sync" VEA. In addition to reading it.

# Description

Kick ltfs_sync by reading "ltfs.sync" VEA. This behavior is useful when the tape is meta-data writable condition. In this condition, LTFS rejects to create additional file object and data. But LTFS accepts meta-data change like unlink objects, modify EA, etc.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
