### PR TITLE
Return good at sync when filesystem is clean

### DIFF
--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -3310,6 +3310,9 @@ start:
 			ltfsmsg(LTFS_ERR, 17069E);
 
 		ltfsmsg(LTFS_INFO, 17070I, vol->label->barcode, ret, vol->device->serial_number);
+	} else {
+		/* Do nothing and return 0 when filesystem is not dirty */
+		ret = 0;
 	}
 
 	return ret;


### PR DESCRIPTION
# Summary of changes

Return good at sync when filesystem is clean

# Description

Previously, return less space condition at sync when the tape is under less space condition.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
