### PR TITLE
Add a debug function to create full tape easily

### DIFF
--- a/messages/tape_linux_sg_ibmtape/root.txt
+++ b/messages/tape_linux_sg_ibmtape/root.txt
@@ -115,6 +115,7 @@ root:table {
 		30273I:string { "Cannot %s device flag (%d)." }
 		30274I:string { "Pseudo-error on %s." }
 		30275I:string { "Pseudo-error on write. Good return code, but a record to emulate a write error did not get sent to the drive." }
+		30276I:string { "Raw capacity info of partition %d (%llu - %llu) %s." }
 
 		30392D:string { "Backend %s %s." }
 		30393D:string { "Backend %s: %d %s." }

--- a/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.h
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.h
@@ -87,6 +87,7 @@ struct sg_ibmtape_global_data {
 	unsigned crc_checking;      /**< Is crc checking enabled? */
 	unsigned strict_drive;      /**< Is bar code length checked strictly? */
 	unsigned disable_auto_dump; /**< Is auto dump disabled? */
+	unsigned capacity_offset;   /**< Dummy capacity offset to create full tape earlier */
 };
 
 #endif // __sg_ibmtape_h


### PR DESCRIPTION
# Summary of changes

Add a debug function to create full tape easily

# Description

For debug purpose, it is useful if we have a function to create full tape easily. 

I introduce a  ltfs.vendor.IBM.capOffset VEA to the sg backend. The sg backend shall subtruct remaining capacity from real one when this value is not 0. The unit is MB (base 1000 not 1024).

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
