### PR TITLE
Experimental support of the IBM TS1160 enterprise tape drive

### DIFF
--- a/src/libltfs/tape_ops.h
+++ b/src/libltfs/tape_ops.h
@@ -116,7 +116,7 @@ struct tc_inq_page {
 #define TC_INQ_PAGE_DRVSERIAL (0x80)
 
 struct tc_current_param {
-	/* Parameters for tape drive */
+	/* Parameters for tape drive*/
 	unsigned int  max_blksize;           /* Maximum block size */
 
 	/* Parameters for current loaded tape */
@@ -154,12 +154,14 @@ enum {
 	TC_DC_JAG4    = 0x54,
 	TC_DC_JAG5    = 0x55,
 	TC_DC_JAG5A   = 0x56,
+	TC_DC_JAG6    = 0x57,
 	TC_DC_JAG1E   = 0x71,
 	TC_DC_JAG2E   = 0x72,
 	TC_DC_JAG3E   = 0x73,
 	TC_DC_JAG4E   = 0x74,
 	TC_DC_JAG5E   = 0x75,
 	TC_DC_JAG5AE  = 0x76,
+	TC_DC_JAG6E   = 0x77,
 };
 
 #define TEST_CRYPTO (0x20)

--- a/src/tape_drivers/ibm_tape.c
+++ b/src/tape_drivers/ibm_tape.c
@@ -64,6 +64,32 @@
 #include "libltfs/ltfs_endian.h"
 
 DRIVE_DENSITY_SUPPORT_MAP jaguar_drive_density[] = {
+	/* TS1160 */
+	{ DRIVE_GEN_JAG6,  TC_MP_JE, TC_DC_JAG6,    MEDIUM_PERFECT_MATCH },
+	{ DRIVE_GEN_JAG6,  TC_MP_JE, TC_DC_UNKNOWN, MEDIUM_PROBABLY_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JV, TC_DC_JAG6,    MEDIUM_PERFECT_MATCH },
+	{ DRIVE_GEN_JAG6,  TC_MP_JV, TC_DC_UNKNOWN, MEDIUM_PROBABLY_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JM, TC_DC_JAG6,    MEDIUM_PERFECT_MATCH },
+	{ DRIVE_GEN_JAG6,  TC_MP_JM, TC_DC_UNKNOWN, MEDIUM_PROBABLY_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JD, TC_DC_JAG5A,   MEDIUM_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JD, TC_DC_JAG5,    MEDIUM_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JD, TC_DC_UNKNOWN, MEDIUM_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JL, TC_DC_JAG5A,   MEDIUM_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JL, TC_DC_JAG5,    MEDIUM_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JL, TC_DC_UNKNOWN, MEDIUM_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JZ, TC_DC_JAG5A,   MEDIUM_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JZ, TC_DC_JAG5,    MEDIUM_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JZ, TC_DC_UNKNOWN, MEDIUM_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JC, TC_DC_JAG5,    MEDIUM_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JC, TC_DC_JAG4,    MEDIUM_READONLY },
+	{ DRIVE_GEN_JAG6,  TC_MP_JC, TC_DC_UNKNOWN, MEDIUM_PROBABLY_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JK, TC_DC_JAG5,    MEDIUM_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JK, TC_DC_JAG4,    MEDIUM_READONLY },
+	{ DRIVE_GEN_JAG6,  TC_MP_JK, TC_DC_UNKNOWN, MEDIUM_PROBABLY_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JY, TC_DC_JAG5,    MEDIUM_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JY, TC_DC_JAG4,    MEDIUM_READONLY },
+	{ DRIVE_GEN_JAG6,  TC_MP_JY, TC_DC_UNKNOWN, MEDIUM_PROBABLY_WRITABLE },
+
 	/* TS1155 */
 	{ DRIVE_GEN_JAG5A, TC_MP_JD, TC_DC_JAG5A,   MEDIUM_PERFECT_MATCH },
 	{ DRIVE_GEN_JAG5A, TC_MP_JD, TC_DC_JAG5,    MEDIUM_WRITABLE },
@@ -115,6 +141,14 @@ DRIVE_DENSITY_SUPPORT_MAP jaguar_drive_density[] = {
 };
 
 DRIVE_DENSITY_SUPPORT_MAP jaguar_drive_density_strict[] = {
+	/* TS1160 */
+	{ DRIVE_GEN_JAG6,  TC_MP_JE, TC_DC_JAG6,    MEDIUM_PERFECT_MATCH },
+	{ DRIVE_GEN_JAG6,  TC_MP_JE, TC_DC_UNKNOWN, MEDIUM_PROBABLY_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JV, TC_DC_JAG6,    MEDIUM_PERFECT_MATCH },
+	{ DRIVE_GEN_JAG6,  TC_MP_JV, TC_DC_UNKNOWN, MEDIUM_PROBABLY_WRITABLE },
+	{ DRIVE_GEN_JAG6,  TC_MP_JM, TC_DC_JAG6,    MEDIUM_PERFECT_MATCH },
+	{ DRIVE_GEN_JAG6,  TC_MP_JM, TC_DC_UNKNOWN, MEDIUM_PROBABLY_WRITABLE },
+
 	/* TS1155 */
 	{ DRIVE_GEN_JAG5A, TC_MP_JD, TC_DC_JAG5A,   MEDIUM_PERFECT_MATCH },
 	{ DRIVE_GEN_JAG5A, TC_MP_JD, TC_DC_UNKNOWN, MEDIUM_PROBABLY_WRITABLE },
@@ -207,13 +241,18 @@ const unsigned char supported_cart[] = {
 	TC_MP_JK,
 	TC_MP_JY,
 	TC_MP_JL,
-	TC_MP_JZ
+	TC_MP_JZ,
+	TC_MP_JE,
+	TC_MP_JV,
+	TC_MP_JM,
 };
 
 const unsigned char supported_density[] = {
+	TC_DC_JAG6E,
 	TC_DC_JAG5AE,
 	TC_DC_JAG5E,
 	TC_DC_JAG4E,
+	TC_DC_JAG6,
 	TC_DC_JAG5A,
 	TC_DC_JAG5,
 	TC_DC_JAG4,
@@ -255,6 +294,7 @@ struct supported_device *ibm_supported_drives[] = {
 		TAPEDRIVE( IBM_VENDOR_ID, "03592E07",     DRIVE_TS1140,  "[03592E07]" ),     /* IBM TS1140 */
 		TAPEDRIVE( IBM_VENDOR_ID, "03592E08",     DRIVE_TS1150,  "[03592E08]" ),     /* IBM TS1150 */
 		TAPEDRIVE( IBM_VENDOR_ID, "0359255F",     DRIVE_TS1155,  "[0359255F]" ),     /* IBM TS1155 */
+		TAPEDRIVE( IBM_VENDOR_ID, "0359260F",     DRIVE_TS1160,  "[0359260F]" ),     /* IBM TS1160 */
 		/* End of supported_devices */
 		NULL
 };
@@ -841,41 +881,81 @@ static struct _timeout_tape timeout_11x0[] = {
 
 static struct _timeout_tape timeout_1140[] = {
 	{ XCOPY,                           -1    },
-	{ ERASE,                           21600 },
-	{ FORMAT_MEDIUM,                   1500  },
+	{ ERASE,                           36900 },
+	{ FORMAT_MEDIUM,                   3000  },
 	{ LOAD_UNLOAD,                     720   },
-	{ LOCATE10,                        840   },
-	{ LOCATE16,                        840   },
-	{ READ,                            1080  },
+	{ LOCATE10,                        2000  },
+	{ LOCATE16,                        2000  },
+	{ READ,                            2100  },
 	{ READ_BUFFER,                     300   },
 	{ REWIND,                          480   },
 	{ SEND_DIAGNOSTIC,                 2100  },
-	{ SPACE6,                          840   },
-	{ SPACE16,                         840   },
-	{ VERIFY,                          21600 },
-	{ WRITE,                           1080  },
-	{ WRITE_BUFFER,                    480   },
-	{ WRITE_FILEMARKS6,                1080  },
+	{ SPACE6,                          2000  },
+	{ SPACE16,                         2000  },
+	{ VERIFY,                          38100 },
+	{ WRITE,                           1200  },
+	{ WRITE_BUFFER,                    540   },
+	{ WRITE_FILEMARKS6,                1100  },
 	{-1, -1}
 };
 
 static struct _timeout_tape timeout_1150[] = {
 	{ XCOPY,                           18000 },
-	{ ERASE,                           46000 },
-	{ FORMAT_MEDIUM,                   3060  },
-	{ LOAD_UNLOAD,                     760   },
-	{ LOCATE10,                        1320  },
-	{ LOCATE16,                        1320  },
-	{ READ,                            1410  },
-	{ READ_BUFFER,                     470   },
+	{ ERASE,                           45800 },
+	{ FORMAT_MEDIUM,                   3100  },
+	{ LOAD_UNLOAD,                     900   },
+	{ LOCATE10,                        2300  },
+	{ LOCATE16,                        2300  },
+	{ READ,                            2400  },
+	{ READ_BUFFER,                     480   },
 	{ REWIND,                          560   },
-	{ SEND_DIAGNOSTIC,                 2200  },
-	{ SPACE6,                          1320  },
-	{ SPACE16,                         1320  },
-	{ VERIFY,                          46000 },
+	{ SEND_DIAGNOSTIC,                 2100  },
+	{ SPACE6,                          2300  },
+	{ SPACE16,                         2300  },
+	{ VERIFY,                          46700 },
+	{ WRITE,                           1500  },
+	{ WRITE_BUFFER,                    540   },
+	{ WRITE_FILEMARKS6,                1400  },
+	{-1, -1}
+};
+
+static struct _timeout_tape timeout_1155[] = {
+	{ XCOPY,                           68900 },
+	{ ERASE,                           68000 },
+	{ FORMAT_MEDIUM,                   3100  },
+	{ LOAD_UNLOAD,                     900   },
+	{ LOCATE10,                        2300  },
+	{ LOCATE16,                        2300  },
+	{ READ,                            2400  },
+	{ READ_BUFFER,                     480   },
+	{ REWIND,                          560   },
+	{ SEND_DIAGNOSTIC,                 2100  },
+	{ SPACE6,                          2300  },
+	{ SPACE16,                         2300  },
+	{ VERIFY,                          68900 },
+	{ WRITE,                           1500  },
+	{ WRITE_BUFFER,                    540   },
+	{ WRITE_FILEMARKS6,                1400  },
+	{-1, -1}
+};
+
+static struct _timeout_tape timeout_1160[] = {
+	{ XCOPY,                           68900 },
+	{ ERASE,                           64860 },
+	{ FORMAT_MEDIUM,                   3060  },
+	{ LOAD_UNLOAD,                     900   },
+	{ LOCATE10,                        2280  },
+	{ LOCATE16,                        2280  },
+	{ READ,                            2340  },
+	{ READ_BUFFER,                     480   },
+	{ REWIND,                          600   },
+	{ SEND_DIAGNOSTIC,                 2100  },
+	{ SPACE6,                          2380  },
+	{ SPACE16,                         2380  },
+	{ VERIFY,                          65820 },
 	{ WRITE,                           1440  },
 	{ WRITE_BUFFER,                    530   },
-	{ WRITE_FILEMARKS6,                1440  },
+	{ WRITE_FILEMARKS6,                1380  },
 	{-1, -1}
 };
 
@@ -949,7 +1029,10 @@ int ibm_tape_init_timeout(struct timeout_tape** table, int type)
 			ret = _create_table_tape(table, timeout_11x0, timeout_1150);
 			break;
 		case DRIVE_TS1155:
-			ret = _create_table_tape(table, timeout_11x0, timeout_1150);
+			ret = _create_table_tape(table, timeout_11x0, timeout_1155);
+			break;
+		case DRIVE_TS1160:
+			ret = _create_table_tape(table, timeout_11x0, timeout_1160);
 			break;
 		default:
 			ret = _create_table_tape(table, timeout_lto, timeout_lto7_hh);
@@ -1024,6 +1107,15 @@ static inline unsigned char _assume_cartridge_type(char product, char btype)
 				break;
 			case 'Z':
 				ctype = TC_MP_JZ;
+				break;
+			case 'E':
+				ctype = TC_MP_JE;
+				break;
+			case 'V':
+				ctype = TC_MP_JV;
+				break;
+			case 'M':
+				ctype = TC_MP_JM;
 				break;
 			default:
 				break;
@@ -1112,6 +1204,15 @@ char* ibm_tape_assume_cart_name(unsigned char type)
 			break;
 		case TC_MP_JZ:
 			name = "JZ";
+			break;
+		case TC_MP_JE:
+			name = "JE";
+			break;
+		case TC_MP_JV:
+			name = "JV";
+			break;
+		case TC_MP_JM:
+			name = "JM";
 			break;
 		default:
 			name = "L5";
@@ -1401,6 +1502,7 @@ bool ibm_tape_is_supported_firmware(int drive_type, const unsigned char * const 
 	case DRIVE_LTO7:
 	case DRIVE_LTO7_HH:
 	case DRIVE_TS1150:
+	case DRIVE_TS1160:
 	default:
 		break;
 	}

--- a/src/tape_drivers/ibm_tape.h
+++ b/src/tape_drivers/ibm_tape.h
@@ -140,6 +140,7 @@ enum {
 	DRIVE_TS1140      = 0x1104, /* TS1140 */
 	DRIVE_TS1150      = 0x1105, /* TS1150 */
 	DRIVE_TS1155      = 0x5105, /* TS1155 */
+	DRIVE_TS1160      = 0x1106, /* TS1160 */
 };
 
 enum {
@@ -151,6 +152,7 @@ enum {
 	DRIVE_GEN_JAG4    = 0x1004,
 	DRIVE_GEN_JAG5    = 0x1005,
 	DRIVE_GEN_JAG5A   = 0x5005,
+	DRIVE_GEN_JAG6    = 0x1006,
 };
 
 typedef struct {
@@ -228,8 +230,8 @@ enum pro_action {
 	PRO_ACT_REGISTER_MOVE   = 0x07
 };
 
-#define IS_SHORT_MEDIUM(m) (m == TC_MP_JK || m == TC_MP_JL)
-#define IS_WORM_MEDIUM(m)  (m == TC_MP_JY || m == TC_MP_JZ)
+#define IS_SHORT_MEDIUM(m) (m == TC_MP_JK || m == TC_MP_JL || m == TC_MP_JM)
+#define IS_WORM_MEDIUM(m)  (m == TC_MP_JY || m == TC_MP_JZ || m == TC_MP_JV)
 
 extern DRIVE_DENSITY_SUPPORT_MAP jaguar_drive_density[];
 extern DRIVE_DENSITY_SUPPORT_MAP jaguar_drive_density_strict[];

--- a/src/tape_drivers/tape_drivers.h
+++ b/src/tape_drivers/tape_drivers.h
@@ -120,28 +120,40 @@ enum {
 	TC_MP_LTO6W_CART  = 0x6C,   /* LTO6 WORM cartridge */
 	TC_MP_LTO7W_CART  = 0x7C,   /* LTO7 WORM cartridge */
 	TC_MP_LTO8W_CART  = 0x8C,   /* LTO8 WORM cartridge */
+	/* 1st gen cart */
 	TC_MP_JA          = 0x91,   /* IBM TS11x0 JA cartridge */
 	TC_MP_JW          = 0xA1,   /* IBM TS11x0 JW cartridge */
 	TC_MP_JJ          = 0xB1,   /* IBM TS11x0 JJ cartridge */
 	TC_MP_JR          = 0xC1,   /* IBM TS11x0 JR cartridge */
+	/* 2nd gen cart */
 	TC_MP_JB          = 0x92,   /* IBM TS11x0 JB cartridge */
 	TC_MP_JX          = 0xA2,   /* IBM TS11x0 JX cartridge */
-	TC_MP_JK          = 0xB2,   /* IBM TS11x0 JK cartridge */
+	/* 3rd gen cart */
 	TC_MP_JC          = 0x93,   /* IBM TS11x0 JC cartridge */
 	TC_MP_JY          = 0xA3,   /* IBM TS11x0 JY cartridge */
-	TC_MP_JL          = 0xB3,   /* IBM TS11x0 JL cartridge */
+	TC_MP_JK          = 0xB2,   /* IBM TS11x0 JK cartridge */
+	/* 4th gen cart */
 	TC_MP_JD          = 0x94,   /* IBM TS11x0 JD cartridge */
 	TC_MP_JZ          = 0xA4,   /* IBM TS11x0 JZ cartridge */
+	TC_MP_JL          = 0xB3,   /* IBM TS11x0 JL cartridge */
+	/* 5th gen */
+	TC_MP_JE          = 0x95,   /* IBM TS11x0 JE cartridge */
+	TC_MP_JV          = 0xA5,   /* IBM TS11x0 JV cartridge */
+	TC_MP_JM          = 0xB4,   /* IBM TS11x0 JM cartridge */
 };
 
 #define IS_REFORMATTABLE_TAPE(t) \
 	( t == TC_MP_JB ||			 \
-	  t == TC_MP_JC ||			 \
-	  t == TC_MP_JD ||			 \
+	  t == TC_MP_JX ||			 \
 	  t == TC_MP_JK ||			 \
-	  t == TC_MP_JL ||			 \
+	  t == TC_MP_JC ||			 \
 	  t == TC_MP_JY ||			 \
+	  t == TC_MP_JL ||			 \
+	  t == TC_MP_JD ||			 \
 	  t == TC_MP_JZ ||			 \
+	  t == TC_MP_JE ||			 \
+	  t == TC_MP_JV ||			 \
+	  t == TC_MP_JM ||			 \
 	  t == TC_MP_LTO7D_CART )
 
 #endif // __tape_drivers_h


### PR DESCRIPTION
# Summary of changes

Experimental support of the IBM TS1160 enterprise tape drive

# Description

IBM announced new enterprise tape drive TS1160. This patch is experimental support of that drive

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
