### PR TITLE
Handle teh case the sg driver returns ENOMEM

### DIFF
--- a/messages/internal_error/root.txt
+++ b/messages/internal_error/root.txt
@@ -365,6 +365,8 @@ root:table {
 		D1721E:string{ "No reservation holder." }
 		D1722E:string{ "A path switch happened. Reissue the command." }
 		D1723E:string{ "A real power on reset is detected." }
+		D1724E:string{ "Buffer allocation error in a driver." }
+		D1725E:string{ "Retry the command again." }
 		D9998E:string{ "Unknown sense." }
 		D9999E:string{ "Vendor unique sense. ASC >= 0x80 or ASCQ >= 0x80." }
 	}

--- a/messages/tape_generic_itdtimg/root.txt
+++ b/messages/tape_generic_itdtimg/root.txt
@@ -77,7 +77,6 @@ root:table {
 		31196D:string { "Backend %s: %llu." }
 		31197D:string { "Backend %s: (%llu, %llu)." }
 		31198D:string { "Backend %s: (%llu, %llu) FM = %llu." }
-		31199I:string { "itdtimg backend options:\n"
-						"    -o devname=<dev>          tape device (default=%s)\n." }
+		31199I:string { "itdtimg backend options:\n    -o devname=<dev>          tape device (default=%s)\n." }
 	}
 }

--- a/messages/tape_linux_sg_ibmtape/root.txt
+++ b/messages/tape_linux_sg_ibmtape/root.txt
@@ -116,6 +116,13 @@ root:table {
 		30274I:string { "Pseudo-error on %s." }
 		30275I:string { "Pseudo-error on write. Good return code, but a record to emulate a write error did not get sent to the drive." }
 		30276I:string { "Raw capacity info of partition %d (%llu - %llu) %s." }
+		30277W:string { "Detect ENOMEM in ioctl() call. Wait 3 secs and retry (%d)." }
+		30278I:string { "Retrying %s operation at (%u, %llu)." }
+		30279I:string { "Retrying %s operation at (%u, %llu) with skip back, because the command was already executed (%u, %llu)." }
+		30280W:string { "Unexpected current position for %s operation (%d). (%u, %llu), (%u, %llu) ." }
+		30281W:string { "Position confirmation for %s operation retry is failed (%d). (%u, %llu), (%u, %llu)." }
+		30282W:string { "Unexpected position after skip back for %s operation. (%u, %llu), (%u, %llu)." }
+		30283W:string { "Skip back for %s operation is failed (%d). (%u, %llu), (%u, %llu)." }
 
 		30392D:string { "Backend %s %s." }
 		30393D:string { "Backend %s: %d %s." }

--- a/src/libltfs/arch/errormap.c
+++ b/src/libltfs/arch/errormap.c
@@ -402,6 +402,8 @@ static struct error_map fuse_error_list[] = {
 	{ EDEV_NO_RESERVATION_HOLDER,    "D1721E", EIO},
 	{ EDEV_NEED_FAILOVER,            "D1722E", EIO},
 	{ EDEV_REAL_POWER_ON_RESET,      "D1723E", EIO},
+	{ EDEV_BUFFER_ALLOCATE_ERROR,    "D1724E", EIO},
+	{ EDEV_RETRY,                    "D1725E", EIO},
 	{ -1, NULL, 0 }
 };
 

--- a/src/libltfs/ltfs_error.h
+++ b/src/libltfs/ltfs_error.h
@@ -44,6 +44,10 @@
 **                  IBM Almaden Research Center
 **                  bbiskebo@us.ibm.com
 **
+**                  Atsushi Abe
+**                  IBM Tokyo Lab., Japan
+**                  piste@jp.ibm.com
+**
 *************************************************************************************
 */
 
@@ -410,6 +414,8 @@
 #define EDEV_NO_RESERVATION_HOLDER   21721  /* No reservation holder */
 #define EDEV_NEED_FAILOVER           21722  /* Path switch happens, need to reissue the command */
 #define EDEV_REAL_POWER_ON_RESET     21723  /* Real power on reset is detected */
+#define EDEV_BUFFER_ALLOCATE_ERROR   21724  /* Buffer allocation error in a driver */
+#define EDEV_RETRY                   21725  /* Retry the command again */
 
 /* Vendor Unique codes */
 #define EDEV_UNKNOWN                 29998  /* Unknown sense code */

--- a/src/tape_drivers/linux/sg-ibmtape/sg_scsi_tape.c
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_scsi_tape.c
@@ -195,6 +195,9 @@ start:
 		if (errno == ENODEV) {
 			if (msg) *msg = "No device found";
 			return -EDEV_CONNECTION_LOST;
+		} else if (errno == ENOMEM) {
+			if (msg) *msg = "ioctl ENOMEM error";
+			return -EDEV_BUFFER_ALLOCATE_ERROR;
 		} else {
 			if (msg) *msg = "ioctl error";
 			return -EDEV_INTERNAL_ERROR;


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Add handling when the sg driver return ENOMEM against a read or write cdb.

# Description

Following recovery procedure is executed when LTFS receives ENOMEM against a read cdb or write cdb.

0. Assume the position before issuing a command is org_pos
1. Check current position (cur_pos)
2. If cur_pos == org_pos, simply retry
3. if cur_pos == org_pos + 1, space back one record and retry
4. otherwise report error

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
