### PR TITLE
Improve reliability of the sg backend

### DIFF
--- a/messages/tape_linux_sg_ibmtape/root.txt
+++ b/messages/tape_linux_sg_ibmtape/root.txt
@@ -123,6 +123,8 @@ root:table {
 		30281W:string { "Position confirmation for %s operation retry is failed (%d). (%u, %llu), (%u, %llu)." }
 		30282W:string { "Unexpected position after skip back for %s operation. (%u, %llu), (%u, %llu)." }
 		30283W:string { "Skip back for %s operation is failed (%d). (%u, %llu), (%u, %llu)." }
+		30284E:string { "Cannot get reserved buffer size of %s." }
+		30285I:string { "Reserved buffer size of %s is %d." }
 
 		30392D:string { "Backend %s %s." }
 		30393D:string { "Backend %s: %d %s." }


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes. 

- Try to set reserved_buffer to 1MB (But may be 512KB is reserved)

# Description

This change will reduce ENOMEM chance because 512KB buffer is reserved in a opened sg device file.

## Type of change

- Performance enhancement

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
