### PR TITLE
Commit some cache files before releasing lock for cache files

### DIFF
--- a/src/libltfs/xml_writer_libltfs.c
+++ b/src/libltfs/xml_writer_libltfs.c
@@ -732,7 +732,8 @@ static int _commit_offset_caches(const char* path, const struct ltfs_index *idx)
 					close(fd);
 					fd = -1;
 				} else {
-					ltfsmsg(LTFS_INFO, 17255I, offset_name, errno);
+					if (errno != ENOENT)
+						ltfsmsg(LTFS_INFO, 17255I, offset_name, errno);
 				}
 				free(offset_name);
 			}
@@ -752,7 +753,8 @@ static int _commit_offset_caches(const char* path, const struct ltfs_index *idx)
 					close(fd);
 					fd = -1;
 				} else {
-					ltfsmsg(LTFS_INFO, 17255I, sync_name, errno);
+					if (errno != ENOENT)
+						ltfsmsg(LTFS_INFO, 17255I, sync_name, errno);
 				}
 				free(sync_name);
 			}
@@ -891,11 +893,11 @@ int xml_schema_to_tape(char *reason, struct ltfs_volume *vol)
 			if (out_ctx->fd >= 0)
 				xml_release_file_lock(vol->index_cache_path, out_ctx->fd, bk, true);
 		} else {
-			if (out_ctx->fd >= 0)
-				xml_release_file_lock(vol->index_cache_path, out_ctx->fd, bk, false);
-
 			if (vol->index_cache_path)
 				_commit_offset_caches(vol->index_cache_path, vol->index);
+
+			if (out_ctx->fd >= 0)
+				xml_release_file_lock(vol->index_cache_path, out_ctx->fd, bk, false);
 		}
 
 		/* Update the creator string */


### PR DESCRIPTION
# Summary of changes

Commit some cache information before releasing lock for cache files

# Description

There is a short window to peep LTFS's internal cache information. Basically it shall be protected by an advisory lock of the index cache. But this lock is released before committing new cache files.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
