### PR TITLE
Handle write perm errors while wrinting an index

### DIFF
--- a/messages/libltfs/root.txt
+++ b/messages/libltfs/root.txt
@@ -427,7 +427,7 @@ root:table {
 		11330I:string { "Loading cartridge." }
 		11331E:string { "Failed to load the cartridge (%s)." }
 		11332I:string { "Load successful." }
-		11333I:string { "A cartridge with a write-perm error is detected. Seek the newest index (%llu, %llu)." }
+		11333I:string { "A cartridge with write-perm error is detected on %s. Seek the newest index (%llu, %llu)." }
 		11334I:string { "Remove extent : %s (%llu, %llu)." }
 		11335D:string { "Get physical block position (%d - %d)." }
 		11336I:string { "The attribute does not exist. Ignore the expected error." }
@@ -435,6 +435,12 @@ root:table {
 		11338I:string { "Syncing index of %s %s." }
 		11339D:string { "%s volume lock status (%d)." }
 		11340I:string { "Revalidation process is successfully done. (%s)" }
+		11341E:string { "Failed to update the volume lock status to %d (%d)." }
+		11342E:string { "Failed to get the volume lock status (%d)." }
+		11343I:string { "Try to write an index on IP on %s because of an permanent write error on DP." }
+		11344I:string { "Tape %s is frozen successfully because of an permanent write error on DP." }
+		11345E:string { "Failed to freeze tape %s because permanent write errors on IP and DP." }
+		11346E:string { "Tape %s is frozen by the previous index on the tape. Some metadata will be lost at unmount operation." }
 
 		// Message IDs 11400 through 11800 are allocated to the libchanger.
 		// DO NOT add messages with those IDs to this file.
@@ -527,7 +533,7 @@ root:table {
 
 		// Message IDs 14000-14499 are reserved for the ltfs executable.
 		// DO NOT add messages with those IDs to this file.
-
+v
 		// Message IDs 14500-14999 are reserved for the admin_channel interface.
 		// DO NOT add messages with those IDs to this file.
 

--- a/src/iosched/unified.c
+++ b/src/iosched/unified.c
@@ -2258,6 +2258,9 @@ int _unified_write_index_after_perm(int write_ret, struct unified_data *priv)
 	}
 
 	ltfsmsg(LTFS_INFO, 13024I, write_ret);
+	ret = tape_set_cart_volume_lock_status(priv->vol, VOLUME_WRITE_PERM_DP);
+	if (ret < 0)
+		ltfsmsg(LTFS_ERR, 13026E, "update MAM", ret);
 
 	blocksize = ltfs_get_blocksize(priv->vol);
 	ret = tape_get_physical_block_position(priv->vol->device, &err_pos);
@@ -2274,16 +2277,7 @@ int _unified_write_index_after_perm(int write_ret, struct unified_data *priv)
 		return ret;
 	}
 
-	ret = ltfs_write_index(ltfs_ip_id(priv->vol), SYNC_WRITE_PERM, priv->vol) ;
-	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, 13026E, "append index", ret);
-		ret = tape_set_cart_volume_lock_status(priv->vol, VOLUME_WRITE_PERM_BOTH);
-		return ret;
-	}
-
-	ret = tape_set_cart_volume_lock_status(priv->vol, VOLUME_WRITE_PERM_DP);
-	if (ret < 0)
-		ltfsmsg(LTFS_ERR, 13026E, "update MAM", ret);
+	ret = ltfs_write_index(ltfs_ip_id(priv->vol), SYNC_WRITE_PERM, priv->vol);
 
 	return ret;
 }

--- a/src/libltfs/tape.c
+++ b/src/libltfs/tape.c
@@ -1713,8 +1713,8 @@ int tape_get_cart_volume_lock_status(struct device_data *dev, int *status)
 
 int tape_set_cart_volume_lock_status(struct ltfs_volume *vol, int status)
 {
-	int ret, cur_stat;
-	char value[TC_MAM_VOLUME_LOCKED_SIZE+1];
+	int ret, cur_stat = -1;
+	char value[TC_MAM_VOLUME_LOCKED_SIZE];
 
 	tape_get_cart_volume_lock_status(vol->device, &cur_stat);
 
@@ -1732,7 +1732,6 @@ int tape_set_cart_volume_lock_status(struct ltfs_volume *vol, int status)
 	}
 
 	value[0] = status;
-	value[1] = '\0';
 
 	/* update CM MAM attribute */
 	ret = update_tape_attribute(vol, value, TC_MAM_VOLUME_LOCKED, TC_MAM_VOLUME_LOCKED_SIZE);

--- a/src/libltfs/xattr.c
+++ b/src/libltfs/xattr.c
@@ -1417,7 +1417,7 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 		lock = strtoull(v, &invalid_start, 0);
 		if( (*invalid_start == '\0') && v ) {
 			enum mam_advisory_lock_status new = VOLUME_UNLOCKED;
-			char status_mam[TC_MAM_VOLUME_LOCKED_SIZE+1];
+			char status_mam[TC_MAM_VOLUME_LOCKED_SIZE];
 
 			switch (vol->t_attr->vollock) {
 				case VOLUME_WRITE_PERM:
@@ -1455,7 +1455,6 @@ int _xattr_set_virtual(struct dentry *d, const char *name, const char *value,
 			}
 
 			status_mam[0] = new;
-			status_mam[1] = '\0';
 
 			/* update MAM attribute */
 			ret =  update_tape_attribute(vol, status_mam, TC_MAM_VOLUME_LOCKED, TC_MAM_VOLUME_LOCKED_SIZE);

--- a/src/tape_drivers/generic/file/filedebug_tc.c
+++ b/src/tape_drivers/generic/file/filedebug_tc.c
@@ -1908,8 +1908,12 @@ int filedebug_read_attribute(void *device, const tape_partition_t part, const ui
 	fd = open(fname, O_RDONLY | O_BINARY);
 	free(fname);
 	if (fd < 0) {
-		ltfsmsg(LTFS_WARN, 30062W, errno);
-		return -EDEV_CM_PERM;
+		if (errno == ENOENT) {
+			return -EDEV_INVALID_FIELD_CDB;
+		} else {
+			ltfsmsg(LTFS_WARN, 30062W, errno);
+			return -EDEV_CM_PERM;
+		}
 	}
 
 	/* TODO: return -EDEV_INVALID_ARG if buffer is too small to hold complete record? */


### PR DESCRIPTION
# Summary of changes

- Handle permanent write error (WritePerm) while writing an index
  + A WritePerm happens on DP, try to write another one on DP and update MAM
  + A WritePerm happens on IP, just update MAM

# Description

Previously, a tape goes to inconsistent state, it may be recoverable, when a WritePerm happens while writing an index.

In this fix, tape state goes to R/O because of WritePerm  as same as a case WritePerm happens while writing contents of a file.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
