### PR TITLE
Accept unexpected '/' in name

### DIFF
--- a/messages/libltfs/root.txt
+++ b/messages/libltfs/root.txt
@@ -792,6 +792,8 @@ root:table {
 		17253E:string { "Cannot get tape parameters: %s (%d)." }
 		17254E:string { "This cartridge cannot be reformatted in the drive (0x%02x, %d)." }
 		17255I:string { "Cannot open %s cache for sync (%d)." }
+		17256I:string { "'%%2f', decoded to '/', is existed into encoded name object (%s): do not encode" }
+		17257I:string { "'/' is existed into name object (%s): replace to '_'" }
 
 		// For Debug 19999I:string { "%s %s %d." }
 

--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -1739,6 +1739,9 @@ out_unlock:
 	else if (index && !vol->index)
 		vol->index = index;
 
+	if (ret && vol->index)
+		ltfs_index_free(&vol->index);
+
 	return ret;
 }
 

--- a/src/libltfs/xml_reader_libltfs.c
+++ b/src/libltfs/xml_reader_libltfs.c
@@ -112,11 +112,28 @@ static int decode_entry_name(char **new_name, const char *name)
 			buf_decode[1] = name[i+1];
 			tmp_name[j] = (int)strtol(buf_decode, NULL, 16);
 			encoded = false;
+
+			/* Allow '/' but replace to '%2f' for supporting bad manner writer */
+			if (tmp_name[j] == '/') {
+				tmp_name[j] = '%';
+				tmp_name[j+1] = '2';
+				tmp_name[j+2] = 'f';
+				j+=2;
+				ltfsmsg(LTFS_ERR, 17256I, name);
+			}
+
 			i+=2;
 		} else {
 			tmp_name[j] = name[i];
 			i++;
 		}
+
+		/* Allow '/' but replace to '_' for supporting bad manner writer */
+		if (tmp_name[j] == '/') {
+			tmp_name[j] = '_';
+			ltfsmsg(LTFS_ERR, 17257I, name);
+		}
+
 		j++;
 	}
 	tmp_name[j] = '\0';
@@ -142,6 +159,9 @@ static int _xml_parse_nametype(xmlTextReaderPtr reader, struct ltfs_name *n, boo
 	} else {
 		n->percent_encode = false;
 	}
+
+	/* Free up encode attribute allocated by xmlTextReaderGetAttribute() */
+	if (encode) free(encode);
 
 	get_tag_text();
 

--- a/src/libltfs/xml_writer_libltfs.c
+++ b/src/libltfs/xml_writer_libltfs.c
@@ -84,11 +84,11 @@ static int encode_entry_name(char **new_name, const char *name)
 	UChar32 c;
 
 	/* Printable ASCII characters
-	 * !\"#$%&`'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
+	 * !\"#$&`'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
 	 *
-	 * In this encoding, only `:` is encoded in this printable character set
+	 * In this encoding, only `:` and `%` is encoded in this printable character set
 	 */
-	static char plain_chars[] = "!\"#$%&`'()*+,-./0123456789;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
+	static char plain_chars[] = "!\"#$&`'()*+,-./0123456789;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~";
 	char *tmp_name;
 	char buf_encode[3];
 	int i=0, count=0, prev=0, j=0;


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Accept an index created by bad manner index writers
- Fix the index writer to encode '%' correctly

# Description

Previously the index writer of LTFS have a bad manner. It doesn't encode '%' correctly when it need to encode a name object by URL encode.

This behavior causes catastrophic situation when the name has both characters required URL encode like ':' and "%2f"  like "AAA%2f:BBB". 

The name "AAA%2f:BBB" is written to the index as "AAA%2f%3A". And it is read as "AAA/:" because of URL encode is required. But this name is invalid and mount is failed (inconsistent state).

The biggest problem is recovery. ltfsck skips this kind of index and finally it reverts the filesystem to the index that can be parsed. (It means data loss!!!)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
