### PR TITLE
Accept unexpected US (0x1f) in name

### DIFF
--- a/messages/libltfs/root.txt
+++ b/messages/libltfs/root.txt
@@ -792,8 +792,8 @@ root:table {
 		17253E:string { "Cannot get tape parameters: %s (%d)." }
 		17254E:string { "This cartridge cannot be reformatted in the drive (0x%02x, %d)." }
 		17255I:string { "Cannot open %s cache for sync (%d)." }
-		17256I:string { "'%%2f', decoded to '/', is existed into encoded name object (%s): do not encode" }
-		17257I:string { "'/' is existed into name object (%s): replace to '_'" }
+		17256I:string { "'%%2f' or '%%1f' is existed into encoded name object (%s): Revert to the encoded character" }
+		17257I:string { "0x2f (/) or 0x1f (US) is existed into name object (%s): Replace to '_'" }
 
 		// For Debug 19999I:string { "%s %s %d." }
 

--- a/src/libltfs/xml_reader_libltfs.c
+++ b/src/libltfs/xml_reader_libltfs.c
@@ -113,11 +113,19 @@ static int decode_entry_name(char **new_name, const char *name)
 			tmp_name[j] = (int)strtol(buf_decode, NULL, 16);
 			encoded = false;
 
-			/* Allow '/' but replace to '%2f' for supporting bad manner writer */
-			if (tmp_name[j] == '/') {
+			/*
+			 * Allow '/' (0x2f) and US (0x1f) but revert to percent encoded
+			 * string for supporting bad manner writer
+			 */
+			/*
+			 * TODO: Need to remove US (0x1f) from this list. Because
+			 * US shall be accepted as a part of filename.
+			 * Now LTFS rejects US because of a historical issue. (See Issue #106 on GitHub)
+			 */
+			if (tmp_name[j] == '/' || tmp_name[j] == 0x1f) {
 				tmp_name[j] = '%';
-				tmp_name[j+1] = '2';
-				tmp_name[j+2] = 'f';
+				tmp_name[j+1] = buf_decode[0];
+				tmp_name[j+2] = buf_decode[1];
 				j+=2;
 				ltfsmsg(LTFS_ERR, 17256I, name);
 			}
@@ -128,8 +136,15 @@ static int decode_entry_name(char **new_name, const char *name)
 			i++;
 		}
 
-		/* Allow '/' but replace to '_' for supporting bad manner writer */
-		if (tmp_name[j] == '/') {
+		/*
+		 * Allow '/' and US (0x1f) but replace to '_' for supporting bad manner writer
+		 */
+		/*
+		 * TODO: Need to remove US (0x1f) from this list. Because
+		 * US shall be accepted as a part of filename.
+		 * Now LTFS rejects US because of a historical issue. (See Issue #106 on GitHub)
+		 */
+		if (tmp_name[j] == '/' || tmp_name[j] == 0x1f) {
 			tmp_name[j] = '_';
 			ltfsmsg(LTFS_ERR, 17257I, name);
 		}


### PR DESCRIPTION
# Summary of changes

This change is additional fix of #105.

# Description

Current LTFS rejects a US in name so need to escase US also as same as '/'.

## Type of change

Please delete items that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
