### PR TITLE
Avoid to recover with prior index on parse error

### DIFF
--- a/messages/libltfs/root.txt
+++ b/messages/libltfs/root.txt
@@ -321,7 +321,7 @@ root:table {
 		11224E:string { "Cannot restore medium consistency: failed to generate lost and found (%d)." }
 		11225E:string { "Cannot check medium: failed to allocate index data (%d)." }
 		11226I:string { "Erasing bad blocks from the index partition." }
-		11227I:string { "Erasing bad blocks from the data partition." }
+		11227I:string { "Preserve existing unreferred data blocks in the data partition, put the latest index at %llu." }
 		11228E:string { "Cannot restore medium consistency: failed to save data partition append position (%d)." }
 		11229E:string { "Cannot restore medium consistency: failed to save index partition append position (%d)." }
 		11230I:string { "Writing index(es) to restore consistency." }
@@ -573,8 +573,8 @@ root:table {
 		17027E:string { "XML parser: unsupported extended attribute type \'%s\'." }
 		17028E:string { "XML parser: base64 decoding failed." }
 		17029E:string { "XML parser: invalid UUID %s." }
-		17030E:string { "XML parser: failed to normalize name \'%s\'." }
-		17031E:string { "XML parser: invalid name \'%s\'." }
+		17030E:string { "XML parser: failed to normalize %s \'%s\'." }
+		17031E:string { "XML parser: invalid %s \'%s\'." }
 		17032E:string { "XML parser: compression must be \'true\' (1) or \'false\' (0)." }
 		17033E:string { "XML parser: invalid partition \'%s\'." }
 		17034E:string { "XML parser: invalid time \'%s\' (%d)." }
@@ -792,8 +792,10 @@ root:table {
 		17253E:string { "Cannot get tape parameters: %s (%d)." }
 		17254E:string { "This cartridge cannot be reformatted in the drive (0x%02x, %d)." }
 		17255I:string { "Cannot open %s cache for sync (%d)." }
-		17256I:string { "'%%2f' or '%%1f' is existed into encoded name object (%s): Revert to the encoded character" }
+		17256I:string { "Unexpected character is existed into decoded name object (%s): Revert to the encoded character" }
 		17257I:string { "0x2f (/) or 0x1f (US) is existed into name object (%s): Replace to '_'" }
+		17258E:string { "Critical error happened while parsing an index (%d). Stop seeking the latest index." }
+		17259I:string { "Recover an index on %s from (%c, %llu)." }
 
 		// For Debug 19999I:string { "%s %s %d." }
 

--- a/src/libltfs/xml_reader.c
+++ b/src/libltfs/xml_reader.c
@@ -312,13 +312,16 @@ int xml_parse_filename(char **out_val, const char *value)
 
 	ret = pathname_normalize(value, out_val);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, 17030E, value);
+		ltfsmsg(LTFS_ERR, 17030E, "name", value);
 		return ret;
-	} else if (pathname_validate_file(*out_val) < 0) {
-		ltfsmsg(LTFS_ERR, 17031E, value);
+	}
+
+	ret = pathname_validate_file(*out_val);
+	if (ret < 0) {
+		ltfsmsg(LTFS_ERR, 17031E, "name", value);
 		free(*out_val);
 		*out_val = NULL;
-		return -1;
+		return ret;
 	}
 
 	return 0;
@@ -340,13 +343,16 @@ int xml_parse_target(char **out_val, const char *value)
 
 	ret = pathname_normalize(value, out_val);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, 17030E, value);
+		ltfsmsg(LTFS_ERR, 17030E, "target", value);
 		return ret;
-	} else if (pathname_validate_target(*out_val) < 0) {
-		ltfsmsg(LTFS_ERR, 17031E, value);
+	}
+
+	ret = pathname_validate_target(*out_val);
+	if (ret < 0) {
+		ltfsmsg(LTFS_ERR, 17031E, "target", value);
 		free(*out_val);
 		*out_val = NULL;
-		return -1;
+		return ret;
 	}
 
 	return 0;


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Stop seeking index when following error happens
  - memory shortage
  - parse error because of unexpected filename
  - parse error because of non UTF-8 characters
  - parse error because of too long filename
- Recover the latest index at the EOD of DP

# Description

The worst case is removing a good file in a bad index without any
warning.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
