### PR TITLE
Relax lock status requirement for formatting

### DIFF
--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -2215,7 +2215,10 @@ int ltfs_write_index(char partition, char *reason, struct ltfs_volume *vol)
 	ret = tape_get_cart_volume_lock_status(vol->device, &volstat);
 	if (ret < 0) {
 		ltfsmsg(LTFS_ERR, 11341E, ret);
-		return ret;
+		if (vol->formatting)
+			ret = 0;
+		else
+			return ret;
 	}
 
 	if (vol->label->barcode[0] == ' ' || vol->label->barcode == NULL)

--- a/src/libltfs/ltfs.h
+++ b/src/libltfs/ltfs.h
@@ -434,6 +434,7 @@ struct ltfs_volume {
 	int file_open_count;            /**< Number of opened files */
 
 	const char *work_directory;
+	bool formatting;		/**< formatting in progress */
 };
 
 struct ltfs_label {

--- a/src/utils/mkltfs.c
+++ b/src/utils/mkltfs.c
@@ -488,10 +488,14 @@ int main(int argc, char **argv)
 	if (! opt.quiet)
 		fprintf(stderr, "\n");
 
+	newvol->formatting = true;
+
 	if(opt.unformat)
 		ret = unformat_tape(newvol, &opt, &args);
 	else
 		ret = format_tape(newvol, &opt, &args);
+
+	newvol->formatting = false;
 
 	free(opt.backend_path);
 	free(opt.kmi_backend_name);
@@ -669,7 +673,11 @@ int format_tape(struct ltfs_volume *vol, struct other_format_opts *opt, void *ar
 	/* Create partitions and write labels and indices to the tape */
 	ltfsmsg(LTFS_INFO, 15010I, DATA_PART_ID, DATA_PART_NUM);
 	ltfsmsg(LTFS_INFO, 15011I, INDEX_PART_ID, INDEX_PART_NUM);
+
+	vol->formatting = true;
 	ret = ltfs_format_tape(vol, 0);
+	vol->formatting = false;
+
 	if (ret < 0) {
 		if (ret == -LTFS_INTERRUPTED) {
 			ltfsmsg(LTFS_ERR, 15045E);


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Fix of issue #112

# Description

Make sure we do not fail formatting just because the lock status attribute is not available on tape.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
