### PR TITLE
Reduce differences with HPE tape backend interface

### DIFF
--- a/src/iosched/unified.c
+++ b/src/iosched/unified.c
@@ -1190,7 +1190,7 @@ void _unified_process_index_queue(struct unified_data *priv)
 					/* Index partition writer: failed to write data to the tape (%d) */
 					ltfsmsg(LTFS_WARN, 13013W, (int)ret);
 					if (IS_WRITE_PERM(-ret)) {
-						ret = tape_set_cart_volume_lock_status(priv->vol, VOLUME_WRITE_PERM_IP);
+						ret = tape_set_cart_volume_lock_status(priv->vol, PWE_MAM_IP);
 					}
 					_unified_handle_write_error(ret, req, dentry_priv, priv);
 					break;
@@ -2258,7 +2258,7 @@ int _unified_write_index_after_perm(int write_ret, struct unified_data *priv)
 	}
 
 	ltfsmsg(LTFS_INFO, 13024I, write_ret);
-	ret = tape_set_cart_volume_lock_status(priv->vol, VOLUME_WRITE_PERM_DP);
+	ret = tape_set_cart_volume_lock_status(priv->vol, PWE_MAM_DP);
 	if (ret < 0)
 		ltfsmsg(LTFS_ERR, 13026E, "update MAM", ret);
 

--- a/src/libltfs/ltfs.h
+++ b/src/libltfs/ltfs.h
@@ -338,19 +338,19 @@ struct tape_attr {
 	char media_pool[TC_MAM_MEDIA_POOL_SIZE + 1];
 };
 
-enum mam_advisory_lock_status {
-	VOLUME_UNLOCKED        = 0,
-	VOLUME_LOCKED          = 1,   /* Advisory locked (Set VOL_LOCKED) */
-	VOLUME_WRITE_PERM      = 2,   /* Single write perm (Set VOL_PERM_WRITE_ERR) */
-	VOLUME_PERM_LOCKED     = 3,   /* Advisory perm locked (Set VOL_PERM_LOCKED) */
-	VOLUME_WRITE_PERM_DP   = 4,   /* Single write perm on DP (Set VOL_DP_PERM_ERR) */
-	VOLUME_WRITE_PERM_IP   = 5,   /* Single write perm on IP (Set VOL_IP_PERM__ERR) */
-	VOLUME_WRITE_PERM_BOTH = 6,   /* Double write perm (Set both VOL_DP_PERM_ERR and VOL_IP_PERM_ERR) */
-	VOLUME_NOLOCK          = 128, /* From HPE LTFS NOLOCK_MAM */
-};
+typedef enum mam_advisory_lock_status {
+	UNLOCKED_MAM   = 0,
+	LOCKED_MAM     = 1,   /* Advisory locked (Set VOL_LOCKED) */
+	PWE_MAM        = 2,   /* Single write perm (Set VOL_PERM_WRITE_ERR) */
+	PERMLOCKED_MAM = 3,   /* Advisory perm locked (Set VOL_PERM_LOCKED) */
+	PWE_MAM_DP     = 4,   /* Single write perm on DP (Set VOL_DP_PERM_ERR) */
+	PWE_MAM_IP     = 5,   /* Single write perm on IP (Set VOL_IP_PERM__ERR) */
+	PWE_MAM_BOTH   = 6,   /* Double write perm (Set both VOL_DP_PERM_ERR and VOL_IP_PERM_ERR) */
+	NOLOCK_MAM    = 128,  /* From HPE */
+} mam_lockval;
 
-#define IS_SINGLE_WRITE_PERM(stat)  (stat == VOLUME_WRITE_PERM || (stat == VOLUME_WRITE_PERM_DP || stat == VOLUME_WRITE_PERM_IP) )
-#define IS_DOUBLE_WRITE_PERM(stat)  (stat == VOLUME_WRITE_PERM_BOTH)
+#define IS_SINGLE_WRITE_PERM(stat)  (stat == PWE_MAM || (stat == PWE_MAM_DP || stat == PWE_MAM_IP) )
+#define IS_DOUBLE_WRITE_PERM(stat)  (stat == PWE_MAM_BOTH)
 
 enum volumelock_status {
 	VOL_UNLOCKED        = 0x00000000,
@@ -432,9 +432,7 @@ struct ltfs_volume {
 	char *mountpoint;              /**< Store mount point for Live Link (SDE) */
 	size_t mountpoint_len;         /**< Store mount point path length (SDE) */
 	struct tape_attr *t_attr;      /**< Tape Attribute data */
-	enum mam_advisory_lock_status lock_status;
-	                               /**< Total volume lock status from t_attr->vollock and index->vollock */
-
+	mam_lockval lock_status;       /**< Total volume lock status from t_attr->vollock and index->vollock */
 	struct ltfs_timespec first_locate; /**< Time to first locate */
 	int file_open_count;            /**< Number of opened files */
 
@@ -514,7 +512,7 @@ struct ltfs_index {
 	size_t symerr_count;                /**< Number of conflicted symlink dentries */
 	struct dentry **symlink_conflict;   /**< symlink/extent conflicted dentries */
 
-	enum mam_advisory_lock_status vollock; /**< volume lock status on index */
+	mam_lockval vollock;                /**< volume lock status on index */
 };
 
 struct ltfs_direntry {

--- a/src/libltfs/ltfslogging.c
+++ b/src/libltfs/ltfslogging.c
@@ -375,14 +375,31 @@ void ltfsprintf_unload_plugin(void *handle)
 }
 
 /* Print a formatted message in the current system locale. */
-int ltfsmsg_internal(bool print_id, int level, char **msg_out, const char *id, ...)
+int ltfsmsg_internal(bool print_id, int level, char **msg_out, const char *_id, ...)
 {
 	const UChar *format_uc = NULL;
 	int32_t prefix_len, format_len;
 	int32_t id_val;
+	char id[16];
+	size_t idlen;
 	UErrorCode err = U_ZERO_ERROR;
 	va_list argp;
 	struct plugin_bundle *entry;
+
+	/*
+	 * We accept quoted id used in HPE backend source,
+	 * hence we need to remove quotes first.
+	 */
+	idlen = strlen(_id);
+	if (idlen > sizeof(id) - 1)
+		goto internal_error;
+
+	if (idlen > 1 && _id[0] == '"' && _id[idlen - 1] == '"') {
+		strncpy(id, _id + 1, idlen - 2);
+		id[idlen - 2] = '\0';
+	} else {
+		strcpy(id, _id);
+	}
 
 	id_val = atol(id);
 

--- a/src/libltfs/ltfslogging.h
+++ b/src/libltfs/ltfslogging.h
@@ -68,13 +68,13 @@ extern bool ltfs_print_thread_id;
 	do {										\
 		printf(LTFS ## id, ##__VA_ARGS__);		\
 	} while(0)
-#else /* MSG_CHECK */
+#else
 #define ltfsmsg(level, id, ...) \
 	do { \
 		if (level <= ltfs_log_level) \
 			ltfsmsg_internal(true, level, NULL, #id, ##__VA_ARGS__);	\
 	} while (0)
-#endif /* MSG_CHECK */
+#endif
 
 /* CAUTION: ltfsmsg_buffer takes message ID as a text literal */
 /* Wrapper for ltfsmsg_internal. It only invokes the message print function if the requested

--- a/src/libltfs/ltfslogging.h
+++ b/src/libltfs/ltfslogging.h
@@ -68,13 +68,13 @@ extern bool ltfs_print_thread_id;
 	do {										\
 		printf(LTFS ## id, ##__VA_ARGS__);		\
 	} while(0)
-#else
+#else /* MSG_CHECK */
 #define ltfsmsg(level, id, ...) \
 	do { \
 		if (level <= ltfs_log_level) \
 			ltfsmsg_internal(true, level, NULL, #id, ##__VA_ARGS__);	\
 	} while (0)
-#endif
+#endif /* MSG_CHECK */
 
 /* CAUTION: ltfsmsg_buffer takes message ID as a text literal */
 /* Wrapper for ltfsmsg_internal. It only invokes the message print function if the requested

--- a/src/libltfs/plugin.c
+++ b/src/libltfs/plugin.c
@@ -185,9 +185,11 @@ int plugin_unload(struct libltfs_plugin *pl)
 
 /**
  * Print the backend's LTFS help message.
+ * @param progname the program name
  * @param ops tape operations for the backend
+ * @param type Plugin type, must be "iosched", "kmi" or "driver"
  */
-static void print_help_message(void *ops, const char * const type)
+static void print_help_message(const char *progname, void *ops, const char * const type)
 {
 	if (! ops) {
 		ltfsmsg(LTFS_WARN, 10006W, "ops", __FUNCTION__);
@@ -200,12 +202,12 @@ static void print_help_message(void *ops, const char * const type)
 			ltfsmsg(LTFS_ERR, 11316E);
 		}
 	} else if (! strcmp(type, "tape"))
-		tape_print_help_message(ops);
+		tape_print_help_message(progname, ops);
 	else
 		ltfsmsg(LTFS_ERR, 11317E, type);
 }
 
-void plugin_usage(const char *type, struct config_file *config)
+void plugin_usage(const char* progname, const char *type, struct config_file *config)
 {
 	struct libltfs_plugin pl = {0};
 	char **backends;
@@ -222,7 +224,7 @@ void plugin_usage(const char *type, struct config_file *config)
 		ret = plugin_load(&pl, type, backends[i], config);
 		if (ret < 0)
 			continue;
-		print_help_message(pl.ops, type);
+		print_help_message(progname, pl.ops, type);
 		plugin_unload(&pl);
 	}
 

--- a/src/libltfs/plugin.h
+++ b/src/libltfs/plugin.h
@@ -81,10 +81,11 @@ int plugin_unload(struct libltfs_plugin *pl);
 
 /**
  * Show usage of a plugin (a shared library that implements a particular set of operations).
+ * @param progname The program name
  * @param type Plugin type, must be "iosched", "kmi" or "driver".
  * @param config Configuration structure to search for the plugin path.
  */
-void plugin_usage(const char *type, struct config_file *config);
+void plugin_usage(const char *progname, const char *type, struct config_file *config);
 
 #endif /* __PLUGIN_H__ */
 

--- a/src/libltfs/tape.c
+++ b/src/libltfs/tape.c
@@ -198,11 +198,6 @@ int tape_device_open(struct device_data *device, const char *devname, struct tap
 
 	/* Validate the tape operations structure. */
 	for (i=0; i<sizeof(struct tape_ops)/sizeof(void *); ++i) {
-		/* It is fine to not define operation not used lib libltfs */
-		if ((void *)ops + i == (void *)&ops->loadunload ||
-		    (void *)ops + i == (void *)&ops->report_density ||
-		    (void *)ops + i == (void *)&ops->update_mam_attr)
-			continue;
 		if ((((void **)ops)[i]) == NULL) {
 			ltfsmsg(LTFS_ERR, 12004E);
 			return -LTFS_PLUGIN_INCOMPLETE;

--- a/src/libltfs/tape.h
+++ b/src/libltfs/tape.h
@@ -142,7 +142,7 @@ int tape_set_compression(struct device_data *dev, bool use_compression);
 int tape_get_append_position(struct device_data *dev, tape_partition_t prt, tape_block_t *pos);
 int tape_set_ip_append_position(struct device_data *dev, tape_partition_t prt, tape_block_t block);
 int tape_set_append_position(struct device_data *dev, tape_partition_t prt, tape_block_t block);
-int tape_get_params(struct device_data *dev, struct tc_current_param *param);
+int tape_get_params(struct device_data *dev, struct tc_drive_param *param);
 int tape_get_max_blocksize(struct device_data *dev, unsigned int *size);
 int tape_read_only(struct device_data *dev, tape_partition_t partition);
 int tape_force_read_only(struct device_data *dev);
@@ -179,7 +179,7 @@ int tape_set_media_pool_info(struct ltfs_volume *vol, const char *new_val, int s
 int tape_check_eod_status(struct device_data *dev, const tape_partition_t part);
 int tape_recover_eod_status(struct device_data *dev, void * const kmi_handle);
 
-void tape_print_help_message(struct tape_ops *ops);
+void tape_print_help_message(const char *progname, struct tape_ops *ops);
 int tape_parse_opts(struct device_data *dev, void *opt_args);
 int tape_parse_library_backend_opts(void *opts, void *opt_args);
 

--- a/src/libltfs/tape_ops.h
+++ b/src/libltfs/tape_ops.h
@@ -453,23 +453,6 @@ struct tape_ops {
 	int   (*rewind)(void *device, struct tc_position *pos);
 
 	/**
-	 * Load or unload medium to/from a device
-	 * Unused by libltfs (HPE extension)
-	 * HPE Change - CR 11358 - Add a more flexible means of loading and unload.
-	 * @param device Device handle returned by the backend's open().
-	 * @param pos Pointer to a tc_position structure. The backend must fill this structure with
-	 *            the final logical block position of the device, even on error.
-	 *            libltfs does not depend on any particular position being set here.
-	 * @param load Whether to load (TRUE) or unload (FALSE)
-	 * @param hold Whether to partially load/unload (TRUE) or fully (FALSE)
-	 * @return 0 on success or a negative value on error.
-	 *         If no medium is present in the device, the backend must return -EDEV_NO_MEDIUM.
-	 *         If the medium is unsupported (for example, does not support two partitions),
-	 *         the backend should return -LTFS_UNSUPPORTED_MEDIUM.
-	 */
-	int (*loadunload)(void *device, struct tc_position *pos, bool load, bool hold);
-
-	/**
 	 * Seek to the specified position on a device.
 	 * @param device Device handle returned by the backend's open().
 	 * @param dest Destination position, specified as a partition and logical block. The filemarks
@@ -712,18 +695,6 @@ struct tape_ops {
 	int   (*allow_overwrite)(void *device, const struct tc_position pos);
 
 	/**
-	 * Issue a Report Density Support command to a device.
-	 * This command is not currently used by libltfs (HPE extension)
-	 * @param device Device handle returned by the backend's open().
-	 * @param rep On success, the backend must fill this with the density report data returned by
-	 *            the device.
-	 * @param medium set medium bit on
-	 * @return 0 on success or a negative value on error.
-	 */
-	int   (*report_density)(void *device, struct tc_density_report *rep, bool medium);
-
-
-	/**
 	 * Enable or disable compression on a device.
 	 * @param device Device handle returned by the backend's open().
 	 * @param enable_compression If true, turn on compression. Otherwise, turn it off.
@@ -895,23 +866,6 @@ struct tape_ops {
 						  const char *barcode,
 						  const unsigned char cart_type,
 						  const unsigned char density);
-
-	/** 
-	 * Updating the MAM attributes.
-	 * Unused by libltfs (HPE extension)
-	 * @param device Pointer to ltotape backend.
-	 * @param FORMAT The format type
-	 * @param vol_name An optional volume name to the tape.
-	 * @param barcode_name The volume barcode name
-	 * @param lockbit volume lock state bit to be set in MAM     
-	 * @return 0 on success, a negative value on error. 
-	 */ 
-	int (*update_mam_attr) (void *device, 
-						  TC_FORMAT_TYPE format,
-						  const char *vol_name,
-						  unsigned int attribute_id,
-						  const char *barcode_name,
-						  mam_lockval lockbit);
 
 	/**
 	 * Check if the loaded carridge is WORM.

--- a/src/libltfs/xml_reader_libltfs.c
+++ b/src/libltfs/xml_reader_libltfs.c
@@ -1495,11 +1495,11 @@ static int _xml_parse_schema(xmlTextReaderPtr reader, struct ltfs_index *idx, st
 			get_tag_text();
 
 			if (!strcmp(value, "unlocked")) {
-				idx->vollock = VOLUME_UNLOCKED;
+				idx->vollock = UNLOCKED_MAM;
 			} else if (!strcmp(value, "locked")) {
-				idx->vollock = VOLUME_LOCKED;
+				idx->vollock = LOCKED_MAM;
 			} else if (!strcmp(value, "permlocked")) {
-				idx->vollock = VOLUME_PERM_LOCKED;
+				idx->vollock = PERMLOCKED_MAM;
 			}
 			check_tag_end("volumelockstate");
 		} else if (idx->version >= IDX_VERSION_UID && ! strcmp(name, NEXTUID_TAGNAME)) {

--- a/src/libltfs/xml_writer_libltfs.c
+++ b/src/libltfs/xml_writer_libltfs.c
@@ -547,10 +547,10 @@ static int _xml_write_schema(xmlTextWriterPtr writer, const char *creator,
 		char *value = NULL;
 
 		switch (idx->vollock) {
-			case VOLUME_LOCKED:
+			case LOCKED_MAM:
 				asprintf(&value, "locked");
 				break;
-			case VOLUME_PERM_LOCKED:
+			case PERMLOCKED_MAM:
 				asprintf(&value, "permlocked");
 				break;
 			default:

--- a/src/main.c
+++ b/src/main.c
@@ -227,8 +227,8 @@ void usage(char *progname, struct ltfs_fuse_data *priv)
 		fprintf(stderr, "\n");
 		single_drive_advanced_usage(default_driver, priv);
 		fprintf(stderr, "\n");
-		plugin_usage("driver", priv->config);
-		plugin_usage("kmi", priv->config);
+		plugin_usage(progname, "driver", priv->config);
+		plugin_usage(progname, "kmi", priv->config);
 	}
 }
 

--- a/src/tape_drivers/generic/file/filedebug_tc.c
+++ b/src/tape_drivers/generic/file/filedebug_tc.c
@@ -360,7 +360,7 @@ static void emulate_rewind_wait(struct filedebug_data *state)
 	emulate_seek_wait(state, &dest);
 }
 
-void filedebug_help_message(void)
+void filedebug_help_message(const char *progname)
 {
 	ltfsresult(30199I, filedebug_default_device);
 }
@@ -1605,7 +1605,7 @@ int filedebug_setcap(void *device, uint16_t proportion)
 	return DEVICE_GOOD;
 }
 
-int filedebug_format(void *device, TC_FORMAT_TYPE format)
+int filedebug_format(void *device, TC_FORMAT_TYPE format, const char *vol_name, const char *barcode_name, const char *vol_mam_uuid)
 {
 	struct filedebug_data *state = (struct filedebug_data *)device;
 	struct tc_position pos;
@@ -2007,7 +2007,7 @@ int filedebug_set_default(void *device)
 	return DEVICE_GOOD;
 }
 
-int filedebug_get_parameters(void *device, struct tc_current_param *params)
+int filedebug_get_parameters(void *device, struct tc_drive_param *params)
 {
 	struct filedebug_data *state = (struct filedebug_data *)device;
 
@@ -2016,9 +2016,9 @@ int filedebug_get_parameters(void *device, struct tc_current_param *params)
 	params->cart_type             = state->conf.cart_type;
 	params->density               = state->conf.density_code;
 
-	params->write_protected       = 0;
+	params->write_protect       = 0;
 	if ( state->conf.emulate_readonly )
-			params->write_protected |= VOL_PHYSICAL_WP;
+			params->write_protect |= VOL_PHYSICAL_WP;
 
 	/* TODO: Following field shall be implemented in the future */
 	//params->is_encrypted          = false;

--- a/src/tape_drivers/generic/itdtimg/itdtimg_tc.c
+++ b/src/tape_drivers/generic/itdtimg/itdtimg_tc.c
@@ -205,7 +205,7 @@ int itdtimage_parse_opts(void *vstate, void *opt_args)
 	return 0;
 }
 
-void itdtimage_help_message(void)
+void itdtimage_help_message(const char *progname)
 {
 	ltfsresult(31199I, itdtimage_default_device);
 }
@@ -763,7 +763,7 @@ int itdtimage_setcap(void *vstate, uint16_t proportion)
 	return DEVICE_GOOD;
 }
 
-int itdtimage_format(void *vstate, TC_FORMAT_TYPE format)
+int itdtimage_format(void *vstate, TC_FORMAT_TYPE format, const char *vol_name, const char *barcode_name, const char *vol_mam_uuid)
 {
 	struct itdtimage_data *state = (struct itdtimage_data *)vstate;
 	struct tc_position pos;
@@ -988,10 +988,10 @@ int itdtimage_set_default(void *device)
 	return DEVICE_GOOD;
 }
 
-int itdtimage_get_parameters(void *vstate, struct tc_current_param *params)
+int itdtimage_get_parameters(void *vstate, struct tc_drive_param *params)
 {
 	params->max_blksize = FILE_DEBUG_MAX_BLOCK_SIZE;
-	params->write_protected = VOL_PHYSICAL_WP;
+	params->write_protect = VOL_PHYSICAL_WP;
 	return DEVICE_GOOD;
 }
 const char *itdtimage_default_device_name(void)

--- a/src/tape_drivers/ibm_tape.h
+++ b/src/tape_drivers/ibm_tape.h
@@ -181,6 +181,7 @@ enum {
 	VOLSTATS_ENCRYPTED_REC    = 0x0200,	/* < First encrypted logical object identifier */
 	VOLSTATS_PARTITION_CAP    = 0x0202,	/* < Native capacity of partitions */
 	VOLSTATS_PART_USED_CAP    = 0x0203,	/* < Used capacity of partitions */
+	VOLSTATS_USED_CAPACITY    = 0x0203,	/* HPE alias of VOLSTATS_PART_USED_CAP */
 	VOLSTATS_PART_REMAIN_CAP  = 0x0204,	/* < Remaining capacity of partitions */
 	VOLSTATS_VU_PGFMTVER      = 0xF000,     /* < Vendor-unique PageFormatVersion */
 };

--- a/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
@@ -2534,7 +2534,7 @@ int sg_ibmtape_setcap(void *device, uint16_t proportion)
 	return ret;
 }
 
-int sg_ibmtape_format(void *device, TC_FORMAT_TYPE format)
+int sg_ibmtape_format(void *device, TC_FORMAT_TYPE format, const char *vol_name, const char *barcode_name, const char *vol_mam_uuid)
 {
 	int ret = -EDEV_UNKNOWN, aux_ret;
 	int ret_ep = DEVICE_GOOD;
@@ -3765,7 +3765,7 @@ static int _cdb_read_block_limits(void *device) {
 	return ret;
 }
 
-int sg_ibmtape_get_parameters(void *device, struct tc_current_param *params)
+int sg_ibmtape_get_parameters(void *device, struct tc_drive_param *params)
 {
 	int ret = -EDEV_UNKNOWN;
 	struct sg_ibmtape_data *priv = (struct sg_ibmtape_data*)device;
@@ -3775,7 +3775,7 @@ int sg_ibmtape_get_parameters(void *device, struct tc_current_param *params)
 	if (priv->loaded) {
 		params->cart_type = priv->cart_type;
 		params->density   = priv->density_code;
-		params->write_protected = 0;
+		params->write_protect = 0;
 
 		if (IS_ENTERPRISE(priv->drive_type)) {
 			unsigned char buf[TC_MP_MEDIUM_SENSE_SIZE];
@@ -3787,11 +3787,11 @@ int sg_ibmtape_get_parameters(void *device, struct tc_current_param *params)
 			char wp_flag = buf[26];
 
 			if (wp_flag & 0x80) {
-				params->write_protected |= VOL_PHYSICAL_WP;
+				params->write_protect |= VOL_PHYSICAL_WP;
 			} else if (wp_flag & 0x01) {
-				params->write_protected |= VOL_PERM_WP;
+				params->write_protect |= VOL_PERM_WP;
 			} else if (wp_flag & 0x10) {
-				params->write_protected |= VOL_PERS_WP;
+				params->write_protect |= VOL_PERS_WP;
 			}
 
 			/* TODO: Following field shall be implemented in the future */
@@ -3810,7 +3810,7 @@ int sg_ibmtape_get_parameters(void *device, struct tc_current_param *params)
 				goto out;
 
 			if (buf[3] & 0x80) {
-				params->write_protected |= VOL_PHYSICAL_WP;
+				params->write_protect |= VOL_PHYSICAL_WP;
 			}
 
 			/* TODO: Following field shall be implemented in the future */
@@ -3990,7 +3990,7 @@ int sg_ibmtape_get_device_list(struct tc_drive_info *buf, int count)
 	return found;
 }
 
-void sg_ibmtape_help_message(void)
+void sg_ibmtape_help_message(const char *progname)
 {
 	ltfsresult(30399I, default_device);
 }

--- a/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
+++ b/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
@@ -2476,7 +2476,7 @@ int scsipi_ibmtape_setcap(void *device, uint16_t proportion)
 	return ret;
 }
 
-int scsipi_ibmtape_format(void *device, TC_FORMAT_TYPE format)
+int scsipi_ibmtape_format(void *device, TC_FORMAT_TYPE format, const char *vol_name, const char *barcode_name, const char *vol_mam_uuid)
 {
 	int ret = -EDEV_UNKNOWN, aux_ret;
 	int ret_ep = DEVICE_GOOD;
@@ -3662,7 +3662,7 @@ static int _cdb_read_block_limits(void *device) {
 	return ret;
 }
 
-int scsipi_ibmtape_get_parameters(void *device, struct tc_current_param *params)
+int scsipi_ibmtape_get_parameters(void *device, struct tc_drive_param *params)
 {
 	int ret = -EDEV_UNKNOWN;
 	struct scsipi_ibmtape_data *priv = (struct scsipi_ibmtape_data*)device;
@@ -3672,7 +3672,7 @@ int scsipi_ibmtape_get_parameters(void *device, struct tc_current_param *params)
 	if (priv->loaded) {
 		params->cart_type = priv->cart_type;
 		params->density   = priv->density_code;
-		params->write_protected = 0;
+		params->write_protect = 0;
 
 		if (IS_ENTERPRISE(priv->drive_type)) {
 			unsigned char buf[TC_MP_MEDIUM_SENSE_SIZE];
@@ -3684,11 +3684,11 @@ int scsipi_ibmtape_get_parameters(void *device, struct tc_current_param *params)
 			char wp_flag = buf[26];
 
 			if (wp_flag & 0x80) {
-				params->write_protected |= VOL_PHYSICAL_WP;
+				params->write_protect |= VOL_PHYSICAL_WP;
 			} else if (wp_flag & 0x01) {
-				params->write_protected |= VOL_PERM_WP;
+				params->write_protect |= VOL_PERM_WP;
 			} else if (wp_flag & 0x10) {
-				params->write_protected |= VOL_PERS_WP;
+				params->write_protect |= VOL_PERS_WP;
 			}
 
 			/* TODO: Following field shall be implemented in the future */
@@ -3707,7 +3707,7 @@ int scsipi_ibmtape_get_parameters(void *device, struct tc_current_param *params)
 				goto out;
 
 			if (buf[3] & 0x80) {
-				params->write_protected |= VOL_PHYSICAL_WP;
+				params->write_protect |= VOL_PHYSICAL_WP;
 			}
 
 			/* TODO: Following field shall be implemented in the future */
@@ -3887,7 +3887,7 @@ int scsipi_ibmtape_get_device_list(struct tc_drive_info *buf, int count)
 	return found;
 }
 
-void scsipi_ibmtape_help_message(void)
+void scsipi_ibmtape_help_message(const char *progname)
 {
 	ltfsresult(30399I, default_device);
 }

--- a/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
+++ b/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
@@ -2099,7 +2099,7 @@ int iokit_ibmtape_setcap(void *device, uint16_t proportion)
 	return ret;
 }
 
-int iokit_ibmtape_format(void *device, TC_FORMAT_TYPE format)
+int iokit_ibmtape_format(void *device, TC_FORMAT_TYPE format, const char *vol_name, const char *barcode_name, const char *vol_mam_uuid)
 {
 	int ret = -EDEV_UNKNOWN, aux_ret;
 	struct iokit_ibmtape_data *priv = (struct iokit_ibmtape_data*)device;
@@ -3284,7 +3284,7 @@ static int _cdb_read_block_limits(void *device) {
 	return ret;
 }
 
-int iokit_ibmtape_get_parameters(void *device, struct tc_current_param *params)
+int iokit_ibmtape_get_parameters(void *device, struct tc_drive_param *params)
 {
 	int ret = -EDEV_UNKNOWN;
 	struct iokit_ibmtape_data *priv = (struct iokit_ibmtape_data*)device;
@@ -3305,11 +3305,11 @@ int iokit_ibmtape_get_parameters(void *device, struct tc_current_param *params)
 			char wp_flag = buf[26];
 
 			if (wp_flag & 0x80) {
-				params->write_protected |= VOL_PHYSICAL_WP;
+				params->write_protect |= VOL_PHYSICAL_WP;
 			} else if (wp_flag & 0x01) {
-				params->write_protected |= VOL_PERM_WP;
+				params->write_protect |= VOL_PERM_WP;
 			} else if (wp_flag & 0x10) {
-				params->write_protected |= VOL_PERS_WP;
+				params->write_protect |= VOL_PERS_WP;
 			}
 
 			/* TODO: Following field shall be implemented in the future */
@@ -3328,7 +3328,7 @@ int iokit_ibmtape_get_parameters(void *device, struct tc_current_param *params)
 				goto out;
 
 			if (buf[3] & 0x80) {
-				params->write_protected |= VOL_PHYSICAL_WP;
+				params->write_protect |= VOL_PHYSICAL_WP;
 			}
 
 			/* TODO: Following field shall be implemented in the future */
@@ -3479,7 +3479,7 @@ int iokit_ibmtape_get_device_list(struct tc_drive_info *buf, int count)
 	return found;
 }
 
-void iokit_ibmtape_help_message(void)
+void iokit_ibmtape_help_message(const char *progname)
 {
 	ltfsresult(30999I, default_device);
 }

--- a/src/utils/ltfsck.c
+++ b/src/utils/ltfsck.c
@@ -218,9 +218,9 @@ void show_usage(char *appname, struct config_file *config, bool full)
 		ltfsresult(16424I);                   /*     --capture-index */
 		ltfsresult(16427I);                   /*     --salvage-rollback-points */
 		fprintf(stderr, "\n");
-		plugin_usage("driver", config);
+		plugin_usage(appname, "driver", config);
 		fprintf(stderr, "\n");
-		plugin_usage("kmi", config);
+		plugin_usage(appname, "kmi", config);
 	}
 	fprintf(stderr, "\n");
 }
@@ -658,7 +658,7 @@ out_unload_backend:
 int check_ltfs_volume(struct ltfs_volume *vol, struct other_check_opts *opt)
 {
 	int ret;
-	int vollock = VOLUME_UNLOCKED;
+	int vollock = UNLOCKED_MAM;
 
 	/* Load tape and read labels */
 	ret = load_tape(vol);
@@ -668,7 +668,7 @@ int check_ltfs_volume(struct ltfs_volume *vol, struct other_check_opts *opt)
 	}
 
 	ret = tape_get_cart_volume_lock_status(vol->device, &vollock);
-	if (vollock != VOLUME_UNLOCKED) {
+	if (vollock != UNLOCKED_MAM) {
 		ltfsmsg(LTFS_INFO, 16111I, vollock);
 	} else if (opt->deep_recovery) {
 		/* Performe EOD recovery, if deep_recovery option is set */

--- a/src/utils/mkltfs.c
+++ b/src/utils/mkltfs.c
@@ -183,9 +183,9 @@ void show_usage(char *appname, struct config_file *config, bool full)
 		ltfsresult(15417I);                         /* -x, --fulltrace */
 		ltfsresult(15424I);                         /* --long-wipe */
 		fprintf(stderr, "\n");
-		plugin_usage("driver", config);
+		plugin_usage(appname, "driver", config);
 		fprintf(stderr, "\n");
-		plugin_usage("kmi", config);
+		plugin_usage(appname, "kmi", config);
 	}
 
 	fprintf(stderr, "\n");


### PR DESCRIPTION
# Summary of changes
This pull request includes following changes or fixes.

- Change tape backend interface to reduce differences with HPE LTFS

# Description

We support building tape backend drivers as external projects, which
lets us load HPE LTFS tape backends at run time. But since HPE tape
backend interface added a few extensions, that require some patches.
This changes reduces the differences of the tape backend interface to
make the process easier.

## Type of change

- Source only change

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
