### PR TITLE
Fix FreeBSD automake destdir

### DIFF
--- a/src/tape_drivers/freebsd/cam/Makefile.am
+++ b/src/tape_drivers/freebsd/cam/Makefile.am
@@ -56,6 +56,6 @@ libtape_cam_la-ibm_tape.lo: ../../ibm_tape.c
 	$(LIBTOOL)  --tag=CC $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libtape_cam_la_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) $(CRC_OPTIMIZE) -MT libtape_cam_la-ibm_tape.lo -MD -MP -c -o libtape_cam_la-ibm_tape.lo ../../ibm_tape.c
 
 install-exec-hook:
-	mkdir -p $(libdir)/ltfs
-	for f in $(lib_LTLIBRARIES); do rm -f $(libdir)/$$f; done
-	for f in $(BASENAMES); do mv $(libdir)/$$f* $(libdir)/ltfs; done
+	mkdir -p $(DESTDIR)$(libdir)/ltfs
+	for f in $(lib_LTLIBRARIES); do rm -f $(DESTDIR)$(libdir)/$$f; done
+	for f in $(BASENAMES); do mv $(DESTDIR)$(libdir)/$$f* $(DESTDIR)$(libdir)/ltfs; done


### PR DESCRIPTION
Signed-off-by: Kevin Bowling <kevin.bowling@kev009.com>

# Summary of changes

This pull request includes following changes or fixes. 

- Fix FreeBSD automake destdir for alternate root builds

# Description

Without this fix the build fails under sandbox builds like FreeBSD's poudriere package builder.  I carry this patch locally in the ports tree until this fix can be committed and released.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works
