### PR TITLE
Remove warning at build

### DIFF
--- a/src/libltfs/ltfslogging.c
+++ b/src/libltfs/ltfslogging.c
@@ -463,17 +463,17 @@ int ltfsmsg_internal(bool print_id, int level, char **msg_out, const char *_id, 
 	}
 
 #ifdef mingw_PLATFORM
-	va_start(argp, id);
+	va_start(argp, _id);
 	vsyslog(level, output_buf, argp);
 	va_end(argp);
 #else
-	va_start(argp, id);
+	va_start(argp, _id);
 	vfprintf(stderr, output_buf, argp);
 	va_end(argp);
 	fprintf(stderr, "\n");
 
 	if (level <= ltfs_syslog_level && ltfs_use_syslog) {
-		va_start(argp, id);
+		va_start(argp, _id);
 		if (level <= LTFS_ERR)
 			vsyslog(syslog_levels[LTFS_ERR], output_buf, argp);
 		else if (level >= LTFS_TRACE)
@@ -485,7 +485,7 @@ int ltfsmsg_internal(bool print_id, int level, char **msg_out, const char *_id, 
 #endif
 
 	if (msg_out) {
-		va_start(argp, id);
+		va_start(argp, _id);
 		vsprintf(msg_buf, output_buf, argp);
 		va_end(argp);
 		*msg_out = strdup(msg_buf);
@@ -496,7 +496,7 @@ int ltfsmsg_internal(bool print_id, int level, char **msg_out, const char *_id, 
 		if (is_snmp_trapid(id) == true) {
 			/* Send a trap of Info (id and pos+1) */
 			char *pos;
-			va_start(argp, id);
+			va_start(argp, _id);
 			vsprintf(msg_buf, output_buf, argp);
 			va_end(argp);
 			pos = strstr(msg_buf, " ");


### PR DESCRIPTION
# Summary of changes

Correct usage of va_start() in ltfsmsg_internal()

# Description

This warning was introduced in the previous #116. va_start() must have a provided argument at 2nd argument.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
