### PR TITLE
Remove PACKAGE_XXX from ltfs.h

### DIFF
--- a/src/libltfs/ltfs.h
+++ b/src/libltfs/ltfs.h
@@ -154,10 +154,7 @@ struct device_data;
 
 #define LTFS_NO_BARCODE               "NO_BARCODE"
 
-#ifdef __APPLE_MAKEFILE__
-#define PACKAGE_NAME                  "LTFS"
-#define PACKAGE_VERSION               "2.4.1.1"
-#else
+#ifndef __APPLE_MAKEFILE__
 #include "config.h"
 #endif
 


### PR DESCRIPTION
# Summary of changes

PACKAGE_NAME and PACKAGE_VERSION is removed from ltfs.h

# Description

PACKAGE_NAME and PACKAGE_VERSION is defined for makefile build of macOS but it is not a good idea to change multiple place when version number is changed.

PACKAGE_NAME and PACKAGE_VERSION shall be provided from Makefile for building macOS build.

There is no change for HomeBrew build.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
