### PR TITLE
Support WORM tape on the sg backend and the iokit backend

### DIFF
--- a/messages/tape_iokit_ibmtape/root.txt
+++ b/messages/tape_iokit_ibmtape/root.txt
@@ -114,6 +114,7 @@ root:table {
 		30867W:string { "WWPID of reservation: x%02x%02x%02x%02x%02x%02x%02x%02x (%s)" }
 		30868I:string { "Retry to reserve from key registration (%s)" }
 		30869W:string { "The drive is already reserved: %s (%s)" }
+		30870I:string { "Failed to get cartridge status. The cartridge is not loaded." }
 
 		30992D:string { "Backend %s %s." }
 		30993D:string { "Backend %s: %d %s." }

--- a/messages/tape_linux_sg_ibmtape/root.txt
+++ b/messages/tape_linux_sg_ibmtape/root.txt
@@ -125,6 +125,7 @@ root:table {
 		30283W:string { "Skip back for %s operation is failed (%d). (%u, %llu), (%u, %llu)." }
 		30284E:string { "Cannot get reserved buffer size of %s." }
 		30285I:string { "Reserved buffer size of %s is %d." }
+		30286I:string { "Failed to get cartridge status. The cartridge is not loaded." }
 
 		30392D:string { "Backend %s %s." }
 		30393D:string { "Backend %s: %d %s." }

--- a/src/tape_drivers/ibm_tape.c
+++ b/src/tape_drivers/ibm_tape.c
@@ -1332,7 +1332,7 @@ int ibm_tape_is_supported_tape(unsigned char type, unsigned char density, bool *
 
 	for (i = 0; i < num_supported_cart; ++i) {
 		if(type == supported_cart[i]) {
-			if (type == TC_MP_JY || type == TC_MP_JZ) {
+			if(IS_WORM_MEDIUM(type)) {
 				/* Detect WORM cartridge */
 				ltfsmsg(LTFS_DEBUG, 39809D);
 				*is_worm = true;

--- a/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
@@ -4466,12 +4466,20 @@ bool sg_ibmtape_is_readonly(void *device)
 
 int sg_ibmtape_get_worm_status(void *device, bool *is_worm)
 {
+	int rc = 0;
 	struct sg_ibmtape_data *priv = (struct sg_ibmtape_data*)device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_GETWORMSTAT));
-	*is_worm = false;
+	if (priv->loaded) {
+		*is_worm = priv->is_worm;
+	} else {
+		ltfsmsg(LTFS_INFO, 30286I);
+		*is_worm = false;
+		rc = -1;
+	}
+
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETWORMSTAT));
-	return 0;
+	return rc;
 }
 
 int sg_ibmtape_get_serialnumber(void *device, char **result)

--- a/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
+++ b/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
@@ -3942,12 +3942,20 @@ bool iokit_ibmtape_is_readonly(void *device)
 
 int iokit_ibmtape_get_worm_status(void *device, bool *is_worm)
 {
+	int rc = 0;
 	struct iokit_ibmtape_data *priv = (struct iokit_ibmtape_data*)device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_GETWORMSTAT));
-	*is_worm = false;
+	if (priv->loaded) {
+		*is_worm = priv->is_worm;
+	} else {
+		ltfsmsg(LTFS_INFO, 30870I);
+		*is_worm = false;
+		rc = -1;
+	}
+
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETWORMSTAT));
-	return 0;
+	return rc;
 }
 
 int iokit_ibmtape_get_serialnumber(void *device, char **result)


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Fix of issue #123 

# Description

Currently, WORM support in the sg backend and the iokit backend is corrupted.

Fixes #123

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
