### PR TITLE
Handle EDEADLK error for acquiring advisory lock

### DIFF
--- a/messages/libltfs/root.txt
+++ b/messages/libltfs/root.txt
@@ -802,6 +802,9 @@ v
 		17257I:string { "0x2f (/) or 0x1f (US) is existed into name object (%s): Replace to '_'" }
 		17258E:string { "Critical error happened while parsing an index (%d). Stop seeking the latest index." }
 		17259I:string { "Recover an index on %s from (%c, %llu)." }
+		17260I:string { "Sleep was interrupted by a signal while taking the advisory lock '%s'." }
+		17261I:string { "Kernel detected a false deadlock retry to acquire the advisory lock '%s' (%d)." }
+		17263I:string { "Sleep was failed while taking the advisory lock '%s' (%d, %d)." }
 
 		// For Debug 19999I:string { "%s %s %d." }
 

--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -2214,7 +2214,7 @@ int ltfs_write_index(char partition, char *reason, struct ltfs_volume *vol)
 
 	ret = tape_get_cart_volume_lock_status(vol->device, &volstat);
 	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, 11341E, ret);
+		ltfsmsg(LTFS_ERR, 11342E, ret);
 		return ret;
 	}
 
@@ -2273,7 +2273,7 @@ int ltfs_write_index(char partition, char *reason, struct ltfs_volume *vol)
 		if (IS_WRITE_PERM(-ret)) {
 			ret = tape_get_cart_volume_lock_status(vol->device, &volstat);
 			if (ret < 0) {
-				ltfsmsg(LTFS_ERR, 11341E, ret);
+				ltfsmsg(LTFS_ERR, 11342E, ret);
 				return ret;
 			}
 

--- a/src/libltfs/ltfs_internal.c
+++ b/src/libltfs/ltfs_internal.c
@@ -1157,10 +1157,10 @@ int ltfs_check_medium(bool fix, bool deep, bool recover_extra, bool recover_syml
 
 			/* Set data partition append position. */
 			if (dp_have_index && dp_blocks_after) {
-				ltfsmsg(LTFS_INFO, 11227I, dp_eod);
+				ltfsmsg(LTFS_INFO, 11227I, (unsigned long long)dp_eod);
 				check_err(tape_set_append_position(vol->device, dp_num, dp_eod), 11228E, out_unlock);
 			} else if (! dp_have_index && dp_eod > 4) {
-				ltfsmsg(LTFS_INFO, 11227I, dp_eod);
+				ltfsmsg(LTFS_INFO, 11227I, (unsigned long long)dp_eod);
 				check_err(tape_set_append_position(vol->device, dp_num, dp_eod), 11228E, out_unlock);
 			}
 		}
@@ -1191,11 +1191,11 @@ int ltfs_check_medium(bool fix, bool deep, bool recover_extra, bool recover_syml
 			}
 			/* write to data partition if it doesn't end in an index file */
 			if (! dp_have_index || dp_blocks_after) {
-				ltfsmsg(LTFS_INFO, 17259I, "DP", vol->index->selfptr.partition, vol->index->selfptr.block);
+				ltfsmsg(LTFS_INFO, 17259I, "DP", vol->index->selfptr.partition, (unsigned long long)vol->index->selfptr.block);
 				ret = ltfs_write_index(vol->label->partid_dp, SYNC_RECOVERY, vol);
 			}
 			if (!ret) {
-				ltfsmsg(LTFS_INFO, 17259I, "IP", vol->index->selfptr.partition, vol->index->selfptr.block);
+				ltfsmsg(LTFS_INFO, 17259I, "IP", vol->index->selfptr.partition, (unsigned long long)vol->index->selfptr.block);
 				ltfs_write_index(vol->label->partid_ip, SYNC_RECOVERY, vol);
 			}
 		} else {


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

 - Keep trying to acquire advisory lock in 20 min
 - LTFS forcely writes down an index when the lock cannot be acquired
 - Fix a few message errors

# Description

Linux kernel returns EDEADLK against taking advisory lock even if 2 threads try to acquire advisory locks in each thread individually. So LTFS may need to retry acquiring to capture an advisory lock even if the kernel returns EDEADLK.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
