### PR TITLE
Add a log when unknown sense is received

### DIFF
--- a/messages/tape_linux_sg_ibmtape/root.txt
+++ b/messages/tape_linux_sg_ibmtape/root.txt
@@ -126,6 +126,7 @@ root:table {
 		30284E:string { "Cannot get reserved buffer size of %s." }
 		30285I:string { "Reserved buffer size of %s is %d." }
 		30286I:string { "Failed to get cartridge status. The cartridge is not loaded." }
+		30287I:string { "Received an unknown sense code %06x." }
 
 		30392D:string { "Backend %s %s." }
 		30393D:string { "Backend %s: %d %s." }

--- a/src/tape_drivers/linux/sg-ibmtape/sg_scsi_tape.c
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_scsi_tape.c
@@ -85,6 +85,10 @@ static int sg_sense2errno(sg_io_hdr_t *req, uint32_t *s, char **msg)
 	if (rc == -EDEV_VENDOR_UNIQUE)
 		rc = _sense2errorcode(sense_value, vendor_table, msg, MASK_WITH_SENSE_KEY);
 
+	if (rc == -EDEV_UNKNOWN) {
+		ltfsmsg(LTFS_INFO, 30287I, sense_value);
+	}
+
 	return rc;
 }
 


### PR DESCRIPTION
# Summary of changes

Print a log when unknown sense is received from the drive for drive
investigation.

# Description

Now, the ltfs doesn't log any message when drive returns an unknown sense. The unknown sense means that sense is not listed into sense-error_code conversion table in ltfs.

So user doesn't detect which error is returned from the device. It is very hard to investigate the roor cause.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
