### PR TITLE
Support --enable-warning-as-error option to build

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,6 +97,17 @@ AC_ARG_ENABLE([message-checker],
 AC_MSG_RESULT([$use_msg_check])
 
 dnl
+dnl Check for warning treatment
+dnl
+AC_MSG_CHECKING([enable warnings as errors])
+AC_ARG_ENABLE([warning-as-error],
+    [AS_HELP_STRING([--enable-warning-as-error],[Treates warnings as errors])],
+    [warning_as_error=$enableval],
+    [warning_as_error=no]
+)
+AC_MSG_RESULT([$warning_as_error])
+
+dnl
 dnl Handle --enable-fast (default:no)
 dnl
 AC_MSG_CHECKING([whether to enable optimizations])
@@ -441,6 +452,11 @@ fi
 if test "x$use_msg_check" = "xyes"
 then
     AM_CPPFLAGS="${AM_CPPFLAGS} -DMSG_CHECK"
+fi
+
+if test "x$warning_as_error" = "xyes"
+then
+    AM_CFLAGS="${AM_CFLAGS} -Werror"
 fi
 
 if test "x$use_new_locking" = "xyes"


### PR DESCRIPTION
# Summary of changes

Compiler will stop when it finds an warning if the option is enabled.
Disable is default behavior.

# Description

This a nice function for writing safety code.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
