### PR TITLE
Do not log into /var/log/messages

### DIFF
--- a/docs/ltfs-log.conf
+++ b/docs/ltfs-log.conf
@@ -2,3 +2,4 @@
 $umask 0000
 $FileCreateMode 0644
 :msg, regex, " LTFS[ID0-9][0-9]*[EWID]" /var/log/ltfs.log
+:msg, regex, " LTFS[ID0-9][0-9]*[EWID]" stop


### PR DESCRIPTION
# Summary of changes

With rsyslog as a logger, /var/log/messages won't contain LTFS log anymore.
Now only the /var/log/ltfs.log is a log file for LTFS.

# Description

New ltfs-log.conf for rsyslog works for rsyslog7 and later.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works
