### PR TITLE
Handle drive connection lost

### DIFF
--- a/messages/internal_error/root.txt
+++ b/messages/internal_error/root.txt
@@ -305,6 +305,7 @@ root:table {
 		D0400E:string{ "All H/W errors." }
 		D0401E:string{ "Logical Block Guard Check Failed." }
 		D0402E:string{ "Logical Block Protection read error." }
+		D0403E:string{ "There is no connection to the device." }
 		D0499E:string{ "Maximum hardware error value." }
 		D0500E:string{ "All illegal request errors." }
 		D0501E:string{ "Invalid field in CDB." }

--- a/src/libltfs/arch/errormap.c
+++ b/src/libltfs/arch/errormap.c
@@ -340,6 +340,7 @@ static struct error_map fuse_error_list[] = {
 	{ EDEV_HARDWARE_ERROR,           "D0400E", EIO},
 	{ EDEV_LBP_WRITE_ERROR,          "D0401E", EIO},
 	{ EDEV_LBP_READ_ERROR,           "D0402E", EIO},
+	{ EDEV_NO_CONNECTION,            "D0403E", EIO},
 	{ EDEV_ILLEGAL_REQUEST,          "D0500E", EILSEQ},
 	{ EDEV_INVALID_FIELD_CDB,        "D0501E", EILSEQ},
 	{ EDEV_DEST_FULL,                "D0502E", EIO},

--- a/src/libltfs/ltfs_error.h
+++ b/src/libltfs/ltfs_error.h
@@ -331,6 +331,7 @@
 #define EDEV_HARDWARE_ERROR          20400  /* 04/xxxx Other H/W errors */
 #define EDEV_LBP_WRITE_ERROR         20401  /* 04/1001 Logical Block Guard Check Failed */
 #define EDEV_LBP_READ_ERROR          20402  /* ------- Logical Block Protection read error */
+#define EDEV_NO_CONNECTION           20403  /* There is no connection to the device */
 #define EDEV_HARDWARE_MAX            20499  /* Maximum hardware error value */
 
 #define IS_HARDWARE_ERROR(e)         ((e>=EDEV_HARDWARE_MIN)&&(e<=EDEV_HARDWARE_MAX))

--- a/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
@@ -622,7 +622,7 @@ static int _reconnect_device(void *device)
 	/* Open another device file found in the previous step */
 	if (!priv->devname) {
 		ltfsmsg(LTFS_INFO, 30247I, priv->drive_serial);
-		return -LTFS_NO_DEVICE;
+		return -EDEV_NO_CONNECTION;
 	}
 
 	ltfsmsg(LTFS_INFO, 30249I, priv->drive_serial, priv->devname);
@@ -676,6 +676,9 @@ static int _process_errors(struct sg_ibmtape_data *priv, int ret, char *msg, cha
 {
 	int ret_fo = 0; /* Error code while reconnecting process */
 	bool unforced_dump;
+
+	if (ret == -EDEV_NO_CONNECTION)
+		return ret;
 
 	if (print) {
 		if (msg != NULL) {

--- a/src/tape_drivers/linux/sg-ibmtape/sg_scsi_tape.c
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_scsi_tape.c
@@ -192,6 +192,9 @@ int sg_issue_cdb_command(struct sg_tape *device, sg_io_hdr_t *req, char **msg)
 	CHECK_ARG_NULL(req, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(msg, -LTFS_NULL_ARG);
 
+	if (device->fd < 0)
+		return -EDEV_NO_CONNECTION;
+
 start:
 	ret = ioctl(device->fd, SG_IO, req);
 	if (ret < 0) {


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Return connection lost error code when LTFS detects a drive connection lost

# Description

Return connection lost error to handle this case correctly by the caller

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
