### PR TITLE
Ensure $(sysconfdir) exists before installing a file to it

### DIFF
--- a/conf/Makefile.am
+++ b/conf/Makefile.am
@@ -33,6 +33,7 @@ ltfs.conf: ltfs.conf.in
 	rm ltfs.conf.tmp
 
 install-data-local:
+	mkdir -p "$(DESTDIR)$(sysconfdir)"
 	if [ ! -f "$(DESTDIR)$(sysconfdir)/ltfs.conf.local" ]; then \
 		cp ltfs.conf.local "$(DESTDIR)$(sysconfdir)/ltfs.conf.local"; \
 	fi


### PR DESCRIPTION
This fixes a failure when building a Debian package in a chroot, for example, when the $(sysconfdir) doesn't already exist.
