### PR TITLE
Add order aware copy utility for LTFS

### DIFF
--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -35,6 +35,8 @@
 
 bin_PROGRAMS = mkltfs ltfsck
 
+nobase_bin_SCRIPTS = ltfsoacp
+
 noinst_HEADERS =
 
 mkltfs_SOURCES = mkltfs.c

--- a/src/utils/ltfsoacp
+++ b/src/utils/ltfsoacp
@@ -1,0 +1,275 @@
+#!/usr/bin/env python2.7
+# -*- coding: utf-8 -*-
+#
+#  OO_Copyright_BEGIN
+#
+#
+#  Copyright 2010, 2019 IBM Corp. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#   modification, are permitted provided that the following conditions
+#  are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#  documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the names of its
+#     contributors may be used to endorse or promote products derived from
+#     this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS ``AS IS''
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#
+#  OO_Copyright_END
+
+import sys
+import platform
+import os.path
+import argparse
+import xattr
+import shutil
+import threading
+
+from collections import deque
+
+class CopyItem:
+    """"""
+    def __init__(self, src, dst, vea_pre, cp_attr):
+        self.src     = src
+        self.dst     = dst
+        self.vea_pre = vea_pre
+        self.cp_attr = cp_attr
+        self.vuuid   = ''
+        self.part    = ''
+        self.start   = -1
+
+    def eval(self):
+        try:
+            self.vuuid = xattr.get(self.src, self.vea_pre + 'ltfs.volumeUUID')
+            self.part  = xattr.get(self.src, self.vea_pre + 'ltfs.partition')
+            start_str  = xattr.get(self.src, self.vea_pre + 'ltfs.startblock')
+            self.start = int(start_str)
+        except Exception as e:
+            self.vuuid = ''
+
+        return (self.vuuid, self.part, self.start)
+
+    def run(self):
+        if self.cp_attr:
+            shutil.copy2(self.src, self.dst)
+        else:
+            shutil.copy(self.src, self.dst)
+
+    def __repr__(self):
+        return self.src + ":" + self.dst + ":" + self.vuuid + ":" + self.part + str(self.start)
+
+def add_copy_item(c, cpls, direct):
+    (u, p, s) = c.eval()
+    if u == '':
+        # Source is not on LTFS
+        direct.append(c)
+    else:
+        cpl = {}
+        cplp = {}
+        if u in cpls.keys():
+            cpl = cpls[u]
+            if not p in cpl.keys():
+                cpls[u][p] = cplp
+            cplp = cpl[p]
+        else:
+            cpls[u] = {}
+            cpl = cpls[u]
+            cpl[p] = {}
+            cplp = cpl[p]
+
+        cplp[s] = c
+
+def walk_dir(source, dest, direct, cpls, ds, cp_attr):
+    (source_root, t) = os.path.split(source)
+    prefix_len = len(source_root)
+    dst = dest + "/" + t
+    dst = os.path.normpath(dst)
+    ds.append(dst)
+
+    for root, dirs, files in os.walk(source):
+        t = root[prefix_len:]
+        dst = dest + "/" + t
+        dst = os.path.normpath(dst)
+
+        for d in dirs:
+            ds.append(os.path.join(dst, d))
+        for f in files:
+            c = CopyItem(os.path.join(root, f), os.path.join(dst, f), VEA_PREFIX, cp_attr)
+            add_copy_item(c, cpls, direct)
+
+    for d in ds:
+        try:
+            os.mkdir(d)
+        except OSError as e:
+            if e.errno != 17: # Not EEXIST
+                sys.stderr.write(str(e) + "\n")
+                exit(1)
+
+def writer(q):
+    while True:
+        try:
+            ci = q.popleft()
+        except IndexError as e:
+            break;
+        except Exception as e:
+            sys.stderr.write(str(e) + "\n")
+            exit(1)
+
+        ci.run()
+
+VEA_PREFIX=''
+LTFS_SIG_VEA='ltfs.softwareProduct'
+
+plat = platform.system()
+if plat == 'Linux':
+    VEA_PREFIX='user.'
+elif plat == 'Darwin':
+    VEA_PREFIX=''
+else:
+    sys.stderr.write("unsupported platform '{0}'\n".format(plat))
+    exit(1)
+
+# Start program here
+parser = argparse.ArgumentParser(description = 'Copy files from source to destination with LTFS optimization')
+parser.add_argument('SOURCE', help='source files', nargs='*')
+parser.add_argument('DEST', help='destination', nargs='?')
+parser.add_argument('-p', help='preserve attibutes', action='store_true')
+parser.add_argument('-r', '--recursive', help='copy directories recursively', action='store_true')
+parser.add_argument('-t', '--target-directory', help='copy all SOURCE arguments into TARGET_DIRECTORY')
+#parser.add_argument('-z', '--zero', help='handle NULL delimited source list (assume input \'find -print0\')', action='store_true')
+parser.add_argument('--keep-tree', help='Keep tree structure like recursive copy. Effective only stdin source')
+
+args=parser.parse_args()
+
+if args.target_directory:
+    if args.DEST != None:
+        args.SOURCE.extend(args.DEST)
+        args.DEST = args.target_directory
+    else:
+        args.DEST = args.target_directory
+else:
+    if args.DEST == None and len(args.SOURCE) >= 2:
+        args.DEST = args.SOURCE[-1]
+        args.SOURCE = args.SOURCE[:-1]
+
+if args.DEST == None:
+    sys.stderr.write("No destination is specified\n")
+    exit(1)
+
+# Special case:
+#  Copy source in only one file
+#  Copy check source is file and
+if args.recursive == False and len(args.SOURCE) == 1:
+    if os.path.isfile(args.SOURCE[0]):
+        try:
+            shutil.copy(args.SOURCE[0], args.DEST)
+        except Exception as e:
+            sys.stderr.write(str(e) + "\n")
+            exit(1)
+        exit(0)
+    else:
+        sys.stderr.write("omitting directory '{0}'\n".format(args.SOURCE[0]))
+        exit(1)
+
+# Check destination is LTFS or not
+direct_write_threads = 8
+try:
+    sig = xattr.get(args.DEST, VEA_PREFIX + LTFS_SIG_VEA)
+
+    if sig.startswith("LTFS"):
+        sys.stderr.write("Destination {0} is LTFS\n".format(args.DEST))
+        direct_write_threads = 1
+    else:
+        sys.stderr.write("Destination {0} is not LTFS\n".format(args.DEST))
+except IOError as e:
+    if e.errno != 61: # Not ENODATA
+        sys.stderr.write(str(e) + "\n")
+        exit(1)
+    sys.stderr.write("Destination {0} is not LTFS\n".format(args.DEST))
+except Exception as e:
+    sys.stderr.write(str(e) + "\n")
+    exit(1)
+
+# Read sources from stdin if required
+if len(args.SOURCE) == 0:
+    for line in sys.stdin:
+        args.SOURCE.append(line.rstrip('\r\n'))
+else:
+    args.keep_tree = ''
+
+# Create the list of copy item
+direct = deque([])
+cpls = {}
+dirs = []
+for s in args.SOURCE:
+    dst = args.DEST
+    if os.path.isfile(s):
+        if len(args.keep_tree):
+            dst = dst + '/' + s[len(args.keep_tree):]
+            dst = os.path.normpath(dst)
+            (new_d, t) = os.path.split(dst)
+            if not os.path.exists(new_d):
+                os.makedirs(new_d)
+        c = CopyItem(s, dst, VEA_PREFIX, args.p)
+        add_copy_item(c, cpls, direct)
+    else:
+        if args.recursive:
+            if len(args.keep_tree):
+                dst = dst + '/' + s[len(args.keep_tree):]
+                dst = os.path.normpath(dst)
+                (new_d, t) = os.path.split(dst)
+                if not os.path.exists(new_d):
+                   os.makedirs(new_d)
+                dst = new_d
+            walk_dir(s, dst, direct, cpls, dirs, args.p)
+        else:
+            sys.stderr.write("omitting directory '{0}'\n".format(s))
+
+sys.stderr.write("On disk sources: {0}\n".format(len(direct)))
+sys.stderr.write("Source tapes: {0}\n".format(len(cpls.keys())))
+
+# Copy file on disk (direct item) with direct_write_threads
+if len(direct):
+    sys.stderr.write("Copying on disk files with {0} threads\n".format(direct_write_threads))
+    writers = []
+    for i in range(direct_write_threads):
+        th = threading.Thread(target = writer, args = ([direct]))
+        writers.append(th)
+        th.start()
+
+    for th in writers:
+        th.join()
+
+# Copy files on LTFS
+cpls_list = sorted(cpls.keys())
+for cpl_key in cpls_list:
+    cpl = cpls[cpl_key]
+    cpl_list = sorted(cpl.keys())
+    for cplp_key in cpl_list:
+        sys.stderr.write("Processing tape {0}, Partition {1}\n".format(cpl_key, cplp_key))
+        cplp = cpl[cplp_key]
+
+        sys.stderr.write("Sorting {}\n".format(len(cplp.keys())))
+        cps = sorted(cplp.keys())
+
+        sys.stderr.write("Copying files on {0} ({1})\n".format(cpl_key, cplp_key))
+        for cp in cps:
+            cplp[cp].run()
+
+exit(0)


### PR DESCRIPTION
# Summary of changes

- Add order aware copy utility for LTFS
- Fix of issue #138 

# Description

- command is `bin/ltfsoacp`
- written by python2.7
- options are subset of GNU cp except --keep-tree
- `ltfsoacp` accepts source list from stdin instead of arguments

examples:
```
# 1. Copy file /foo/aaa to file /foo/bbb
$ ltfsoacp /foo/aaa /foo/bbb

# 2. Copy file /foo/aaa and /foo/bbb to directory /bar/
$ ltfsoacp /foo/aaa /foo/bbb /bar

# 3. Copy directory /foo/ddd and /foo/DDD to directory /bar/
$ ltfsoacp /foo/ddd /foo/DDD /bar

# 4. Copy all files under /foo/ddd to directory /bar
$ find /foo/ddd -type f | ltfsoacp -t /bar

# 5. Copy all directories just under /foo/ddd to directory /bar
$ find /foo/ddd -type d -maxdepth 1 | ltfsoacp -t /bar

# 6. Copy all files just under /foo/ddd to directory /bar with keeping tree (Chop /foo/ddd from source list)
$ find /foo/ddd -type f | ltfsoacp -t /bar --keep-tree=/foo/ddd
```

Fixes #138 

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
