### PR TITLE
Fix the bug of detecting read length

### DIFF
--- a/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
@@ -1445,8 +1445,12 @@ static int _cdb_read(void *device, char *buf, size_t size, bool sili)
 				length = ret;
 		}
 	} else {
-		/* check condition is not set so we have a good read and can trust the length value */
-		length = req.dxfer_len;
+		if (sili) {
+			length = size - req.resid;
+		} else {
+			/* check condition is not set so we have a good read and can trust the length value */
+			length = size;
+		}
 	}
 
 	return length;


### PR DESCRIPTION
# Summary of changes

Calculate read length from req.residm in _cdb_read()

- Fix of issue #140 

# Description

When READ6 is issued with sili the sg backend returns a wrong length.
This behavior doesn't create any error when LBP is disabled (default),
but LBP is enabled by `-o scsi_lbprotection=on` is specified in the
argument. The sg backend returns CRC error because wrong read length is
returned from _cdb_read().

The problem is the sg backend returns req.dxfer_len even if sili is
true. This field is [I] in the document so we must not expect the field
is updated in SG_IO ioctl. We must use req.resid instead.

Fixes #140 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
