### PR TITLE
Set PF bit in modesense

### DIFF
--- a/src/libltfs/tape.h
+++ b/src/libltfs/tape.h
@@ -207,9 +207,9 @@ int tape_set_key(struct device_data *dev, const unsigned char *keyalias, const u
 int tape_clear_key(struct device_data *device, void * const kmi_handle);
 int tape_get_keyalias(struct device_data *dev, unsigned char **keyalias);
 int tape_takedump_drive(struct device_data *dev, bool nonforced_dump);
-const char *tape_get_media_encrypted(struct device_data *dev);
-const char *tape_get_drive_encryption_state(struct device_data *dev);
-const char *tape_get_drive_encryption_method(struct device_data *dev);
+char* tape_get_media_encrypted(struct device_data *dev);
+char* tape_get_drive_encryption_state(struct device_data *dev);
+char* tape_get_drive_encryption_method(struct device_data *dev);
 int tape_get_worm_status(struct device_data *dev, bool *is_worm);
 
 void set_tape_attribute(struct ltfs_volume *vol, struct tape_attr *t_attr);

--- a/src/libltfs/tape_ops.h
+++ b/src/libltfs/tape_ops.h
@@ -604,8 +604,8 @@ struct tape_ops {
 	 * @param subpage Subpage of the specified mode page.
 	 * @param buf On success, the backend must fill this buffer with the mode page's value.
 	 * @param size Buffer size.
-	 * @return 0 on success or a negative value on error. Backends for which Mode Sense is
-	 *         meaningless should zero out the buffer and return 0.
+	 * @return positive value or 0 on success or a negative value on error. Backend can return 0
+	 *         on success or positive value on success as transfered length.
 	 */
 	int   (*modesense)(void *device, const uint8_t page, const TC_MP_PC_TYPE pc, const uint8_t subpage, unsigned char *buf, const size_t size);
 

--- a/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
@@ -2863,6 +2863,8 @@ int sg_ibmtape_modesense(void *device, const unsigned char page, const TC_MP_PC_
 		ret_ep = _process_errors(device, ret, msg, cmd_desc, true, true);
 		if (ret_ep < 0)
 			ret = ret_ep;
+	} else {
+		ret = size - req.resid;
 	}
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_MODESENSE));
@@ -2896,6 +2898,7 @@ int sg_ibmtape_modeselect(void *device, unsigned char *buf, const size_t size)
 
 	/* Build CDB */
 	cdb[0] = MODE_SELECT10;
+	cdb[1] = 0x10; /* Set PF bit */
 	ltfs_u16tobe(cdb + 7, size);
 
 	timeout = ibm_tape_get_timeout(priv->timeouts, cdb[0]);


### PR DESCRIPTION
# Summary of changes

There are a few minor change in this change

  - Change return code of modesense method
  - Support drives that doesn't support PEW and append only mode
  - Set unit in GB into partition mode page to format a tape 
  - Code cleaning

# Description

It's not a feature enhancement but I made some minor change.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
