### PR TITLE
fix error in man

### DIFF
--- a/man/sgml/ltfs-sde.sgml
+++ b/man/sgml/ltfs-sde.sgml
@@ -204,7 +204,7 @@
 
       <variablelist>
         <varlistentry>
-          <term><option>o umask=<replaceable>M</replaceable></option></term>
+          <term><option>-o umask=<replaceable>M</replaceable></option></term>
           <listitem>
             <para>Set file permissions (octal)</para>
           </listitem>


### PR DESCRIPTION
# Summary of changes

- fix tiny error in the SGML source for man page (missing dash before `-o`)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works
