### PR TITLE
Fix parse error because of symlink target is too long

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@
 dnl
 dnl LTFS configure.ac.
 dnl
-AC_INIT([LTFS], [2.4.1.2 (10254)], IBM corporation.)
+AC_INIT([LTFS], [2.4.1.3 (Prelim)], IBM corporation.)
 AC_CONFIG_SRCDIR([src/main.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIRS([m4])

--- a/configure.ac
+++ b/configure.ac
@@ -36,7 +36,7 @@
 dnl
 dnl LTFS configure.ac.
 dnl
-AC_INIT([LTFS], [2.4.1.2 (Prelim)], IBM corporation.)
+AC_INIT([LTFS], [2.4.1.2 (10254)], IBM corporation.)
 AC_CONFIG_SRCDIR([src/main.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIRS([m4])

--- a/src/libltfs/pathname.c
+++ b/src/libltfs/pathname.c
@@ -277,9 +277,6 @@ int pathname_validate_target(const char *name)
 	namelen = pathname_strlen(name);
 	if (namelen < 0)
 		return namelen;
-	if (namelen > LTFS_FILENAME_MAX) {
-		return -LTFS_NAMETOOLONG;
-	}
 	ret = _pathname_validate(name, true);
 	return ret;
 }


### PR DESCRIPTION
# Summary of changes

Fix parse error because of symlink target is too long

- Fix of issue #148

# Description

The index parser reports error when symlink target length is 256 or more. This change remove the length check of symlink target

Fixes #148

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
