### PR TITLE
ltfs_ordered_copy improvement

### DIFF
--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -45,11 +45,12 @@ from collections import deque
 
 class CopyItem:
     """"""
-    def __init__(self, src, dst, vea_pre, cp_attr): #initialization
+    def __init__(self, src, dst, vea_pre, cp_attr, cp_xattr): #initialization
         self.src     = src
         self.dst     = dst
         self.vea_pre = vea_pre
         self.cp_attr = cp_attr
+	self.cp_xattr = cp_xattr
         self.vuuid   = ''
         self.part    = ''
         self.start   = -1
@@ -81,14 +82,16 @@ class CopyItem:
             #    sys.stderr.write("Copying {0}\n".format(self.src))
 
             if self.cp_attr: #Copy data and metadata
-		src_attributes = {}
-		for key in xattr.list(self.src):
-			src_attributes[key] = xattr.get(self.src, key)
-                shutil.copy2(self.src, self.dst)
-		#print(src_attributes)
-		(_, filename) = os.path.split(self.src)
-		for key in src_attributes:
-			xattr.set(os.path.join(self.dst, filename), key, src_attributes[key])
+		shutil.copy2(self.src, self.dst)
+		if self.cp_xattr:
+			src_attributes = {}
+			for key in xattr.list(self.src):
+				src_attributes[key] = xattr.get(self.src, key)
+			#shutil.copy2(self.src, self.dst)
+			#print(src_attributes)
+			(_, filename) = os.path.split(self.src)
+			for key in src_attributes:
+				xattr.set(os.path.join(self.dst, filename), key, src_attributes[key])
             else: #Only copy data
                 shutil.copy(self.src, self.dst)
         except Exception as e:
@@ -100,35 +103,35 @@ class CopyItem:
 
 HalfMegaByte = 512 * 1024
 
-def add_copy_item(c, cpls, direct):
+def add_copy_item(c, tape_num, direct):
     (u, p, s) = c.eval()
     if u == '':
         # Source is not on LTFS
         direct.append(c)
     else:
-        cpl = {}
-        cplp = {}
-        if u in cpls.keys(): 
-            cpl = cpls[u]
-            if not p in cpl.keys():
-                cpls[u][p] = {}
-            cplp = cpl[p]
+        partation = {}
+        start_block = {}
+        if u in tape_num.keys():
+            partation = tape_num[u]
+            if not p in partation.keys():
+                tape_num[u][p] = {}
+            start_block = partation[p]
         else:
-            cpls[u] = {}
-            cpl = cpls[u]
-            cpl[p] = {}
-            cplp = cpl[p]
+            tape_num[u] = {}
+            partation = tape_num[u]
+            partation[p] = {}
+            start_block = partation[p]
 
-        if s in cplp.keys():
-            tail = cplp[s][-1]
+        if s in start_block.keys():
+            tail = start_block[s][-1]
             if tail.size >= HalfMegaByte:
-                cplp[s].append(c)
+                start_block[s].append(c)
             else:
-                cplp[s].insert(-1, c)
+                start_block[s].insert(-1, c)
         else:
-            cplp[s] = [c]
+            start_block[s] = [c]
 
-def walk_dir(source, dest, direct, cpls, ds, cp_attr):
+def walk_dir(source, dest, direct, tape_num, ds, cp_attr, cp_xattr=False):
     (source_root, t) = os.path.split(source)
     prefix_len = len(source_root)
     dst = dest + "/" + t
@@ -143,8 +146,8 @@ def walk_dir(source, dest, direct, cpls, ds, cp_attr):
         for d in dirs:
             ds.append(os.path.join(dst, d))
         for f in files:
-            c = CopyItem(os.path.join(root, f), os.path.join(dst, f), VEA_PREFIX, cp_attr)
-            add_copy_item(c, cpls, direct)
+            c = CopyItem(os.path.join(root, f), os.path.join(dst, f), VEA_PREFIX, cp_attr, cp_xattr)
+            add_copy_item(c, tape_num, direct)
 
     for d in ds:
         try:
@@ -295,37 +298,22 @@ if len(direct):
         th.join()
 
 # Copy files on LTFS
-cpls_list = sorted(cpls.keys())
-for cpl_key in cpls_list:
-    cpl = cpls[cpl_key]
-    cpl_list = sorted(cpl.keys())
-    for cplp_key in cpl_list:
-        sys.stderr.write("Processing tape {0}, Partition {1}\n".format(cpl_key, cplp_key))
-        cplp = cpl[cplp_key]
+tape_list = sorted(tape.keys())                 #List: tape number list
+for partition_key in tape_list:
+    partition = tape[partition_key]
+    partation_list = sorted(partition.keys())   #List: partition number list
 
-        sys.stderr.write("Sorting {}\n".format(len(cplp.keys())))
-        cps = sorted(cplp.keys())
+    for start_block_key in partation_list:
+        sys.stderr.write("Processing tape {0}, Partition {1}\n".format(partition_key, start_block_key))
+        start_block = partition[start_block_key]
 
-        sys.stderr.write("Copying files on {0} ({1})\n".format(cpl_key, cplp_key))
-        for s in cps:
-            cpsl = cplp[s]
-            for cp in cpsl:
+        sys.stderr.write("Sorting {}\n".format(len(start_block.keys())))
+        start_block_list = sorted(start_block.keys())  #List: start block number list
+        sys.stderr.write("Copying files on {0} ({1})\n".format(partition_key, start_block_key))
+
+        for file_ind_key in start_block_list:          #List: if multi-file in one block, file position will be write in here
+            file_ind = start_block[file_ind_key]
+            for cp in file_ind:
                 cp.run()
 
 exit(0)
-#{  Here is "cpls"
-#	tape X:{  Here is "cpl"
-#		partition X:{  Here is "cpsl"
-#			start X:  Here is "cplp"
-#				[threadX]
-#		}
-#		partition Y:{
-#			start Y:[threadD, threadZ]
-#		}
-#	}
-#	tape F:{
-#		partition H:{
-#			start K:[threadR, threadS]
-#		}
-#	}
-#}

--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -45,7 +45,7 @@ from collections import deque
 
 class CopyItem:
     """"""
-    def __init__(self, src, dst, vea_pre, cp_attr):
+    def __init__(self, src, dst, vea_pre, cp_attr): #initialization
         self.src     = src
         self.dst     = dst
         self.vea_pre = vea_pre
@@ -55,7 +55,7 @@ class CopyItem:
         self.start   = -1
         self.size    = 0
 
-    def eval(self):
+    def eval(self): #access to the extended attributes present in some operating systems/filesystems by xattr
         try:
             self.vuuid = xattr.get(self.src, self.vea_pre + 'ltfs.volumeUUID')
         except Exception as e:
@@ -80,16 +80,16 @@ class CopyItem:
             #else:
             #    sys.stderr.write("Copying {0}\n".format(self.src))
 
-            if self.cp_attr:
+            if self.cp_attr: #Copy data and metadata
 		src_attributes = {}
 		for key in xattr.list(self.src):
 			src_attributes[key] = xattr.get(self.src, key)
                 shutil.copy2(self.src, self.dst)
-		print(src_attributes)
+		#print(src_attributes)
 		(_, filename) = os.path.split(self.src)
 		for key in src_attributes:
 			xattr.set(os.path.join(self.dst, filename), key, src_attributes[key])
-            else:
+            else: #Only copy data
                 shutil.copy(self.src, self.dst)
         except Exception as e:
             sys.stderr.write("Failed to copy {0} to {1}: ${2}\n".format(self.src, self.dst, str(str(e))))
@@ -108,7 +108,7 @@ def add_copy_item(c, cpls, direct):
     else:
         cpl = {}
         cplp = {}
-        if u in cpls.keys():
+        if u in cpls.keys(): 
             cpl = cpls[u]
             if not p in cpl.keys():
                 cpls[u][p] = {}
@@ -313,3 +313,19 @@ for cpl_key in cpls_list:
                 cp.run()
 
 exit(0)
+#{  Here is "cpls"
+#	tape X:{  Here is "cpl"
+#		partition X:{  Here is "cpsl"
+#			start X:  Here is "cplp"
+#				[threadX]
+#		}
+#		partition Y:{
+#			start Y:[threadD, threadZ]
+#		}
+#	}
+#	tape F:{
+#		partition H:{
+#			start K:[threadR, threadS]
+#		}
+#	}
+#}

--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -81,7 +81,14 @@ class CopyItem:
             #    sys.stderr.write("Copying {0}\n".format(self.src))
 
             if self.cp_attr:
+		src_attributes = {}
+		for key in xattr.list(self.src):
+			src_attributes[key] = xattr.get(self.src, key)
                 shutil.copy2(self.src, self.dst)
+		print(src_attributes)
+		(_, filename) = os.path.split(self.src)
+		for key in src_attributes:
+			xattr.set(os.path.join(self.dst, filename), key, src_attributes[key])
             else:
                 shutil.copy(self.src, self.dst)
         except Exception as e:
@@ -180,8 +187,13 @@ parser.add_argument('-r', '--recursive', help='copy directories recursively', ac
 parser.add_argument('-t', '--target-directory', help='copy all SOURCE arguments into TARGET_DIRECTORY')
 #parser.add_argument('-z', '--zero', help='handle NULL delimited source list (assume input \'find -print0\')', action='store_true')
 parser.add_argument('--keep-tree', help='Keep tree structure like recursive copy. Effective only stdin source')
+parser.add_argument('-a','-all', help='achieve files recursively and preserve attributes', action='store_true')
 
 args=parser.parse_args()
+
+if args.a:
+	args.p = True
+	args.recursive = True
 
 if args.target_directory:
     if args.DEST != None:

--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -298,20 +298,20 @@ if len(direct):
         th.join()
 
 # Copy files on LTFS
-tape_dict = sorted(cpls.keys())                 #List: tape number dict
-for partition_key in tape_dict:
+tape_list = sorted(cpls.keys())                 #List: tape number dict
+for partition_key in tape_list:
     partition = cpls[partition_key]
-    partation_dict = sorted(partition.keys())   #List: partition number dict
+    partation_list = sorted(partition.keys())   #List: partition number dict
 
-    for start_block_key in partation_dict:
+    for start_block_key in partation_list:
         sys.stderr.write("Processing tape {0}, Partition {1}\n".format(partition_key, start_block_key))
         start_block = partition[start_block_key]
 
         sys.stderr.write("Sorting {}\n".format(len(start_block.keys())))
-        start_block_dict = sorted(start_block.keys())  #List: start block number dict
+        start_block_list = sorted(start_block.keys())  #List: start block number dict
         sys.stderr.write("Copying files on {0} ({1})\n".format(partition_key, start_block_key))
 
-        for file_ind_key in start_block_dict:          #List: if multi-file in one block, file position will be write in here
+        for file_ind_key in start_block_list:          #List: if multi-file in one block, file position will be write in here
             file_ind = start_block[file_ind_key]
             for cp in file_ind:
                 cp.run()

--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -267,7 +267,7 @@ for s in args.SOURCE:
             (new_d, t) = os.path.split(dst)
             if not os.path.exists(new_d):
                 os.makedirs(new_d)
-        c = CopyItem(s, dst, VEA_PREFIX, args.p)
+        c = CopyItem(s, dst, VEA_PREFIX, args.p, args.a)
         add_copy_item(c, cpls, direct)
     else:
         if args.recursive:
@@ -278,7 +278,7 @@ for s in args.SOURCE:
                 if not os.path.exists(new_d):
                    os.makedirs(new_d)
                 dst = new_d
-            walk_dir(s, dst, direct, cpls, dirs, args.p)
+            walk_dir(s, dst, direct, cpls, dirs, args.p, args.a)
         else:
             sys.stderr.write("omitting directory '{0}'\n".format(s))
 
@@ -298,20 +298,20 @@ if len(direct):
         th.join()
 
 # Copy files on LTFS
-tape_list = sorted(tape.keys())                 #List: tape number list
-for partition_key in tape_list:
-    partition = tape[partition_key]
-    partation_list = sorted(partition.keys())   #List: partition number list
+tape_dict = sorted(cpls.keys())                 #List: tape number dict
+for partition_key in tape_dict:
+    partition = cpls[partition_key]
+    partation_dict = sorted(partition.keys())   #List: partition number dict
 
-    for start_block_key in partation_list:
+    for start_block_key in partation_dict:
         sys.stderr.write("Processing tape {0}, Partition {1}\n".format(partition_key, start_block_key))
         start_block = partition[start_block_key]
 
         sys.stderr.write("Sorting {}\n".format(len(start_block.keys())))
-        start_block_list = sorted(start_block.keys())  #List: start block number list
+        start_block_dict = sorted(start_block.keys())  #List: start block number dict
         sys.stderr.write("Copying files on {0} ({1})\n".format(partition_key, start_block_key))
 
-        for file_ind_key in start_block_list:          #List: if multi-file in one block, file position will be write in here
+        for file_ind_key in start_block_dict:          #List: if multi-file in one block, file position will be write in here
             file_ind = start_block[file_ind_key]
             for cp in file_ind:
                 cp.run()


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Fix of issue #155 

# Description
1. `cp -p` copies mode,ownership and timestamps; `cp -a` copies all the attributes including mode,ownership,timestamps,context, links, xattr(according to man page) 
2. `shutil.copy()` copies mode(permission bits)
3. `shutil.copy2()` copies mode, last access time, last modification time, and flags 
4. Neither `shutil.copy()` nor `shutil.copy2()` can copy xattr and ownership
5. Now ,`ltfs_ordered_copy -a` can copy mode,timestamps and xattr , which is slightly different from `cp -a` because ownership and links are not considered
6. Now , `ltfs_ordered_copy -p` can copy mode and timestamps which is slightly different from `cp -p` because ownership and links are not considered
######
|   | `shutil.copy()` | `shutil.copy2()` | `cp -a` | `cp -p` | `ltfs_ordered_copy -a` | `ltfs_ordered_copy -p` |
|---------------|----------------|-------|-------|----------------------|----------------------|---|
| mode          | O              | O     | O     | O                    | O                    | O |
| timestamps    | X              | O     | O     | O                    | O                    | O |
| ownership     | X              | X     | O     | O                    | X                    | X |
| xattr         | X              | X     | O     | X                    | O                    | X |
| links         | ?              | ?     | O     | X                    | ?                    | ? |

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
