### PR TITLE
Allow BOM in the path name

### DIFF
--- a/src/libltfs/pathname.c
+++ b/src/libltfs/pathname.c
@@ -439,7 +439,7 @@ int _pathname_validate(const char *name, bool allow_slash)
  */
 int _pathname_valid_in_xml(UChar32 c)
 {
-	if (c == 0 || c == 0x1f || (c >= 0xd800 && c <= 0xdfff) || c == 0xfeff || c == 0xfffe || c == 0xffff)
+	if (c == 0 || c == 0x1f || (c >= 0xd800 && c <= 0xdfff) || c == 0xfffe || c == 0xffff)
 		return 0;
 	else
 		return 1;


### PR DESCRIPTION
# Summary of changes

Allow `BOM` in the path name

- Fix of issue #159 

# Description

In the previous version (2.2), LTFS allows BOM in the path name. But new
code rejects it. May be it is a kind of side effect of the changes for
'%' support in the path name. So I will revert the implementation.

Fixes #159

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
