### PR TITLE
Check the reservation in sg_ibmtape_open()

### DIFF
--- a/messages/tape_linux_sg_ibmtape/root.txt
+++ b/messages/tape_linux_sg_ibmtape/root.txt
@@ -128,6 +128,11 @@ root:table {
 		30286I:string { "Failed to get cartridge status. The cartridge is not loaded." }
 		30287I:string { "Received an unknown sense code %06x." }
 		30288I:string { "Opening a tape device for drive serial %s." }
+		30289I:string { "Cannot fetch the reservation key (%s, %d)." }
+		30290I:string { "Changer %s isn't reserved from any nodes." }
+		30291I:string { "Changer %s was reserved from this node and can be reserved from the current path." }
+		30292I:string { "Changer %s was reserved from this node but failed to reserve from the current path." }
+		30293I:string { "Changer %s was reserved from another node (%s)." }
 
 		30392D:string { "Backend %s %s." }
 		30393D:string { "Backend %s: %d %s." }


### PR DESCRIPTION
# Summary of changes

Keep searching the device to open even if reserving the device fails when drive serial is specified in the sg  backend.

# Description

This is a fix of side effect of specification change.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
