### PR TITLE
Treat DID_NEXUS_FAILURE as reservation conflict

### DIFF
--- a/src/tape_drivers/linux/sg-ibmtape/sg_scsi_tape.c
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_scsi_tape.c
@@ -280,8 +280,9 @@ start:
 				ret = -EDEV_CONNECTION_LOST;
 				break;
 			case HOST_NEXUS_FAIL:
-				if (msg) *msg = "SCSI nexus failure";
-				ret = -EDEV_CONNECTION_LOST;
+				/* See https://fossies.org/linux/sdparm/lib/sg_pt_linux.c */
+				if (msg) *msg = "SCSI nexus failure (reservation conflict)";
+				ret = -EDEV_RESERVATION_CONFLICT;
 				break;
 			default:
 				ltfsmsg(LTFS_INFO, 30244I, req->host_status, req->driver_status);


### PR DESCRIPTION
# Summary of changes

Backport of #168 on the master branch

# Description

In the kernel 4.14 on Power9, scsi middle layer seems to return DID_NEXUS_FAILURE(0x11) in host_status. This change handle this behavior. Of cause, SCSI_RESERVATION_CONFLICT in masked status is treated as reservation conflict.

In addition to DID_NEXUS_FAILURE handling. I slightly change the code about timeout table handling. It is configured after open the device by serial number search.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
