### PR TITLE
Fix the problem to miss the write protect notch condition

### DIFF
--- a/src/libltfs/tape.c
+++ b/src/libltfs/tape.c
@@ -460,10 +460,11 @@ int tape_load_tape(struct device_data *dev, void * const kmi_handle, bool force)
 
 	/* Update read only flags */
 	ltfs_mutex_lock(&dev->read_only_flag_mutex);
-	if (param.write_protect || param.logical_write_protect)
-		dev->write_protected = true;
-	else
-		dev->write_protected = false;
+
+	/* TODO: Need to handle logical write protect here */
+	if (param.write_protect)
+		dev->write_protected = param.write_protect;
+
 	dev->write_error = false;
 	if (cap.max_p0 && cap.max_p1 && !cap.remaining_p0)
 		dev->partition_space[0] = PART_NO_SPACE;

--- a/src/libltfs/tape.c
+++ b/src/libltfs/tape.c
@@ -462,6 +462,7 @@ int tape_load_tape(struct device_data *dev, void * const kmi_handle, bool force)
 	ltfs_mutex_lock(&dev->read_only_flag_mutex);
 
 	/* TODO: Need to handle logical write protect here */
+	dev->write_protected = 0;
 	if (param.write_protect)
 		dev->write_protected = param.write_protect;
 


### PR DESCRIPTION
# Summary of changes

This pull request fixes the problem to miss the physical write protected notch condition

# Description

By the backend I/F change, `device_data::write_protected` shall have an integer value about physical write protect condition. But it still has a boolean value. 

This shall be corrected.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
