### PR TITLE
Fix a NULL pointer dereference in the file backend.

### DIFF
--- a/src/tape_drivers/generic/file/filedebug_tc.c
+++ b/src/tape_drivers/generic/file/filedebug_tc.c
@@ -434,6 +434,8 @@ int filedebug_open(const char *name, void **handle)
 		}
 
 		/* Run on file mode */
+		if (devname == NULL)
+			devname = strdup(name);
 		ltfsmsg(LTFS_INFO, 30001I, devname);
 		state->fd = open(devname, O_RDWR | O_BINARY);
 		if (state->fd < 0) {


### PR DESCRIPTION
In filedebug_open(), devname is used in a situation where it is not
necessarily non-NULL.  If it is NULL, strdup the passed in name.

# Summary of changes

- Fixes a NULL pointer dereference in the file backend.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
