### PR TITLE
Relax the index parser to allow 0-byte name

### DIFF
--- a/src/libltfs/xml.h
+++ b/src/libltfs/xml.h
@@ -224,6 +224,12 @@ int xml_format_time(struct ltfs_timespec t, char** out);
 	} \
 } while (0)
 
+#define get_tag_text_allow_zero_length() do { \
+	assert_not_empty(); \
+	if (xml_scan_text(reader, &value) < 0) \
+		return -1; \
+} while (0)
+
 /* get text from a tag. if successful, it reads the text into "value".
  * It does not consume the remainder of the tag. */
 #define get_tag_text_allow_empty() do { \


### PR DESCRIPTION
# Summary of changes

Accept `<name></name>` for root directory.

# Description

Name of `root` directory is treated as a volume name. So `empty` value is allowed when there is no volume name.

The current code only accepts `<name/>` as empty tag. So the index parser may reject an index written by another implementation.

This fix accepts both `<name/>` and `<name></name>`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
