### PR TITLE
Correct flags on sg_io_hdr

### DIFF
--- a/src/tape_drivers/linux/sg-ibmtape/sg_scsi_tape.h
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_scsi_tape.h
@@ -106,7 +106,6 @@ static inline int init_sg_io_header(sg_io_hdr_t *req)
 	memset(req, 0, sizeof(sg_io_hdr_t));
 
 	req->interface_id = 'S';
-	req->flags        = SG_FLAG_LUN_INHIBIT;
 
 	return 0;
 }


### PR DESCRIPTION
# Summary of changes

Previously the code set SG_FLAG_LUN_INHIBIT when LTFS issues SG_IO.

But this flag is not effective to any FC/SAS devices anymore. So it is unset in this change.

## Type of change

- Small correction

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
