### PR TITLE
Ignore cleaning required sense from drive.

### DIFF
--- a/src/libltfs/tape.c
+++ b/src/libltfs/tape.c
@@ -510,6 +510,10 @@ int tape_unload_tape(bool keep_on_drive, struct device_data *dev)
 	if (! keep_on_drive) {
 		do {
 			ret = dev->backend->unload(dev->backend_data, &dev->position);
+			if (ret == -EDEV_CLEANING_REQUIRED) {
+				/* Ignore cleaning sense */
+				ret = 0;
+			}
 		} while (NEED_REVAL(ret));
 	}
 
@@ -2450,6 +2454,11 @@ int tape_enable_append_only_mode(struct device_data *dev, bool enable)
 	   the cartridge has to be unloaded before sending mode select. */
 	if (loaded && !enable && (mp_dev_config_ext[21]& 0xF0) == 0x10) {
 		ret = dev->backend->unload(dev->backend_data, &dev->position);
+		if (ret == -EDEV_CLEANING_REQUIRED) {
+			/* Ignore cleaning sense */
+			ret = 0;
+		}
+
 		if (ret < 0) {
 			ltfsmsg(LTFS_ERR, 17151E, ret);
 			return ret;


### PR DESCRIPTION
# Summary of changes

Treat cleaning required sense as a good state against unload command.

- Fix of issue #190

# Description

Cleaning required sense is an informational sense from drive point of view. So we need to ignore that.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
