### PR TITLE
Use CRC32C as much as possible on LTO

### DIFF
--- a/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
+++ b/src/tape_drivers/linux/sg-ibmtape/sg_ibmtape.c
@@ -191,14 +191,25 @@ static int _set_lbp(void *device, bool enable)
 	unsigned char lbp_method = LBP_DISABLE;
 
 	/* Check logical block protection capability */
-	ret = sg_ibmtape_modesense(device, TC_MP_INIT_EXT, TC_MP_PC_CURRENT, 0x00, buf_ext, sizeof(buf_ext));
-	if (ret < 0)
-		return ret;
+	if (IS_ENTERPRISE(priv->drive_type)) {
+		ret = sg_ibmtape_modesense(device, TC_MP_INIT_EXT, TC_MP_PC_CURRENT, 0x00, buf_ext, sizeof(buf_ext));
+		if (ret < 0)
+			return ret;
 
-	if (buf_ext[0x12] & TC_MP_INIT_EXT_LBP_CRC32C)
-		lbp_method = CRC32C_CRC;
-	else
-		lbp_method = REED_SOLOMON_CRC;
+		if (buf_ext[0x12] & TC_MP_INIT_EXT_LBP_CRC32C)
+			lbp_method = CRC32C_CRC;
+		else
+			lbp_method = REED_SOLOMON_CRC;
+	} else {
+		/*
+		 * LTO drive doesn't have a modepage to support CRC32C or not
+		 * So use CRC32C based on it's generation
+		 */
+		if (DRIVE_GEN(priv->drive_type) >= 0x07)
+			lbp_method = CRC32C_CRC;
+		else
+			lbp_method = REED_SOLOMON_CRC;
+	}
 
 	/* set logical block protection */
 	ltfsmsg(LTFS_DEBUG, 30393D, "LBP Enable", enable, "");

--- a/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
+++ b/src/tape_drivers/osx/iokit-ibmtape/iokit_ibmtape.c
@@ -186,14 +186,25 @@ static int _set_lbp(void *device, bool enable)
 	unsigned char lbp_method = LBP_DISABLE;
 
 	/* Check logical block protection capability */
-	ret = iokit_ibmtape_modesense(device, TC_MP_INIT_EXT, TC_MP_PC_CURRENT, 0x00, buf_ext, sizeof(buf_ext));
-	if (ret < 0)
-		return ret;
+	if (IS_ENTERPRISE(priv->drive_type)) {
+		ret = iokit_ibmtape_modesense(device, TC_MP_INIT_EXT, TC_MP_PC_CURRENT, 0x00, buf_ext, sizeof(buf_ext));
+		if (ret < 0)
+			return ret;
 
-	if (buf_ext[0x12] & TC_MP_INIT_EXT_LBP_CRC32C)
-		lbp_method = CRC32C_CRC;
-	else
-		lbp_method = REED_SOLOMON_CRC;
+		if (buf_ext[0x12] & TC_MP_INIT_EXT_LBP_CRC32C)
+			lbp_method = CRC32C_CRC;
+		else
+			lbp_method = REED_SOLOMON_CRC;
+	} else {
+		/*
+		 * LTO drive doesn't have a modepage to support CRC32C or not
+		 * So use CRC32C based on it's generation
+		 */
+		if (DRIVE_GEN(priv->drive_type) >= 0x07)
+			lbp_method = CRC32C_CRC;
+		else
+			lbp_method = REED_SOLOMON_CRC;
+	}
 
 	/* set logical block protection */
 	ltfsmsg(LTFS_DEBUG, 30993D, "LBP Enable", enable, "");


### PR DESCRIPTION
# Summary of changes

This change checks generation of LTO drive and use CRC32C if the drive
is LTO-7 or LTO-8. The x86_64 CPU has H/W accelerator for CRC32C. So
faster process and lower CPU power can be expected.

- Fix of issue #194

# Description

Currently LTFS uses Reed-Solomon for logical block protection on LTO
drive. But there is no H/W accelerator for Reed-Solomon. So more CPU
power is needed than CRC32C when `-o scsi_lbprotect=on` on LTO drive.

Fixes #194

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
