### PR TITLE
Handle unknown H/W as a H/W correctly

### DIFF
--- a/src/tape_drivers/freebsd/cam/cam_cmn.c
+++ b/src/tape_drivers/freebsd/cam/cam_cmn.c
@@ -93,6 +93,9 @@ int camtape_sense2rc(void *device, struct scsi_sense_data *sense, int sense_len)
 		rc = _sense2errcode(sense_concat, vendor_table, NULL, MASK_WITH_SENSE_KEY);
 	}
 
+	if (rc == -EDEV_UNKNOWN && ((sense_concat & 0xFF0000) == 0x040000) )
+		rc = -EDEV_HARDWARE_ERROR;
+
 	return rc;
 }
 

--- a/src/tape_drivers/linux/sg/sg_scsi_tape.c
+++ b/src/tape_drivers/linux/sg/sg_scsi_tape.c
@@ -85,6 +85,9 @@ static int sg_sense2errno(sg_io_hdr_t *req, uint32_t *s, char **msg)
 	if (rc == -EDEV_VENDOR_UNIQUE)
 		rc = _sense2errorcode(sense_value, vendor_table, msg, MASK_WITH_SENSE_KEY);
 
+	if (rc == -EDEV_UNKNOWN && ((sense_value & 0xFF0000) == 0x040000) )
+		rc = -EDEV_HARDWARE_ERROR;
+
 	if (rc == -EDEV_UNKNOWN) {
 		ltfsmsg(LTFS_INFO, 30287I, sense_value);
 	}

--- a/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_scsi_tape.c
+++ b/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_scsi_tape.c
@@ -85,6 +85,9 @@ static int scsipi_sense2errno(scsireq_t *req, uint32_t *s, char **msg)
 	if (rc == -EDEV_VENDOR_UNIQUE)
 		rc = _sense2errorcode(sense_value, vendor_table, msg, MASK_WITH_SENSE_KEY);
 
+	if (rc == -EDEV_UNKNOWN && ((sense_value & 0xFF0000) == 0x040000) )
+		rc = -EDEV_HARDWARE_ERROR;
+
 	return rc;
 }
 

--- a/src/tape_drivers/osx/iokit/iokit_scsi.c
+++ b/src/tape_drivers/osx/iokit/iokit_scsi.c
@@ -94,6 +94,9 @@ static int iokit_sense2errno(struct iokit_scsi_request *req, uint32_t *s, char *
 	if (rc == -EDEV_VENDOR_UNIQUE)
 		rc = _sense2errorcode(sense_value, vendor_table, msg, MASK_WITH_SENSE_KEY);
 
+	if (rc == -EDEV_UNKNOWN && ((sense_value & 0xFF0000) == 0x040000) )
+		rc = -EDEV_HARDWARE_ERROR;
+
 	return rc;
 }
 

--- a/src/tape_drivers/vendor_compat.c
+++ b/src/tape_drivers/vendor_compat.c
@@ -131,6 +131,7 @@ struct error_table standard_tape_errors[] = {
 	{0x035300, -EDEV_LOAD_UNLOAD_ERROR,         "Media Load or Eject Failed"},
 	{0x035304, -EDEV_LOAD_UNLOAD_ERROR,         "Medium Thread or Unthread Failure"},
 	/* Sense Key 4 (Hardware or Firmware Error) */
+	{0x040302, -EDEV_HARDWARE_ERROR,            "Open Writer Failure"},
 	{0x040403, -EDEV_HARDWARE_ERROR,            "Manual Intervention Required"},
 	{0x040801, -EDEV_HARDWARE_ERROR,            "Logical Unit Communication Failure"},
 	{0x040900, -EDEV_HARDWARE_ERROR,            "Track Following Error"},


### PR DESCRIPTION
# Summary of changes

Handle unknown H/W as a H/W correctly

# Description

At this time, unknown H/W error is detected as just an unknown error. But actually, drive might not work correctly at all at this timing. So it is good to handle it as a H/W error.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
