### PR TITLE
State HP drive support in README

### DIFF
--- a/.github/workflows/build-ubuntu-focal.yml
+++ b/.github/workflows/build-ubuntu-focal.yml
@@ -12,6 +12,6 @@ jobs:
         uses: actions/checkout@v1
       - name: Build LTFS
         id: build
-        uses: LinearTapeFileSystem/Ubuntu2004-Build@v0.1
+        uses: LinearTapeFileSystem/Ubuntu2004-Build@v0.2
         with:
           destination: '/tmp/ltfs'

--- a/.github/workflows/build-ubuntu-focal.yml
+++ b/.github/workflows/build-ubuntu-focal.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: Build on Ubuntu Bionic
+    name: Build on Ubuntu Focal
     runs-on: ubuntu-latest
 
     steps:
@@ -12,6 +12,6 @@ jobs:
         uses: actions/checkout@v1
       - name: Build LTFS
         id: build
-        uses: LinearTapeFileSystem/Ubuntu2004-Build@v0.2
+        uses: LinearTapeFileSystem/Ubuntu2004-Build@v1.0
         with:
           destination: '/tmp/ltfs'

--- a/.github/workflows/build-ubuntu-focal.yml
+++ b/.github/workflows/build-ubuntu-focal.yml
@@ -1,0 +1,17 @@
+name: Ubuntu 20.04 Build Job
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: Build on Ubuntu Bionic
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Set up Git repository
+        uses: actions/checkout@v1
+      - name: Build LTFS
+        id: build
+        uses: LinearTapeFileSystem/Ubuntu2004-Build@v0.1
+        with:
+          destination: '/tmp/ltfs'

--- a/README.md
+++ b/README.md
@@ -93,6 +93,10 @@ These instructions will get you a copy of the project up and running on your loc
   | IBM    | TS1150     | None              |
   | IBM    | TS1155     | None              |
   | IBM    | TS1160     | None              |
+  | HP     | LTO5       | T.B.D.            |
+  | HP     | LTO6       | T.B.D.            |
+  | HP     | LTO7       | T.B.D.            |
+  | HP     | LTO8       | T.B.D.            |
 
 ## Installing
 
@@ -175,22 +179,23 @@ You need to add `--enable-lintape` as an argument of ./configure script if you w
 
 #### Buildable distributions
 
-  | Dist                          | Arch    | Status      |
-  |:-:                            |:-:      |:-:          |
-  | RHEL 7                        | x86_64  | OK          |
-  | RHEL 7                        | ppc64le | OK          |
-  | CentOS 7                      | x86_64  | ![GH Action status](https://github.com/LinearTapeFileSystem/ltfs/workflows/CentOS7%20Build%20Job/badge.svg?branch=master)|
-  | CentOS 7                      | ppc64le | Probably OK |
-  | Fedora 28                     | x86_64  | ![GH Action status](https://github.com/LinearTapeFileSystem/ltfs/workflows/Fedora28%20Build%20Job/badge.svg?branch=master)|
-  | Ubuntu 16.04 LTS              | x86_64  | ![GH Action status](https://github.com/LinearTapeFileSystem/ltfs/workflows/Ubuntu%2016.04%20Build%20Job/badge.svg?branch=master)|
-  | Ubuntu 16.04 LTS              | ppc64le | [![Build Status](https://travis-ci.org/LinearTapeFileSystem/ltfs.svg?branch=master)](https://travis-ci.org/LinearTapeFileSystem/ltfs) |
-  | Ubuntu 18.04 LTS              | x86_64  | ![GH Action status](https://github.com/LinearTapeFileSystem/ltfs/workflows/Ubuntu%2018.04%20Build%20Job/badge.svg?branch=master)|
-  | Ubuntu 18.04 LTS              | ppc64le | [![Build Status](https://travis-ci.org/LinearTapeFileSystem/ltfs.svg?branch=master)](https://travis-ci.org/LinearTapeFileSystem/ltfs) |
-  | Ubuntu 19.10 (Need icu-config)| x86_64  | ![GH Action status](https://github.com/LinearTapeFileSystem/ltfs/workflows/Ubuntu%2019.10%20Build%20Job/badge.svg?branch=master)|  
-  | Debian 9                      | x86_64  | ![GH Action status](https://github.com/LinearTapeFileSystem/ltfs/workflows/Debian9%20Build%20Job/badge.svg?branch=master)|
-  | Debian 10 (Need icu-config)   | x86_64  | ![GH Action status](https://github.com/LinearTapeFileSystem/ltfs/workflows/Debian10%20Build%20Job/badge.svg?branch=master)|
-  | ArchLinux 2018.08.01          | x86_64  | OK          |
-  | ArchLinux 2018.12.31 (rolling)| x86_64  | OK          |
+  | Dist                              | Arch    | Status      |
+  |:-:                                |:-:      |:-:          |
+  | RHEL 7                            | x86_64  | OK          |
+  | RHEL 7                            | ppc64le | OK          |
+  | CentOS 7                          | x86_64  | ![GH Action status](https://github.com/LinearTapeFileSystem/ltfs/workflows/CentOS7%20Build%20Job/badge.svg?branch=master)|
+  | CentOS 7                          | ppc64le | Probably OK |
+  | Fedora 28                         | x86_64  | ![GH Action status](https://github.com/LinearTapeFileSystem/ltfs/workflows/Fedora28%20Build%20Job/badge.svg?branch=master)|
+  | Ubuntu 16.04 LTS                  | x86_64  | ![GH Action status](https://github.com/LinearTapeFileSystem/ltfs/workflows/Ubuntu%2016.04%20Build%20Job/badge.svg?branch=master)|
+  | Ubuntu 16.04 LTS                  | ppc64le | [![Build Status](https://travis-ci.org/LinearTapeFileSystem/ltfs.svg?branch=master)](https://travis-ci.org/LinearTapeFileSystem/ltfs) |
+  | Ubuntu 18.04 LTS                  | x86_64  | ![GH Action status](https://github.com/LinearTapeFileSystem/ltfs/workflows/Ubuntu%2018.04%20Build%20Job/badge.svg?branch=master)|
+  | Ubuntu 18.04 LTS                  | ppc64le | [![Build Status](https://travis-ci.org/LinearTapeFileSystem/ltfs.svg?branch=master)](https://travis-ci.org/LinearTapeFileSystem/ltfs) |
+  | Ubuntu 19.10 (Need icu-config)    | x86_64  | ![GH Action status](https://github.com/LinearTapeFileSystem/ltfs/workflows/Ubuntu%2019.10%20Build%20Job/badge.svg?branch=master)|
+  | Ubuntu 20.04 LTS (Need icu-config)| x86_64  | ![GH Action status](https://github.com/LinearTapeFileSystem/ltfs/workflows/Ubuntu%2020.04%20Build%20Job/badge.svg?branch=master)|
+  | Debian 9                          | x86_64  | ![GH Action status](https://github.com/LinearTapeFileSystem/ltfs/workflows/Debian9%20Build%20Job/badge.svg?branch=master)|
+  | Debian 10 (Need icu-config)       | x86_64  | ![GH Action status](https://github.com/LinearTapeFileSystem/ltfs/workflows/Debian10%20Build%20Job/badge.svg?branch=master)|
+  | ArchLinux 2018.08.01              | x86_64  | OK          |
+  | ArchLinux 2018.12.31 (rolling)    | x86_64  | OK          |
 
 Currently, automatic build checking is working on GitHub Actions and Travis CI.
 


### PR DESCRIPTION
# Summary of changes

State HP drive support in README

# Description

Following changes are made by this PR.

1. Add HP's drives into README as supported drives
2. Add build checker for Ubuntu 20.04 LTS (Focal)

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
