### PR TITLE
Handle dirty MAM on unmount

### DIFF
--- a/messages/libltfs/root.txt
+++ b/messages/libltfs/root.txt
@@ -427,7 +427,7 @@ root:table {
 		11330I:string { "Loading cartridge." }
 		11331E:string { "Failed to load the cartridge (%s)." }
 		11332I:string { "Load successful." }
-		11333I:string { "A cartridge with write-perm error is detected on %s. Seek the newest index (%llu, %llu)." }
+		11333I:string { "A cartridge with write-perm error is detected on %s. Seek the newest index (IP Gen = %llu, VCR = %llu) (DP Gen = %llu, VCR = %llu) (VCR = %llu)." }
 		11334I:string { "Remove extent : %s (%llu, %llu)." }
 		11335D:string { "Get physical block position (%d - %d)." }
 		11336I:string { "The attribute does not exist. Ignore the expected error." }
@@ -805,6 +805,8 @@ v
 		17260I:string { "Sleep was interrupted by a signal while taking the advisory lock '%s'." }
 		17261I:string { "Kernel detected a false deadlock retry to acquire the advisory lock '%s' (%d)." }
 		17263I:string { "Sleep was failed while taking the advisory lock '%s' (%d, %d)." }
+		17264W:string { "Index on %s is newer but MAM shows a permanent write error happened on %s." }
+		17265I:string { "Skip writing index because %s." }
 
 		// For Debug 19999I:string { "%s %s %d." }
 

--- a/src/libltfs/ltfs.h
+++ b/src/libltfs/ltfs.h
@@ -366,6 +366,12 @@ enum volumelock_status {
 	VOL_FORCE_READ_ONLY = 0x100000000, /**< Force read only */
 };
 
+enum volume_mount_type {
+	MOUNT_NORMAL = 0, /**< Normal mount */
+	MOUNT_ROLLBACK,   /**< Roll back mount */
+	MOUNT_ERR_TAPE,   /**< Mount write perm tape */
+};
+
 #define VOL_WRITE_PERM_MASK (0xE0)
 #define VOL_ADV_LOCK_MASK   (0x03)
 
@@ -389,13 +395,13 @@ struct ltfs_volume {
 	void *kmi_handle;              /**< Handle to the key manager interface state */
 
 	/* Internal state variables */
-	struct device_data *device;    /**< Device-specific data */
-	bool ip_index_file_end;        /**< Does the index partition end in an index file? */
-	bool dp_index_file_end;        /**< Does the data partition end in an index file? */
-	bool rollback_mount;           /**< Is the volume mounted in rollback mount mode? */
-	int  traverse_mode;            /**< Traverse strategy (rollback, list index, rollback mount) */
-	bool skip_eod_check;           /**< Skip EOD existance check? */
-	bool ignore_wrong_version;     /**< Ignore wrong index version while seeking index? */
+	struct device_data *device;        /**< Device-specific data */
+	bool ip_index_file_end;            /**< Does the index partition end in an index file? */
+	bool dp_index_file_end;            /**< Does the data partition end in an index file? */
+	enum volume_mount_type mount_type; /**< Mount type defined by enum */
+	int  traverse_mode;                /**< Traverse strategy (rollback, list index, rollback mount) */
+	bool skip_eod_check;               /**< Skip EOD existance check? */
+	bool ignore_wrong_version;         /**< Ignore wrong index version while seeking index? */
 
 	/* A 1-block read cache, used to prevent reading the same block from tape over and over.
 	 * You MUST hold the tape device lock before accessing this buffer. */


### PR DESCRIPTION
# Summary of changes

Currently, LTFS might try to write an index on tape even if the tape is marked as "Write Error tape" when index info and volume lock info is different on MAM.

This fix introduce following changes

1. Print more MAM info when volume lock is specified
2. Print a warning message and capture dump when index info and volume
lock info is different on an error tape mount
3. Skip to write index at unmount when LTFS make a error tape mount

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works