### PR TITLE
Enhancement for creating pretty extent at flush

### DIFF
--- a/messages/iosched_unified/root.txt
+++ b/messages/iosched_unified/root.txt
@@ -64,5 +64,11 @@ root:table {
 		13024I:string { "Clean up extents and append index at index partition (%d)." }
 		13025I:string { "Get error position (%d, %d)." }
 		13026E:string { "Write perm handling error : %s (%d)." }
+		13027D:string { "Created DPR : %s." }
+		13028D:string { "Removed DPR : %s." }
+		13029D:string { "DPR (%s): %s (%u)." }
+		13030D:string { "No DPR on %s (req = 0x%llx)." }
+		13031D:string { "Created a request (0x%llx)." }
+		13032D:string { "Removed a request (0x%llx)." }
 	}
 }

--- a/messages/iosched_unified/root.txt
+++ b/messages/iosched_unified/root.txt
@@ -70,5 +70,10 @@ root:table {
 		13030D:string { "No DPR on %s (req = 0x%llx)." }
 		13031D:string { "Created a request (0x%llx)." }
 		13032D:string { "Removed a request (0x%llx)." }
+		13033D:string { "Flushing all (%s, %s)." }
+		13034D:string { "Send a broadcast from %s." }
+		13035D:string { "Waiting a broadcast." }
+		13036D:string { "Received a broadcast." }
+		13037D:string { "Flush is done." }
 	}
 }

--- a/messages/iosched_unified/root.txt
+++ b/messages/iosched_unified/root.txt
@@ -75,5 +75,6 @@ root:table {
 		13035D:string { "Waiting a broadcast signal." }
 		13036D:string { "Received a broadcast signal." }
 		13037D:string { "Flush all operation is finished." }
+		13038E:string { "Cannot capture dentry private in %s (%d)"}
 	}
 }

--- a/messages/iosched_unified/root.txt
+++ b/messages/iosched_unified/root.txt
@@ -72,8 +72,8 @@ root:table {
 		13032D:string { "Removed a request (0x%llx)." }
 		13033D:string { "Flushing all (%s, %s)." }
 		13034D:string { "Send a broadcast from %s." }
-		13035D:string { "Waiting a broadcast." }
-		13036D:string { "Received a broadcast." }
-		13037D:string { "Flush is done." }
+		13035D:string { "Waiting a broadcast signal." }
+		13036D:string { "Received a broadcast signal." }
+		13037D:string { "Flush all operation is finished." }
 	}
 }

--- a/src/iosched/fcfs.c
+++ b/src/iosched/fcfs.c
@@ -119,7 +119,7 @@ int fcfs_open(const char *path, bool open_write, struct dentry **dentry, void *i
 
 	ret = ltfs_fsraw_open(path, open_write, dentry, priv->vol);
 	if (!ret)
-		ltfs_fsraw_get_dentry(d, priv->vol);
+		ltfs_fsraw_get_dentry(*dentry, priv->vol);
 
 	return ret;
 }
@@ -133,6 +133,8 @@ int fcfs_open(const char *path, bool open_write, struct dentry **dentry, void *i
  */
 int fcfs_close(struct dentry *d, bool flush, void *iosched_handle)
 {
+	struct fcfs_data *priv = (struct fcfs_data *) iosched_handle;
+
 	CHECK_ARG_NULL(d, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(iosched_handle, -LTFS_NULL_ARG);
 

--- a/src/iosched/fcfs.c
+++ b/src/iosched/fcfs.c
@@ -110,13 +110,18 @@ int fcfs_destroy(void *iosched_handle)
  */
 int fcfs_open(const char *path, bool open_write, struct dentry **dentry, void *iosched_handle)
 {
+	int ret;
 	struct fcfs_data *priv = (struct fcfs_data *) iosched_handle;
 
 	CHECK_ARG_NULL(path, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(dentry, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(iosched_handle, -LTFS_NULL_ARG);
 
-	return ltfs_fsraw_open(path, open_write, dentry, priv->vol);
+	ret = ltfs_fsraw_open(path, open_write, dentry, priv->vol);
+	if (!ret)
+		ltfs_fsraw_get_dentry(d, priv->vol);
+
+	return ret;
 }
 
 /**
@@ -130,6 +135,8 @@ int fcfs_close(struct dentry *d, bool flush, void *iosched_handle)
 {
 	CHECK_ARG_NULL(d, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(iosched_handle, -LTFS_NULL_ARG);
+
+	ltfs_fsraw_put_dentry(d, priv->vol);
 
 	return ltfs_fsraw_close(d);
 }

--- a/src/iosched/fcfs.c
+++ b/src/iosched/fcfs.c
@@ -118,7 +118,7 @@ int fcfs_open(const char *path, bool open_write, struct dentry **dentry, void *i
 	CHECK_ARG_NULL(iosched_handle, -LTFS_NULL_ARG);
 
 	ret = ltfs_fsraw_open(path, open_write, dentry, priv->vol);
-	if (!ret)
+	if (ret == 0)
 		ltfs_fsraw_get_dentry(*dentry, priv->vol);
 
 	return ret;

--- a/src/iosched/unified.c
+++ b/src/iosched/unified.c
@@ -1389,8 +1389,6 @@ void _unified_process_data_queue(enum request_state queue, struct unified_data *
 				} else {
 					TAILQ_REMOVE(&dentry_priv->requests, req, list);
 					TAILQ_INSERT_TAIL(&local_req_list, req, list);
-					if (queue != REQUEST_PARTIAL)
-						ltfs_profiler_add_entry(priv->profiler, &priv->proflock, IOSCHED_REQ_EVENT(REQ_IOS_DEQUEUE_DP));
 				}
 			}
 		}
@@ -1761,7 +1759,6 @@ int _unified_update_queue_membership(bool add, bool all, enum request_state queu
 				if (! dentry_priv->write_ip)
 					++priv->dp_request_count;
 				++dentry_priv->in_dp_queue;
-				ltfs_profiler_add_entry(priv->profiler, &priv->proflock, IOSCHED_REQ_EVENT(REQ_IOS_ENQUEUE_DP));
 			} else {
 				if ((all && dentry_priv->in_dp_queue) || dentry_priv->in_dp_queue == 1) {
 					TAILQ_REMOVE(&priv->dp_queue, dentry_priv, dp_queue);
@@ -1787,7 +1784,6 @@ int _unified_update_queue_membership(bool add, bool all, enum request_state queu
 				}
 				++dentry_priv->in_ip_queue;
 				++priv->ip_request_count;
-				ltfs_profiler_add_entry(priv->profiler, &priv->proflock, IOSCHED_REQ_EVENT(REQ_IOS_ENQUEUE_IP));
 			} else {
 				if ((all && dentry_priv->in_ip_queue) || dentry_priv->in_ip_queue == 1) {
 					TAILQ_REMOVE(&priv->ip_queue, dentry_priv, ip_queue);
@@ -1800,7 +1796,6 @@ int _unified_update_queue_membership(bool add, bool all, enum request_state queu
 					--dentry_priv->in_ip_queue;
 					--priv->ip_request_count;
 				}
-				ltfs_profiler_add_entry(priv->profiler, &priv->proflock, IOSCHED_REQ_EVENT(REQ_IOS_DEQUEUE_IP));
 			}
 			break;
 
@@ -1835,6 +1830,8 @@ void _unified_free_request(struct write_request *req, struct unified_data *priv)
 	}
 
 	free(req);
+
+	ltfs_profiler_add_entry(priv->profiler, &priv->proflock, IOSCHED_REQ_EVENT(REQ_IOS_DEL_REQUEST));
 }
 
 /**
@@ -1971,6 +1968,7 @@ ssize_t _unified_insert_new_request(const char *buf, off_t offset, size_t count,
 		dpr->file_size = new_req->offset + new_req->count;
 
 	ltfsmsg(LTFS_DEBUG3, 13031D, new_req);
+	ltfs_profiler_add_entry(priv->profiler, &priv->proflock, IOSCHED_REQ_EVENT(REQ_IOS_ADD_REQUEST));
 
 	return (ssize_t)count;
 }

--- a/src/libltfs/iosched_ops.h
+++ b/src/libltfs/iosched_ops.h
@@ -85,7 +85,6 @@ const char *iosched_get_message_bundle_name(void **message_data);
 /**
  * Request type definisions for LTFS request profile
  */
-
 #define REQ_IOS_OPEN        0000	/**< open */
 #define REQ_IOS_CLOSE       0001	/**< close */
 #define REQ_IOS_READ        0002	/**< read */
@@ -95,9 +94,11 @@ const char *iosched_get_message_bundle_name(void **message_data);
 #define REQ_IOS_GETFSIZE    0006	/**< get_filesize */
 #define REQ_IOS_UPDPLACE    0007	/**< update_data_placement */
 #define REQ_IOS_IOSCHED     0008	/**< (io_scheduler ... _unified_writer_thread) */
-#define REQ_IOS_ENQUEUE_IP  0009	/**< Enqueue data block to IP */
-#define REQ_IOS_DEQUEUE_IP  000A	/**< Dequeue data block to IP */
-#define REQ_IOS_ENQUEUE_DP  000B	/**< Enqueue data block to DP */
-#define REQ_IOS_DEQUEUE_DP  000C	/**< Dequeue data block to DP */
+#define REQ_IOS_ENQUEUE_IP  0009	/**< Enqueue data block to IP (unused at this time) */
+#define REQ_IOS_DEQUEUE_IP  000A	/**< Dequeue data block to IP (unused at this time) */
+#define REQ_IOS_ENQUEUE_DP  000B	/**< Enqueue data block to DP (unused at this time) */
+#define REQ_IOS_DEQUEUE_DP  000C	/**< Dequeue data block to DP (unused at this time) */
+#define REQ_IOS_ADD_REQUEST 000D	/**< Add a request */
+#define REQ_IOS_DEL_REQUEST 000E	/**< Remove a request */
 
 #endif /* __iosched_ops_h */

--- a/src/libltfs/ltfs_fsops.c
+++ b/src/libltfs/ltfs_fsops.c
@@ -340,7 +340,7 @@ int ltfs_fsops_create(const char *path, bool isdir, bool readonly, bool overwrit
 	d->parent = parent;
 	++d->link_count;
 
-	if (!iosched_initialized(vol)) {
+	if (isdir || !iosched_initialized(vol)) {
 		/*
 		 * numhandles will be incremented in iosched_open() below when ioscheduler is
 		 * enabled.
@@ -386,7 +386,7 @@ out_dispose:
 		}
 	}
 
-	if (ret == 0 && iosched_initialized(vol)) {
+	if (!isdir && !ret && iosched_initialized(vol)) {
 		ret = iosched_open(dentry_path, overwrite, &d, vol);
 		if (ret < 0) {
 			fs_release_dentry(d);

--- a/src/ltfs_fuse.c
+++ b/src/ltfs_fuse.c
@@ -162,7 +162,7 @@ static void _free_file_info(struct file_info *fi)
  * @return File handle information, or NULL if memory allocation failed or if 'priv' is NULL.
  */
 static struct file_info *_file_open(const char *path, void *d, struct file_info *spare,
-	struct ltfs_fuse_data *priv)
+									struct ltfs_fuse_data *priv)
 {
 	struct file_info *fi = NULL;
 	CHECK_ARG_NULL(priv, NULL);

--- a/src/tape_drivers/linux/sg/.gitignore
+++ b/src/tape_drivers/linux/sg/.gitignore
@@ -1,4 +1,5 @@
 vendor_compat.c
 ibm_tape.c
 hp_tape.c
+quantum_tape.c
 open_factor.c


### PR DESCRIPTION
# Summary of changes

Change the implementation of flush() request to enqueue the remaining blocks to the writer queue. And make them processed sequentially.

# Description

Previously, our flush operation might flip the final block when we get a small time window below.
 
1. LTFS receives a write and the unified scheduler completes one block and send it to the Q
2. LTFS receives another write
3. LTFS receives a flush
4. LTFS processes the block created in step2 within flush operation (because previous flush stops the writer thread and write blocks directly)
5. The writer thread wake up because of step1 and process the block queued in step1

In this change, all blocks are queued in flush operation and shall be processed by writer thread.
 
- Do not wait the writer thread processes the queued block when flush is called against individual files
- Wait the writer thread processes the queued block when flush is called against all files (like periodical sync request)
 
I believe this strategy improves the LTFS performance in normal condition (little bit make LTFS danger but enough safe, I believe). And LTFS makes a pretty extent in any time.

## Type of change

- Enhancement with long term test

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
