### PR TITLE
Handle error on setting append only mode

### DIFF
--- a/messages/libltfs/root.txt
+++ b/messages/libltfs/root.txt
@@ -807,6 +807,7 @@ v
 		17263I:string { "Sleep was failed while taking the advisory lock '%s' (%d, %d)." }
 		17264W:string { "Index on %s is newer but MAM shows a permanent write error happened on %s." }
 		17265I:string { "Skip writing index because %s." }
+		17266I:string { "Skip to set append only mode because the drive doesn't seem to support it." }
 
 		// For Debug 19999I:string { "%s %s %d." }
 

--- a/src/tape_drivers/osx/iokit/.gitignore
+++ b/src/tape_drivers/osx/iokit/.gitignore
@@ -1,3 +1,4 @@
 vendor_compat.c
 ibm_tape.c
 hp_tape.c
+quantum_tape.c


### PR DESCRIPTION
# Summary of changes

Skip to set append only mode when the drive returns error at setting append only mode.

- Fix of issue #212 

# Description

For now,  just ignore the error (-EDEV_ILLEGAL_REQUEST) from drive against `modeselect` command while setting append only mode. 

We might need to consider to skip to set append only mode cleanly within the backend if required. (At this time HP's LTO5 doesn't support it.)

Fixes #212 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
