### PR TITLE
Do not capture dump when LTFS detects funny MAM

### DIFF
--- a/messages/libltfs/root.txt
+++ b/messages/libltfs/root.txt
@@ -435,7 +435,7 @@ root:table {
 		11338I:string { "Syncing index of %s %s." }
 		11339D:string { "%s volume lock status (%d)." }
 		11340I:string { "Revalidation process is successfully done. (%s)" }
-		11341E:string { "Failed to update the volume lock status to %d (%d)." }
+		//unused 11341E:string { "Failed to update the volume lock status to %d (%d)." }
 		11342E:string { "Failed to get the volume lock status (%d)." }
 		11343I:string { "Try to write an index on IP on %s because of an permanent write error on DP." }
 		11344I:string { "Tape %s is frozen successfully because of an permanent write error on DP." }
@@ -805,7 +805,7 @@ v
 		17260I:string { "Sleep was interrupted by a signal while taking the advisory lock '%s'." }
 		17261I:string { "Kernel detected a false deadlock retry to acquire the advisory lock '%s' (%d)." }
 		17263I:string { "Sleep was failed while taking the advisory lock '%s' (%d, %d)." }
-		17264W:string { "Index on %s is newer but MAM shows a permanent write error happened on %s." }
+		17264I:string { "Index on %s is newer but MAM shows a permanent write error happened on %s." }
 		17265I:string { "Skip writing index because %s." }
 		17266I:string { "Skip to set append only mode because the drive doesn't seem to support it." }
 

--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -1578,14 +1578,23 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 
 		if (vol->ip_coh.count < vol->dp_coh.count) {
 			if (vollock != PWE_MAM_IP && vollock != PWE_MAM) {
-				ltfsmsg(LTFS_WARN, 17264W, "DP", vl_print);
-				tape_takedump_drive(vol->device, false);
+				/*
+				 * The index on DP is newer but MAM shows write perm doesn't happen in IP.
+				 * If LTFS failed to write IP with non-medium reason error (like cable pull on locate)
+				 * while write error handling at DP in the previous session, this condition would happen.
+				 */
+				ltfsmsg(LTFS_INFO, 17264I, "DP", vl_print);
 			}
 			seekpos.partition = ltfs_part_id2num(vol->label->partid_dp, vol);
 			seekpos.block = vol->dp_coh.set_id;
 		} else {
 			if (vollock != PWE_MAM_DP && vollock != PWE_MAM) {
-				ltfsmsg(LTFS_WARN, 17264W, "IP", vl_print);
+				/*
+				 * The index on IP is newer but MAM shows write perm doesn't happen in DP.
+				 * LTFS already have written an index on DP when it is writing an index on IP,
+				 * so this condition wouldn't happen logically.
+				 */
+				ltfsmsg(LTFS_INFO, 17264I, "IP", vl_print);
 				tape_takedump_drive(vol->device, false);
 			}
 			seekpos.partition = ltfs_part_id2num(vol->label->partid_ip, vol);

--- a/src/libltfs/xml_reader_libltfs.c
+++ b/src/libltfs/xml_reader_libltfs.c
@@ -126,7 +126,7 @@ static int decode_entry_name(char **new_name, const char *name)
 				tmp_name[j+1] = buf_decode[0];
 				tmp_name[j+2] = buf_decode[1];
 				j+=2;
-				ltfsmsg(LTFS_ERR, 17256I, name);
+				ltfsmsg(LTFS_INFO, 17256I, name);
 			}
 
 			i+=2;
@@ -145,7 +145,7 @@ static int decode_entry_name(char **new_name, const char *name)
 		 */
 		if (tmp_name[j] == '/' || tmp_name[j] == 0x1f) {
 			tmp_name[j] = '_';
-			ltfsmsg(LTFS_ERR, 17257I, name);
+			ltfsmsg(LTFS_INFO, 17257I, name);
 		}
 
 		j++;


### PR DESCRIPTION
# Summary of changes

LTFS capture drive dump when it detects funny MAM at mount. This code was introduced into PR #210. But we find a condition to make a funny MAM. So remove the code to capture drive dump at that situation.

# Description

In the MAM condition below, LTFS capture drive dump now.

1. MAM shows write perm at DP
2. MAM shows index on DP is the newest (IP shall be the newest)

This situation would happen when some non-medium error happens on IP in
the process of medium error on DP.
Please include relevant motivation and context. List any dependencies that are required for this change.

In addition to logic changes, message cleaning is done in this PR.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
