### PR TITLE
Fix handling when caches is available

### DIFF
--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -2272,7 +2272,6 @@ int ltfs_write_index(char partition, char *reason, struct ltfs_volume *vol)
 	struct ltfs_timespec modtime_old = { .tv_sec = 0, .tv_nsec = 0 };
 	bool generation_inc = false;
 	struct tc_position physical_selfptr;
-	bool immed = false;
 	char *cache_path_save = NULL;
 	bool write_perm = (strcmp(reason, SYNC_WRITE_PERM) == 0);
 	bool update_vollock = false;
@@ -2445,24 +2444,6 @@ int ltfs_write_index(char partition, char *reason, struct ltfs_volume *vol)
 	ret = xml_schema_to_tape(reason, vol);
 	if (ret < 0) {
 		ltfsmsg(LTFS_ERR, 11083E, ret);
-		if (generation_inc) {
-			vol->index->mod_time = modtime_old;
-			--vol->index->generation;
-		}
-		vol->index->backptr = old_backptr;
-		vol->index->selfptr = old_selfptr;
-
-		if (IS_WRITE_PERM(-ret))
-			update_vollock = true;
-
-		goto out_write_perm;
-	}
-
-	/* WFM immed @ format */
-	immed = (strcmp(reason, SYNC_FORMAT) == 0);
-	ret = tape_write_filemark(vol->device, 1, true, true, immed);
-	if (ret < 0) {
-		ltfsmsg(LTFS_ERR, 11084E, ret);
 		if (generation_inc) {
 			vol->index->mod_time = modtime_old;
 			--vol->index->generation;


### PR DESCRIPTION
# Summary of changes

This commit fixes the case about cache handling when a write error happens at writing following FM of an index.

Previous code might propagate files to be synced even if last index would be partial. Because WRITEFM command against the following FM of index means drive can't flush the buffered data completely. So the files only in the last index would lost at next mount.

# Description

Move the WRITEFM command handling to xml_schema_to_tape(). And propagate the caches when the command is successfully done.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
