### PR TITLE
Tiny corrction of value initalize

### DIFF
--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2.7
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 #
 #  OO_Copyright_BEGIN

--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -368,7 +368,8 @@ if len(args.SOURCE) == 0:
     for line in sys.stdin:
         args.SOURCE.append(line.rstrip('\r\n'))
     logger.log(NOTSET + 1, 'Source: {}'.format(args.SOURCE))
-else:
+
+if args.keep_tree is None:
     args.keep_tree = ''
 
 # Create the list of copy item


### PR DESCRIPTION
There are 2 changes on `ltfs-ordered_copy`

1. Change python interpreter from python 2.7 to system default
2. Fix NonType error