### PR TITLE
Fix build break in FreeBSD

### DIFF
--- a/src/libltfs/fs.c
+++ b/src/libltfs/fs.c
@@ -263,7 +263,7 @@ struct dentry * fs_allocate_dentry(struct dentry *parent, const char *name, cons
 		d->platform_safe_name = NULL;
 	} else if (name && !platform_safe_name) {
 		d->name.name = strdup(name);
-		update_platform_safe_name(d, FALSE, idx);
+		update_platform_safe_name(d, false, idx);
 		if (! d->name.name || ! d->platform_safe_name) {
 			ltfsmsg(LTFS_ERR, 10001E, "fs_allocate_dentry: name");
 			if (d->name.name)

--- a/src/tape_drivers/freebsd/cam/Makefile.am
+++ b/src/tape_drivers/freebsd/cam/Makefile.am
@@ -41,8 +41,8 @@ BASENAMES = libtape-cam
 AM_LIBTOOLFLAGS = --tag=disable-static
 
 libtape_cam_la_SOURCES = cam_cmn.c cam_tc.c vendor_compat.c ibm_tape.c hp_tape.c quantum_tape.c
-libtape_cam_la_DEPENDENCIES = ../../../../messages/libtape_freebsd_cam_dat.a ../../../libltfs/libltfs.la libtape_cam_la-reed_solomon_crc.lo libtape_cam_la-crc32c_crc.lo libtape_cam_la-ibm_tape.lo
-libtape_cam_la_LIBADD = ../../../libltfs/libltfs.la ./libtape_cam_la-reed_solomon_crc.lo ./libtape_cam_la-crc32c_crc.lo ./libtape_cam_la-ibm_tape.lo
+libtape_cam_la_DEPENDENCIES = ../../../../messages/libtape_freebsd_cam_dat.a ../../../libltfs/libltfs.la libtape_cam_la-reed_solomon_crc.lo libtape_cam_la-crc32c_crc.lo 
+libtape_cam_la_LIBADD = ../../../libltfs/libltfs.la ./libtape_cam_la-reed_solomon_crc.lo ./libtape_cam_la-crc32c_crc.lo 
 libtape_cam_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ -L../../../../messages -ltape_freebsd_cam_dat
 libtape_cam_la_CPPFLAGS = @AM_CPPFLAGS@ -I ../../.. -I ../..
 


### PR DESCRIPTION
# Summary of changes

Fix build break on FreeBSD.

# Description

Previous `Makefile.am` tries to link a same object file twice. So linker reports a multiple objects error.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
