### PR TITLE
Handle write-perm on LOCATE correctly

### DIFF
--- a/messages/internal_error/root.txt
+++ b/messages/internal_error/root.txt
@@ -251,6 +251,7 @@ root:table {
 		I1198E:string{ "The tape is already removed." }
 		I1199E:string{ "You need to move tape to a storage slot first before the operation." }
 		I1200E:string{ "The operation needs to be started again." }
+		I1201E:string{ "Locate returns write-perm error." }
 
 		// Special error codes
 		I9997E:string{ "Child process error (ltfsck/mkltfs): %s (%d)." }

--- a/messages/libltfs/root.txt
+++ b/messages/libltfs/root.txt
@@ -808,6 +808,7 @@ v
 		17264I:string { "The index on %s is newer, but MAM shows a permanent write error happened on %s." }
 		17265I:string { "Skip writing the index because of %s." }
 		17266I:string { "Skip setting the append only mode because the drive doesn't seem to support it." }
+		17267E:string { "Locate command returns write-perm error (%d). Replace a return code to %d." }
 
 		// For Debug 19999I:string { "%s %s %d." }
 

--- a/src/libltfs/arch/errormap.c
+++ b/src/libltfs/arch/errormap.c
@@ -286,6 +286,7 @@ static struct error_map fuse_error_list[] = {
 	{ LTFS_TAPE_REMOVED,             "I1198E", EIDRM},
 	{ LTFS_NEED_MOVE,                "I1199E", EINVAL},
 	{ LTFS_NEED_START_OVER,          "I1200E", EINVAL},
+	{ LTFS_LOCATE_ERROR,             "I1201E", EIO},
 
 	{ EDEV_NO_SENSE,                 "D0000E", EIO},
 	{ EDEV_OVERRUN,                  "D0002E", EIO},

--- a/src/libltfs/ltfs_error.h
+++ b/src/libltfs/ltfs_error.h
@@ -257,6 +257,7 @@
 #define LTFS_TAPE_REMOVED         1198  /* The tape is already removed */
 #define LTFS_NEED_MOVE            1199  /* Need to move tape to a storage slot first before the operation */
 #define LTFS_NEED_START_OVER      1200  /* Need operation needs to be started again */
+#define LTFS_LOCATE_ERROR         1201  /* Locate returns write-perm error */
 
 #define LTFS_ERR_MAX              19999
 


### PR DESCRIPTION
# Summary of changes

Override the error code to `LTFS_LOCATE_ERROR` when tape backend's `locate()` call returns write-perm error.

# Description

On #232, LTFS could remove files automatically when tape backend's `locate()` call returns write-perm error even if It is not necessary. But I believe this is so rare like breaking H/W.

Fixes #232

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
