### PR TITLE
ltfs_ordered_copy: honor `--keep-tree` for single file copies

### DIFF
--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -338,6 +338,12 @@ if args.recursive == False and len(args.SOURCE) == 1:
     logger.log(NOTSET + 1, 'Single file copy')
     if os.path.isfile(args.SOURCE[0]):
         try:
+            if len(args.keep_tree):
+                dst = args.DEST + '/' + args.SOURCE[0][len(args.keep_tree):]
+                args.DEST = os.path.normpath(dst)
+                (new_d, t) = os.path.split(dst)
+                if not os.path.exists(new_d):
+                    os.makedirs(new_d)
             shutil.copy(args.SOURCE[0], args.DEST)
         except Exception as e:
             logger.error(str(e))


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Add `--keep-tree` support for single file copies

# Description

Single file copies did not honor the `--keep-tree` flag so would always end up in the destination folder regardless of tree depth of source. This changes makes it possible to copy a single file with the tree preserved. It reuses the same logic that is used for multi-file copies.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works
