### PR TITLE
Support another Quantum drive

### DIFF
--- a/messages/tape_iokit/root.txt
+++ b/messages/tape_iokit/root.txt
@@ -115,6 +115,7 @@ root:table {
 		30868I:string { "Retry to reserve from key registration (%s)" }
 		30869W:string { "The drive is already reserved: %s (%s)" }
 		30870I:string { "Failed to get the cartridge status. The cartridge is not loaded." }
+		30871W:string { "Failed to get medium type code: medium type check is skipped." }
 
 		30992D:string { "Backend %s %s." }
 		30993D:string { "Backend %s: %d %s." }

--- a/src/tape_drivers/freebsd/cam/cam_tc.c
+++ b/src/tape_drivers/freebsd/cam/cam_tc.c
@@ -1133,14 +1133,19 @@ int camtape_load(void *device, struct tc_position *pos)
 	softc->force_readperm  = DEFAULT_READPERM;
 	softc->write_counter = 0;
 	softc->read_counter = 0;
-	softc->cart_type = buf[2];
 	softc->density_code = buf[8];
 
-	if (softc->vendor == VENDOR_HP) {
-		softc->cart_type = assume_cart_type(softc->density_code);
+	if (buf[2] == 0x00 || buf[2] == 0x01) {
+		/*
+		 * Non-IBM drive doesn't have cartridge type so need to assume from density code.
+		 */
+		softc->cart_type = assume_cart_type(priv->density_code);
 		if (buf[2] == 0x01)
 			softc->is_worm = true;
 	} else {
+		/*
+		 * IBM drive haves cartridge type in buf[2] like TC_MP_LTO5D_CART.
+		 */
 		softc->cart_type = buf[2];
 	}
 

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -2595,11 +2595,17 @@ int sg_load(void *device, struct tc_position *pos)
 
 	priv->density_code = buf[8];
 
-	if (priv->vendor == VENDOR_HP) {
+	if (buf[2] == 0x00 || buf[2] == 0x01) {
+		/*
+		 * Non-IBM drive doesn't have cartridge type so need to assume from density code.
+		 */
 		priv->cart_type = assume_cart_type(priv->density_code);
 		if (buf[2] == 0x01)
 			priv->is_worm = true;
 	} else {
+		/*
+		 * IBM drive haves cartridge type in buf[2] like TC_MP_LTO5D_CART.
+		 */
 		priv->cart_type = buf[2];
 	}
 

--- a/src/tape_drivers/quantum_tape.c
+++ b/src/tape_drivers/quantum_tape.c
@@ -67,6 +67,7 @@ struct supported_device *quantum_supported_drives[] = {
 	TAPEDRIVE( QUANTUM_VENDOR_ID, "ULTRIUM-HH6",  DRIVE_LTO6_HH, "[ULTRIUM-HH6]" ),  /* QUANTUM Ultrium Gen 6 Half-High */
 	TAPEDRIVE( QUANTUM_VENDOR_ID, "ULTRIUM-HH7",  DRIVE_LTO7_HH, "[ULTRIUM-HH7]" ),  /* QUANTUM Ultrium Gen 7 Half-High */
 	TAPEDRIVE( QUANTUM_VENDOR_ID, "ULTRIUM-HH8",  DRIVE_LTO8_HH, "[ULTRIUM-HH8]" ),  /* QUANTUM Ultrium Gen 8 Half-High */
+	TAPEDRIVE( QUANTUM_VENDOR_ID, "ULTRIUM 5",    DRIVE_LTO5_HH, "[ULTRIUM-5]" ),    /* Another QUANTUM Ultrium Gen 5 Half-High */
 	/* End of supported_devices */
 	NULL
 };


### PR DESCRIPTION
# Summary of changes

Support another Quantum drive `'QUANTUM ' / 'ULTRIUM 5       '`

- Fix of issue #245

# Description

It looks Quantum has 2 types of LTO5 drive. One is `QUANTUM/ULTRIUM 5` the other is `QUANTUM/ULTRIUM-HH5`. `QUANTUM/ULTRIUM 5` is supported into this PR.

Fixes #245 

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
