### PR TITLE
Fix remaining capacity handling of HP LTO6

### DIFF
--- a/src/tape_drivers/freebsd/cam/cam_tc.c
+++ b/src/tape_drivers/freebsd/cam/cam_tc.c
@@ -1766,7 +1766,9 @@ int camtape_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 	int rc;
 
 	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_REMAINCAP));
-	if (IS_LTO(softc->drive_type) && (DRIVE_GEN(softc->drive_type) == 0x05)) {
+	if ((IS_LTO(softc->drive_type) && (DRIVE_GEN(softc->drive_type) == 0x05)) ||
+		(softc->vendor == VENDOR_HP && IS_LTO(softc->drive_type) && (DRIVE_GEN(softc->drive_type) == 0x06))) {
+
 		/* Issue LogPage 0x31 */
 		rc = camtape_logsense(device, LOG_TAPECAPACITY, logdata, LOGSENSEPAGE);
 		if (rc) {

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -2873,7 +2873,9 @@ int sg_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 
 	memset(buffer, 0, LOGSENSEPAGE);
 
-	if (IS_LTO(priv->drive_type) && (DRIVE_GEN(priv->drive_type) == 0x05)) {
+	if ((IS_LTO(priv->drive_type) && (DRIVE_GEN(priv->drive_type) == 0x05)) ||
+		(priv->vendor == VENDOR_HP && IS_LTO(priv->drive_type) && (DRIVE_GEN(priv->drive_type) == 0x06))) {
+
 		/* Use LogPage 0x31 */
 		ret = sg_logsense(device, (uint8_t)LOG_TAPECAPACITY, (void *)buffer, LOGSENSEPAGE);
 		if(ret < 0)

--- a/src/tape_drivers/osx/iokit/iokit_tape.c
+++ b/src/tape_drivers/osx/iokit/iokit_tape.c
@@ -2216,7 +2216,9 @@ int iokit_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 
 	memset(&buffer, 0, LOGSENSEPAGE);
 
-	if (IS_LTO(priv->drive_type) && (DRIVE_GEN(priv->drive_type) == 0x05)) {
+	if ((IS_LTO(priv->drive_type) && (DRIVE_GEN(priv->drive_type) == 0x05)) ||
+		(priv->vendor == VENDOR_HP && IS_LTO(priv->drive_type) && (DRIVE_GEN(priv->drive_type) == 0x06))) {
+
 		/* Use LogPage 0x31 */
 		ret = iokit_logsense(device, (uint8_t)LOG_TAPECAPACITY, (void *)buffer, LOGSENSEPAGE);
 		if(ret < 0)


### PR DESCRIPTION
# Summary of changes

Fix how to get remaining capacity on HP LTO6.

- Fix of issue #241 

# Description

It looks HP LTO6 doesn't support LP17h. So this fix uses LP31h instead like IBM/HP LTO5.

Fixes #241 

## Type of change

Please delete items that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
