### PR TITLE
Introduce generic logselect issue I/F via EA

### DIFF
--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -4040,8 +4040,36 @@ int ltfs_release_medium(struct ltfs_volume *vol)
 }
 
 /**
+ * Capture log page.
+ *
+ * At buffer shortage, this function returns the length of the page. The page is truncated
+ * by size.
+ *
+ * @param vol LTFS volume
+ * @param page log page to capture
+ * @param subpage subpage to capture
+ * @param buf buffer of the contents of logpage
+ * @param size buffer size
+ * @return page length on success or a negative value on error
+ */
+int ltfs_logpage(const uint8_t page, const uint8_t subpage, unsigned char *buf,
+				 const size_t size, struct ltfs_volume *vol)
+{
+	int ret = -EDEV_UNKNOWN;
+
+	if (vol->device) {
+		tape_device_lock(vol->device);
+		ret = tape_logsense(vol->device, page, subpage, buf, size);
+		tape_device_unlock(vol->device);
+	}
+
+	return ret;
+}
+
+/**
  * Wait the drive goes to ready state
- * @param device handle to tape device
+ *
+ * @param vol LTFS volume
  * @return 0 on success or a negative value on error
  */
 int ltfs_wait_device_ready(struct ltfs_volume *vol)

--- a/src/libltfs/ltfs.h
+++ b/src/libltfs/ltfs.h
@@ -672,7 +672,6 @@ void ltfs_unset_index_dirty(bool update_version, struct ltfs_index *idx);
 int ltfs_write_index(char partition, char *reason, struct ltfs_volume *vol);
 int ltfs_save_index_to_disk(const char *work_dir, char * reason, bool need_gen, struct ltfs_volume *vol);
 
-
 char ltfs_dp_id(struct ltfs_volume *vol);
 char ltfs_ip_id(struct ltfs_volume *vol);
 const char *ltfs_get_volume_uuid(struct ltfs_volume *vol);
@@ -688,6 +687,8 @@ int ltfs_traverse_index_no_eod(struct ltfs_volume *vol, char partition, unsigned
 int ltfs_check_eod_status(struct ltfs_volume *vol);
 int ltfs_recover_eod(struct ltfs_volume *vol);
 int ltfs_release_medium(struct ltfs_volume *vol);
+int ltfs_logpage(const uint8_t page, const uint8_t subpage, unsigned char *buf,
+				 const size_t size, struct ltfs_volume *vol);
 int ltfs_wait_device_ready(struct ltfs_volume *vol);
 void ltfs_recover_eod_simple(struct ltfs_volume *vol);
 

--- a/src/libltfs/tape.c
+++ b/src/libltfs/tape.c
@@ -2611,6 +2611,18 @@ out:
 	return ret;
 }
 
+int tape_logsense(struct device_data *dev, const uint8_t page, const uint8_t subpage,
+				  unsigned char *buf, const size_t size)
+{
+	int ret = -EDEV_UNKNOWN;
+
+	CHECK_ARG_NULL(dev, -LTFS_NULL_ARG);
+
+	ret = dev->backend->logsense(dev->backend_data, page, subpage, buf, size);
+
+	return ret;
+}
+
 /**
  * Wait the drive goes to ready state
  * @param device handle to tape device

--- a/src/libltfs/tape.h
+++ b/src/libltfs/tape.h
@@ -203,6 +203,8 @@ int tape_enable_append_only_mode(struct device_data *dev, bool enable);
 int tape_get_append_only_mode_setting(struct device_data *dev, bool *enabled);
 
 int tape_is_cartridge_loadable(struct device_data *dev);
+int tape_logsense(struct device_data *dev, const uint8_t page, const uint8_t subpage,
+				  unsigned char *buf, const size_t size);
 int tape_wait_device_ready(struct device_data *dev, void * const kmi_handle);
 int tape_set_key(struct device_data *dev, const unsigned char *keyalias, const unsigned char *key);
 int tape_clear_key(struct device_data *device, void * const kmi_handle);

--- a/src/libltfs/tape_ops.h
+++ b/src/libltfs/tape_ops.h
@@ -581,6 +581,7 @@ struct tape_ops {
 
 	/**
 	 * Get capacity data from a device.
+	 *
 	 * @param device Device handle returned by the backend's open().
 	 * @param cap On success, the backend must fill this structure with the total and remaining
 	 *            capacity values of the two partitions on the medium, in units of 1048576 bytes.
@@ -590,16 +591,17 @@ struct tape_ops {
 
 	/**
 	 * Send a SCSI Log Sense command to a device.
-	 * libltfs does not currently use this function, but it may be useful internally (for example,
-	 * ibmtape uses it from its remaining_capacity() function).
+	 *
 	 * @param device Device handle returned by the backend's open().
 	 * @param page Log page to query.
+	 * @param subpage Specify the sub page of the log page to query.
 	 * @param buf On success, the backend must fill this buffer with the log page's value.
 	 * @param size Buffer size.
-	 * @return 0 on success or a negative value on error. Backends for which Log Sense is
+	 * @return Page length on success or a negative value on error. Backends for which Log Sense is
 	 *         meaningless should return -1.
 	 */
-	int   (*logsense)(void *device, const uint8_t page, unsigned char *buf, const size_t size);
+	int   (*logsense)(void *device, const uint8_t page, const uint8_t subpage,
+					  unsigned char *buf, const size_t size);
 
 	/**
 	 * Send a SCSI Mode Sense(10) command to a device.

--- a/src/tape_drivers/freebsd/cam/cam_tc.c
+++ b/src/tape_drivers/freebsd/cam/cam_tc.c
@@ -1681,8 +1681,8 @@ bailout:
  */
 #define MAX_UINT16 (0x0000FFFF)
 
-int camtape_logsense_page(struct camtape_data *softc, const uint8_t page, const uint8_t subpage,
-						  unsigned char *buf, const size_t size)
+int camtape_logsense(struct camtape_data *softc, const uint8_t page, const uint8_t subpage,
+					 unsigned char *buf, const size_t size)
 {
 	int rc = DEVICE_GOOD;
 	char *msg = NULL;
@@ -1690,8 +1690,15 @@ int camtape_logsense_page(struct camtape_data *softc, const uint8_t page, const 
 	union ccb *ccb = NULL;
 	int timeout;
 
-	ltfsmsg(LTFS_DEBUG3, 31397D, "logsense", (unsigned long long)page, (unsigned long long)subpage,
-			softc->drive_serial);
+	unsigned char *inner_buf = NULL;
+
+	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOGSENSE));
+	ltfsmsg(LTFS_DEBUG3, 31397D, "logsense",
+			(unsigned long long)page, (unsigned long long)subpage, softc->drive_serial);
+
+	inner_buf = calloc(1, MAXLP_SIZE); /* Assume max length of LP is 1MB */
+	if (!inner_buf)
+		return -LTFS_NO_MEMORY;
 
 	ccb = cam_getccb(softc->cd);
 	if (ccb == NULL) {
@@ -1717,8 +1724,8 @@ int camtape_logsense_page(struct camtape_data *softc, const uint8_t page, const 
 				   /*save_pages*/ 0,
 				   /*ppc*/ 0,
 				   /*paramptr*/ 0,
-				   /*param_buf*/ buf,
-				   /*param_len*/ size,
+				   /*param_buf*/ inner_buf,
+				   /*param_len*/ MAXLP_SIZE,
 				   /*sense_len*/ SSD_FULL_SIZE,
 				   /*timeout*/ timeout);
 	/*
@@ -1733,23 +1740,25 @@ int camtape_logsense_page(struct camtape_data *softc, const uint8_t page, const 
 
 	if (rc != DEVICE_GOOD)
 		camtape_process_errors(softc, rc, msg, "logsense page", true);
+	else {
+		if (size > (ccb->csio.dxfer_len - ccb->csio.resid))
+			memcpy(buf, inner_buf, (ccb->csio.dxfer_len - ccb->csio.resid));
+		else
+			memcpy(buf, inner_buf, size);
+
+		ret = ccb->csio.dxfer_len - ccb->csio.resid;
+	}
 
 bailout:
+	if (inner_buf != NULL)
+		free(inner_buf);
+
 	if (ccb != NULL)
 		cam_freeccb(ccb);
 
-	return rc;
-}
-
-int camtape_logsense(void *device, const uint8_t page, unsigned char *buf, const size_t size)
-{
-	struct camtape_data *softc = (struct camtape_data *)device;
-	int ret = 0;
-
-	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOGSENSE));
-	ret = camtape_logsense_page(softc, page, 0, buf, size);
 	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOGSENSE));
-	return ret;
+
+	return rc;
 }
 
 #define PARTITIOIN_REC_HEADER_LEN (4)
@@ -1768,8 +1777,8 @@ int camtape_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_REMAINCAP));
 	if (IS_LTO(softc->drive_type) && (DRIVE_GEN(softc->drive_type) == 0x05)) {
 		/* Issue LogPage 0x31 */
-		rc = camtape_logsense(device, LOG_TAPECAPACITY, logdata, LOGSENSEPAGE);
-		if (rc) {
+		rc = camtape_logsense(device, LOG_TAPECAPACITY, (uint8_t)0, logdata, LOGSENSEPAGE);
+		if (rc < 0) {
 			ltfsmsg(LTFS_INFO, 31257I, LOG_TAPECAPACITY, rc);
 			ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REMAINCAP));
 			return rc;
@@ -1808,8 +1817,8 @@ int camtape_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 	}
 	else {
 		/* Issue LogPage 0x17 */
-		rc = camtape_logsense(device, LOG_VOLUMESTATS, logdata, LOGSENSEPAGE);
-		if (rc) {
+		rc = camtape_logsense(device, LOG_VOLUMESTATS, (uint8_t)0, logdata, LOGSENSEPAGE);
+		if (rc < 0) {
 			ltfsmsg(LTFS_INFO, 31257I, LOG_VOLUMESTATS, rc);
 			ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REMAINCAP));
 			return rc;
@@ -2460,8 +2469,8 @@ int camtape_get_cartridge_health(void *device, struct tc_cartridge_health *cart_
 
 	/* Issue LogPage 0x37 */
 	cart_health->tape_efficiency  = UNSUPPORTED_CARTRIDGE_HEALTH;
-	rc = camtape_logsense(device, LOG_PERFORMANCE, logdata, LOGSENSEPAGE);
-	if (rc)
+	rc = camtape_logsense(device, LOG_PERFORMANCE, (uint8_t)0, logdata, LOGSENSEPAGE);
+	if (rc < 0)
 		ltfsmsg(LTFS_INFO, 31261I, LOG_PERFORMANCE, rc, "get cart health");
 	else {
 		for(i = 0; i < (int)((sizeof(perfstats)/sizeof(perfstats[0]))); i++) { /* BEAM: loop doesn't iterate - Use loop for future enhancement. */
@@ -2511,8 +2520,9 @@ int camtape_get_cartridge_health(void *device, struct tc_cartridge_health *cart_
 	cart_health->read_mbytes      = UNSUPPORTED_CARTRIDGE_HEALTH;
 	cart_health->passes_begin     = UNSUPPORTED_CARTRIDGE_HEALTH;
 	cart_health->passes_middle    = UNSUPPORTED_CARTRIDGE_HEALTH;
-	rc = camtape_logsense(device, LOG_VOLUMESTATS, logdata, LOGSENSEPAGE);
-	if (rc)
+
+	rc = camtape_logsense(device, LOG_VOLUMESTATS, (uint8_t)0, logdata, LOGSENSEPAGE);
+	if (rc < 0)
 		ltfsmsg(LTFS_INFO, 31261I, LOG_VOLUMESTATS, rc, "get cart health");
 	else {
 		for(i = 0; i < (int)((sizeof(volstats)/sizeof(volstats[0]))); i++) {
@@ -2608,10 +2618,11 @@ int camtape_get_tape_alert(void *device, uint64_t *tape_alert)
 	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_GETTAPEALT));
 	/* Issue LogPage 0x2E */
 	ta = 0;
-	rc = camtape_logsense(device, LOG_TAPE_ALERT, logdata, LOGSENSEPAGE);
-	if (rc)
+	rc = camtape_logsense(device, LOG_TAPE_ALERT, (uint8_t)0, logdata, LOGSENSEPAGE);
+	if (rc < 0)
 		ltfsmsg(LTFS_INFO, 31261I, LOG_TAPE_ALERT, rc, "get tape alert");
 	else {
+		rc = 0;
 		for(i = 1; i <= 64; i++) {
 			if (parse_logPage(logdata, (uint16_t) i, &param_size, buf, 16)
 				|| param_size != sizeof(uint8_t)) {
@@ -3058,8 +3069,8 @@ int camtape_get_eod_status(void *device, int part)
 
 	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_GETEODSTAT));
 	/* Issue LogPage 0x17 */
-	rc = camtape_logsense(device, LOG_VOL_STATISTICS, logdata, LOGSENSEPAGE);
-	if (rc) {
+	rc = camtape_logsense(device, LOG_VOL_STATISTICS, (uint8_t)0, logdata, LOGSENSEPAGE);
+	if (rc < 0) {
 		ltfsmsg(LTFS_WARN, 31264W, LOG_VOL_STATISTICS, rc);
 		ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETEODSTAT));
 		return EOD_UNKNOWN;
@@ -3127,11 +3138,12 @@ int camtape_get_xattr(void *device, const char *name, char **buf)
 		get_current_timespec(&now);
 		if ( softc->fetch_sec_acq_loss_w == 0 ||
 			 ((softc->fetch_sec_acq_loss_w + 60 < now.tv_sec) && softc->dirty_acq_loss_w)) {
-			rc = camtape_logsense_page(device, LOG_PERFORMANCE, LOG_PERFORMANCE_CAPACITY_SUB,
-									   logdata, LOGSENSEPAGE);
-			if (rc)
+			rc = camtape_logsense(device, LOG_PERFORMANCE, LOG_PERFORMANCE_CAPACITY_SUB,
+								  logdata, LOGSENSEPAGE);
+			if (rc < 0)
 				ltfsmsg(LTFS_INFO, 31261I, LOG_PERFORMANCE, rc, "get xattr");
 			else {
+				rc = 0;
 				if (parse_logPage(logdata, PERF_ACTIVE_CQ_LOSS_W, &param_size, logbuf, 16)) {
 					ltfsmsg(LTFS_INFO, 31262I, LOG_PERFORMANCE, "get xattr");
 					rc = -LTFS_NO_XATTR;

--- a/src/tape_drivers/generic/file/filedebug_tc.c
+++ b/src/tape_drivers/generic/file/filedebug_tc.c
@@ -1906,7 +1906,7 @@ int filedebug_set_xattr(void *device, const char *name, const char *buf, size_t 
 	return ret;
 }
 
-int filedebug_logsense(void *device, const uint8_t page, unsigned char *buf, const size_t size)
+int filedebug_logsense(void *device, const uint8_t page, const uint8_t subpage, unsigned char *buf, const size_t size)
 {
 	ltfsmsg(LTFS_ERR, 10007E, __FUNCTION__);
 	return -EDEV_UNSUPPORTED_FUNCTION;

--- a/src/tape_drivers/generic/itdtimg/itdtimg_tc.c
+++ b/src/tape_drivers/generic/itdtimg/itdtimg_tc.c
@@ -857,7 +857,7 @@ int itdtimage_set_xattr(void *device, const char *name, const char *buf, size_t 
 	return -LTFS_NO_XATTR;
 }
 
-int itdtimage_logsense(void *device, const uint8_t page, unsigned char *buf, const size_t size)
+int itdtimage_logsense(void *device, const uint8_t page, const uint8_t subpage, unsigned char *buf, const size_t size)
 {
 	ltfsmsg(LTFS_ERR, 10007E, __FUNCTION__);
 	return -EDEV_UNSUPPORTED_FUNCTION;

--- a/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
+++ b/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
@@ -2208,13 +2208,14 @@ int lin_tape_ibmtape_format(void *device, TC_FORMAT_TYPE format, const char *vol
  */
 #define MAX_UINT16 (0x0000FFFF)
 
-int lin_tape_ibmtape_logsense_page(void *device, const uint8_t page, const uint8_t subpage,
-						  unsigned char *buf, const size_t size)
+int lin_tape_ibmtape_logsense(void *device, const uint8_t page, const uint8_t subpage,
+							  unsigned char *buf, const size_t size)
 {
 	int rc;
 	char *msg;
 	struct log_sense10_page log_page;
 
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOGSENSE));
 	ltfsmsg(LTFS_DEBUG3, 30597D, "logsense", (unsigned long long)page, (unsigned long long)subpage,
 			((struct lin_tape_ibmtape *) device)->drive_serial);
 
@@ -2228,23 +2229,13 @@ int lin_tape_ibmtape_logsense_page(void *device, const uint8_t page, const uint8
 
 	if (rc != DEVICE_GOOD) {
 		lin_tape_ibmtape_process_errors(device, rc, msg, "logsense page", true);
-	}
-	else {
+	} else {
 		memcpy(buf, log_page.data, size);
 	}
 
-	return rc;
-}
-
-int lin_tape_ibmtape_logsense(void *device, const uint8_t page, unsigned char *buf, const size_t size)
-{
-	int ret = 0;
-	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
-
-	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOGSENSE));
-	ret = lin_tape_ibmtape_logsense_page(device, page, 0, buf, size);
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOGSENSE));
-	return ret;
+
+	return rc;
 }
 
 /**
@@ -2269,7 +2260,7 @@ int lin_tape_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *c
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_REMAINCAP));
 	if (IS_LTO(priv->drive_type) && (DRIVE_GEN(priv->drive_type) == 0x05)) {
 		/* Issue LogPage 0x31 */
-		rc = lin_tape_ibmtape_logsense(device, LOG_TAPECAPACITY, logdata, LOGSENSEPAGE);
+		rc = lin_tape_ibmtape_logsense(device, LOG_TAPECAPACITY, (uint8_t)0, logdata, LOGSENSEPAGE);
 		if (rc) {
 			ltfsmsg(LTFS_INFO, 30457I, LOG_TAPECAPACITY, rc);
 			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REMAINCAP));
@@ -2309,7 +2300,7 @@ int lin_tape_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *c
 	}
 	else {
 		/* Issue LogPage 0x17 */
-		rc = lin_tape_ibmtape_logsense(device, LOG_VOLUMESTATS, logdata, LOGSENSEPAGE);
+		rc = lin_tape_ibmtape_logsense(device, LOG_VOLUMESTATS, (uint8_t)0, logdata, LOGSENSEPAGE);
 		if (rc) {
 			ltfsmsg(LTFS_INFO, 30457I, LOG_VOLUMESTATS, rc);
 			ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_REMAINCAP));
@@ -2904,7 +2895,7 @@ int lin_tape_ibmtape_get_cartridge_health(void *device, struct tc_cartridge_heal
 
 	/* Issue LogPage 0x37 */
 	cart_health->tape_efficiency  = UNSUPPORTED_CARTRIDGE_HEALTH;
-	rc = lin_tape_ibmtape_logsense(device, LOG_PERFORMANCE, logdata, LOGSENSEPAGE);
+	rc = lin_tape_ibmtape_logsense(device, LOG_PERFORMANCE, (uint8_t)0, logdata, LOGSENSEPAGE);
 	if (rc)
 		ltfsmsg(LTFS_INFO, 30461I, LOG_PERFORMANCE, rc, "get cart health");
 	else {
@@ -2955,7 +2946,8 @@ int lin_tape_ibmtape_get_cartridge_health(void *device, struct tc_cartridge_heal
 	cart_health->read_mbytes      = UNSUPPORTED_CARTRIDGE_HEALTH;
 	cart_health->passes_begin     = UNSUPPORTED_CARTRIDGE_HEALTH;
 	cart_health->passes_middle    = UNSUPPORTED_CARTRIDGE_HEALTH;
-	rc = lin_tape_ibmtape_logsense(device, LOG_VOLUMESTATS, logdata, LOGSENSEPAGE);
+
+	rc = lin_tape_ibmtape_logsense(device, LOG_VOLUMESTATS, (uint8_t)0, logdata, LOGSENSEPAGE);
 	if (rc)
 		ltfsmsg(LTFS_INFO, 30461I, LOG_VOLUMESTATS, rc, "get cart health");
 	else {
@@ -3052,7 +3044,7 @@ int lin_tape_ibmtape_get_tape_alert(void *device, uint64_t *tape_alert)
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_GETTAPEALT));
 	/* Issue LogPage 0x2E */
 	ta = 0;
-	rc = lin_tape_ibmtape_logsense(device, LOG_TAPE_ALERT, logdata, LOGSENSEPAGE);
+	rc = lin_tape_ibmtape_logsense(device, LOG_TAPE_ALERT, (uint8_t)0, logdata, LOGSENSEPAGE);
 	if (rc)
 		ltfsmsg(LTFS_INFO, 30461I, LOG_TAPE_ALERT, rc, "get tape alert");
 	else {
@@ -3393,7 +3385,7 @@ int lin_tape_ibmtape_get_eod_status(void *device, int part)
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_GETEODSTAT));
 	/* Issue LogPage 0x17 */
-	rc = lin_tape_ibmtape_logsense(device, LOG_VOL_STATISTICS, logdata, LOGSENSEPAGE);
+	rc = lin_tape_ibmtape_logsense(device, LOG_VOL_STATISTICS, (uint8_t)0, logdata, LOGSENSEPAGE);
 	if (rc) {
 		ltfsmsg(LTFS_WARN, 30464W, LOG_VOL_STATISTICS, rc);
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETEODSTAT));
@@ -3462,8 +3454,8 @@ int lin_tape_ibmtape_get_xattr(void *device, const char *name, char **buf)
 		get_current_timespec(&now);
 		if ( priv->fetch_sec_acq_loss_w == 0 ||
 			 ((priv->fetch_sec_acq_loss_w + 60 < now.tv_sec) && priv->dirty_acq_loss_w)) {
-			rc = lin_tape_ibmtape_logsense_page(device, LOG_PERFORMANCE, LOG_PERFORMANCE_CAPACITY_SUB,
-									   logdata, LOGSENSEPAGE);
+			rc = lin_tape_ibmtape_logsense(device, LOG_PERFORMANCE, LOG_PERFORMANCE_CAPACITY_SUB,
+										   logdata, LOGSENSEPAGE);
 			if (rc)
 				ltfsmsg(LTFS_INFO, 30461I, LOG_PERFORMANCE, rc, "get xattr");
 			else {

--- a/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
+++ b/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
@@ -2235,7 +2235,7 @@ int lin_tape_ibmtape_logsense(void *device, const uint8_t page, const uint8_t su
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOGSENSE));
 
-	return rc;
+	return logpage.len;
 }
 
 /**

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -107,7 +107,7 @@ struct sg_global_data global_data;
 int sg_readpos(void *device, struct tc_position *pos);
 int sg_locate(void *device, struct tc_position dest, struct tc_position *pos);
 int sg_space(void *device, size_t count, TC_SPACE_TYPE type, struct tc_position *pos);
-int sg_logsense(void *device, const unsigned char page, unsigned char *buf, const size_t size);
+int sg_logsense(void *device, const uint8_t page, const uint8_t subpage, unsigned char *buf, const size_t size);
 int sg_modesense(void *device, const unsigned char page, const TC_MP_PC_TYPE pc,
 						 const unsigned char subpage, unsigned char *buf, const size_t size);
 int sg_modeselect(void *device, unsigned char *buf, const size_t size);
@@ -2964,7 +2964,7 @@ int sg_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 
 	if (IS_LTO(priv->drive_type) && (DRIVE_GEN(priv->drive_type) == 0x05)) {
 		/* Use LogPage 0x31 */
-		ret = sg_logsense(device, (uint8_t)LOG_TAPECAPACITY, (void *)buffer, LOGSENSEPAGE);
+		ret = sg_logsense(device, (uint8_t)LOG_TAPECAPACITY, (uint8_t)0, (void *)buffer, LOGSENSEPAGE);
 		if(ret < 0)
 		{
 			ltfsmsg(LTFS_INFO, 30229I, LOG_VOLUMESTATS, ret);
@@ -3019,7 +3019,7 @@ int sg_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 		ret = DEVICE_GOOD;
 	} else {
 		/* Use LogPage 0x17 */
-		ret = sg_logsense(device, LOG_VOLUMESTATS, (void *)buffer, LOGSENSEPAGE);
+		ret = sg_logsense(device, LOG_VOLUMESTATS, (uint8_t)0, (void *)buffer, LOGSENSEPAGE);
 		if(ret < 0)
 		{
 			ltfsmsg(LTFS_INFO, 30229I, LOG_VOLUMESTATS, ret);
@@ -3088,8 +3088,8 @@ out:
 	return ret;
 }
 
-static int _cdb_logsense(void *device, const unsigned char page, const unsigned char subpage,
-						 unsigned char *buf, const size_t size)
+int sg_logsense(void *device, const uint8_t page, const uint8_t subpage,
+				unsigned char *buf, const size_t size)
 {
 	int ret = -EDEV_UNKNOWN;
 	int ret_ep = DEVICE_GOOD;
@@ -3102,12 +3102,22 @@ static int _cdb_logsense(void *device, const unsigned char page, const unsigned 
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "LOGSENSE";
 	char *msg = NULL;
 
+	unsigned char *inner_buf = NULL;
+
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOGSENSE));
+	ltfsmsg(LTFS_DEBUG3, 30397D, "logsense",
+			(unsigned long long)page, (unsigned long long)subpage, priv->drive_serial);
+
+	inner_buf = calloc(1, MAXLP_SIZE); /* Assume max length of LP is 1MB */
+	if (!inner_buf)
+		return -LTFS_NO_MEMORY;
 
 	/* Zero out the CDB and the result buffer */
 	ret = init_sg_io_header(&req);
-	if (ret < 0)
+	if (ret < 0) {
+		free(inner_buf);
 		return ret;
+	}
 
 	memset(cdb, 0, sizeof(cdb));
 	memset(sense, 0, sizeof(sense));
@@ -3119,15 +3129,17 @@ static int _cdb_logsense(void *device, const unsigned char page, const unsigned 
 	ltfs_u16tobe(cdb + 7, size);
 
 	timeout = get_timeout(priv->timeouts, cdb[0]);
-	if (timeout < 0)
+	if (timeout < 0) {
+		free(inner_buf);
 		return -EDEV_UNSUPPORETD_COMMAND;
+	}
 
 	/* Build request */
 	req.dxfer_direction = SCSI_FROM_TARGET_TO_INITIATOR;
 	req.cmd_len         = sizeof(cdb);
 	req.mx_sb_len       = sizeof(sense);
-	req.dxfer_len       = size;
-	req.dxferp          = buf;
+	req.dxfer_len       = MAXLP_SIZE;;
+	req.dxferp          = inner_buf;
 	req.cmdp            = cdb;
 	req.sbp             = sense;
 	req.timeout         = SGConversion(timeout);
@@ -3138,19 +3150,17 @@ static int _cdb_logsense(void *device, const unsigned char page, const unsigned 
 		ret_ep = _process_errors(device, ret, msg, cmd_desc, true, true);
 		if (ret_ep < 0)
 			ret = ret_ep;
+	} else {
+		if (size > req.actual_xfered)
+			memcpy(buf, inner_buf, req.actual_xfered);
+		else
+			memcpy(buf, inner_buf, size);
+
+		ret = req.actual_xfered;
 	}
 
+	free (inner_buf);
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOGSENSE));
-
-	return ret;
-}
-
-int sg_logsense(void *device, const unsigned char page, unsigned char *buf, const size_t size)
-{
-	int ret = -EDEV_UNKNOWN;
-
-	ltfsmsg(LTFS_DEBUG3, 30393D, "logsense", page, "");
-	ret = _cdb_logsense(device, page, 0x00, buf, size);
 
 	return ret;
 }
@@ -3755,8 +3765,8 @@ int sg_get_cartridge_health(void *device, struct tc_cartridge_health *cart_healt
 
 	/* Issue LogPage 0x37 */
 	cart_health->tape_efficiency  = UNSUPPORTED_CARTRIDGE_HEALTH;
-	ret = sg_logsense(device, LOG_PERFORMANCE, logdata, LOGSENSEPAGE);
-	if (ret)
+	ret = sg_logsense(device, LOG_PERFORMANCE, (uint8_t)0, logdata, LOGSENSEPAGE);
+	if (ret < 0)
 		ltfsmsg(LTFS_INFO, 30234I, LOG_PERFORMANCE, ret, "get cart health");
 	else {
 		for(i = 0; i < (int)((sizeof(perfstats)/sizeof(perfstats[0]))); i++) {
@@ -3810,7 +3820,7 @@ int sg_get_cartridge_health(void *device, struct tc_cartridge_health *cart_healt
 	cart_health->read_mbytes      = UNSUPPORTED_CARTRIDGE_HEALTH;
 	cart_health->passes_begin     = UNSUPPORTED_CARTRIDGE_HEALTH;
 	cart_health->passes_middle    = UNSUPPORTED_CARTRIDGE_HEALTH;
-	ret = sg_logsense(device, LOG_VOLUMESTATS, logdata, LOGSENSEPAGE);
+	ret = sg_logsense(device, LOG_VOLUMESTATS, (uint8_t)0, logdata, LOGSENSEPAGE);
 	if (ret < 0)
 		ltfsmsg(LTFS_INFO, 30234I, LOG_VOLUMESTATS, ret, "get cart health");
 	else {
@@ -3906,10 +3916,11 @@ int sg_get_tape_alert(void *device, uint64_t *tape_alert)
 
 	/* Issue LogPage 0x2E */
 	ta = 0;
-	ret = sg_logsense(device, LOG_TAPE_ALERT, logdata, LOGSENSEPAGE);
+	ret = sg_logsense(device, LOG_TAPE_ALERT, (uint8_t)0, logdata, LOGSENSEPAGE);
 	if (ret < 0)
 		ltfsmsg(LTFS_INFO, 30234I, LOG_TAPE_ALERT, ret, "get tape alert");
 	else {
+		ret = 0;
 		for(i = 1; i <= 64; i++) {
 			if (_parse_logPage(logdata, (uint16_t) i, &param_size, buf, 16)
 				|| param_size != sizeof(uint8_t)) {
@@ -3962,11 +3973,11 @@ int sg_get_xattr(void *device, const char *name, char **buf)
 		if (priv->fetch_sec_acq_loss_w == 0 ||
 			((priv->fetch_sec_acq_loss_w + 60 < now.tv_sec) && priv->dirty_acq_loss_w))
 		{
-			ret = _cdb_logsense(device, LOG_PERFORMANCE, LOG_PERFORMANCE_CAPACITY_SUB, logdata, LOGSENSEPAGE);
-
+			ret = sg_logsense(device, LOG_PERFORMANCE, LOG_PERFORMANCE_CAPACITY_SUB, logdata, LOGSENSEPAGE);
 			if (ret < 0) {
 				ltfsmsg(LTFS_INFO, 30234I, LOG_PERFORMANCE, ret, "get xattr");
 			} else {
+				ret = 0;
 				if (_parse_logPage(logdata, PERF_ACTIVE_CQ_LOSS_W, &param_size, logbuf, 16)) {
 					ltfsmsg(LTFS_INFO, 30235I, LOG_PERFORMANCE,  "get xattr");
 					ret = -LTFS_NO_XATTR;
@@ -4217,8 +4228,8 @@ int sg_get_eod_status(void *device, int part)
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_GETEODSTAT));
 
 	/* Issue LogPage 0x17 */
-	ret = sg_logsense(device, LOG_VOLUMESTATS, logdata, LOGSENSEPAGE);
-	if (ret) {
+	ret = sg_logsense(device, LOG_VOLUMESTATS, (uint8_t)0, logdata, LOGSENSEPAGE);
+	if (ret < 0) {
 		ltfsmsg(LTFS_WARN, 30237W, LOG_VOLUMESTATS, ret);
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETEODSTAT));
 		return EOD_UNKNOWN;

--- a/src/tape_drivers/osx/iokit/iokit_tape.c
+++ b/src/tape_drivers/osx/iokit/iokit_tape.c
@@ -104,7 +104,8 @@ struct iokit_global_data global_data;
 /* Forward references (For keep function order to struct tape_ops) */
 int iokit_readpos(void *device, struct tc_position *pos);
 int iokit_locate(void *device, struct tc_position dest, struct tc_position *pos);
-int iokit_logsense(void *device, const unsigned char page, unsigned char *buf, const size_t size);
+int iokit_logsense(void *device, const uint8_t page, const uint8_t subpage,
+				   unsigned char *buf, const size_t size);
 int iokit_modesense(void *device, const unsigned char page, const TC_MP_PC_TYPE pc,
 							const unsigned char subpage, unsigned char *buf, const size_t size);
 int iokit_modeselect(void *device, unsigned char *buf, const size_t size);
@@ -457,7 +458,7 @@ static int _cdb_read_buffer(void *device, int id, unsigned char *buf, size_t off
 
 	ltfsmsg(LTFS_DEBUG, 30993D, "read buffer", id, priv->drive_serial);
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -509,7 +510,7 @@ static int _cdb_force_dump(struct iokit_data *priv)
 
 	ltfsmsg(LTFS_DEBUG, 30993D, "force dump", 0, priv->drive_serial);
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 	memset(&buf, 0, sizeof(buf));
@@ -1095,7 +1096,7 @@ int iokit_inquiry_page(void *device, unsigned char page, struct tc_inq_page *inq
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_INQUIRYPAGE));
 	ltfsmsg(LTFS_DEBUG, 30993D, "inquiry", page, priv->drive_serial);
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -1174,7 +1175,7 @@ int iokit_test_unit_ready(void *device)
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_TUR));
 	ltfsmsg(LTFS_DEBUG3, 30992D, "test unit ready", priv->drive_serial);
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -1238,7 +1239,7 @@ static int _cdb_read(void *device, char *buf, size_t size, boolean_t sili)
 	char *msg = NULL;
 	size_t length = -EDEV_UNKNOWN;
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -1439,7 +1440,7 @@ static int _cdb_write(void *device, uint8_t *buf, size_t size, bool *ew, bool *p
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "WRITE";
 	char *msg = NULL;
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -1559,7 +1560,7 @@ int iokit_writefm(void *device, size_t count, struct tc_position *pos, bool imme
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_WRITEFM));
 	ltfsmsg(LTFS_DEBUG, 30994D, "write file marks", count, priv->drive_serial);
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -1639,7 +1640,7 @@ int iokit_rewind(void *device, struct tc_position *pos)
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_REWIND));
 	ltfsmsg(LTFS_DEBUG, 30997D, "rewind", (unsigned long long)0, (unsigned long long)0, priv->drive_serial);
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -1714,7 +1715,7 @@ int iokit_locate(void *device, struct tc_position dest, struct tc_position *pos)
 		pc = true;
 	}
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -1777,7 +1778,7 @@ int iokit_space(void *device, size_t count, TC_SPACE_TYPE type, struct tc_positi
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_SPACE));
 
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -1860,7 +1861,7 @@ static int _cdb_request_sense(void *device, unsigned char *buf, unsigned char si
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "REQUEST_SENSE";
 	char *msg = NULL;
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -1910,7 +1911,7 @@ int iokit_erase(void *device, struct tc_position *pos, bool long_erase)
 
 	get_current_timespec(&ts_start);
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -1984,7 +1985,7 @@ static int _cdb_load_unload(void *device, bool load)
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "LOAD_UNLOAD";
 	char *msg = NULL;
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -2123,7 +2124,7 @@ int iokit_readpos(void *device, struct tc_position *pos)
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_READPOS));
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -2202,7 +2203,7 @@ int iokit_setcap(void *device, uint16_t proportion)
 
 		ret = iokit_modeselect(device, buf, sizeof(buf));
 	} else {
-		// Zero out the CDB and the result buffer
+		/* Zero out the CDB and the result buffer */
 		memset(cdb, 0, sizeof(cdb));
 		memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -2248,7 +2249,7 @@ int iokit_format(void *device, TC_FORMAT_TYPE format, const char *vol_name, cons
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_FORMAT));
 	ltfsmsg(LTFS_DEBUG, 30992D, "format", priv->drive_serial);
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -2303,7 +2304,7 @@ int iokit_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 
 	if (IS_LTO(priv->drive_type) && (DRIVE_GEN(priv->drive_type) == 0x05)) {
 		/* Use LogPage 0x31 */
-		ret = iokit_logsense(device, (uint8_t)LOG_TAPECAPACITY, (void *)buffer, LOGSENSEPAGE);
+		ret = iokit_logsense(device, (uint8_t)LOG_TAPECAPACITY, (uint8_t)0, (void *)buffer, LOGSENSEPAGE);
 		if(ret < 0)
 		{
 			ltfsmsg(LTFS_INFO, 30832I, LOG_VOLUMESTATS, ret);
@@ -2346,9 +2347,8 @@ int iokit_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 		ret = DEVICE_GOOD;
 	} else {
 		/* Use LogPage 0x17 */
-		ret = iokit_logsense(device, LOG_VOLUMESTATS, (void *)buffer, LOGSENSEPAGE);
-		if(ret < 0)
-		{
+		ret = iokit_logsense(device, LOG_VOLUMESTATS, (uint8_t)0, (void *)buffer, LOGSENSEPAGE);
+		if(ret < 0) {
 			ltfsmsg(LTFS_INFO, 30832I, LOG_VOLUMESTATS, ret);
 			goto out;
 		}
@@ -2404,8 +2404,8 @@ out:
 	return ret;
 }
 
-static int _cdb_logsense(void *device, const unsigned char page, const unsigned char subpage,
-						 unsigned char *buf, const size_t size)
+int iokit_logsense(void *device, const uint8_t page, const uint8_t subpage,
+				   unsigned char *buf, const size_t size)
 {
 	int ret = -EDEV_UNKNOWN;
 	struct iokit_data *priv = (struct iokit_data*)device;
@@ -2416,9 +2416,17 @@ static int _cdb_logsense(void *device, const unsigned char page, const unsigned 
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "LOGSENSE";
 	char *msg = NULL;
 
-	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOGSENSE));
+	unsigned char *inner_buf = NULL;
 
-	// Zero out the CDB and the result buffer
+	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOGSENSE));
+	ltfsmsg(LTFS_DEBUG3, 30997D, "logsense",
+			(unsigned long long)page, (unsigned long long)subpage, priv->drive_serial);
+
+	inner_buf = calloc(1, MAXLP_SIZE); /* Assume max length of LP is 1MB */
+	if (!inner_buf)
+		return -LTFS_NO_MEMORY;
+
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -2429,15 +2437,17 @@ static int _cdb_logsense(void *device, const unsigned char page, const unsigned 
 	ltfs_u16tobe(cdb + 7, size);
 
 	timeout = get_timeout(priv->timeouts, cdb[0]);
-	if (timeout < 0)
+	if (timeout < 0) {
+		free(inner_buf);
 		return -EDEV_UNSUPPORETD_COMMAND;
+	}
 
 	/* Build request */
 	req.dxfer_direction = SCSI_FROM_TARGET_TO_INITIATOR;
 	req.cmd_len         = sizeof(cdb);
 	req.mx_sb_len       = sizeof(SCSI_Sense_Data);
-	req.dxfer_len       = size;
-	req.dxferp          = buf;
+	req.dxfer_len       = MAXLP_SIZE;
+	req.dxferp          = inner_buf;
 	req.cmdp            = cdb;
 	memset(&req.sense_buffer, 0, req.mx_sb_len);
 	req.timeout         = IOKitConversion(timeout);
@@ -2446,19 +2456,17 @@ static int _cdb_logsense(void *device, const unsigned char page, const unsigned 
 	ret = iokit_issue_cdb_command(&priv->dev, &req, &msg);
 	if (ret < 0){
 		_process_errors(device, ret, msg, cmd_desc, true);
+	} else {
+		if (size > req.actual_xfered)
+			memcpy(buf, inner_buf, req.actual_xfered);
+		else
+			memcpy(buf, inner_buf, size);
+
+		ret = req.actual_xfered;
 	}
 
+	free (inner_buf);
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOGSENSE));
-
-	return ret;
-}
-
-int iokit_logsense(void *device, const unsigned char page, unsigned char *buf, const size_t size)
-{
-	int ret = -EDEV_UNKNOWN;
-
-	ltfsmsg(LTFS_DEBUG3, 30993D, "logsense", page, "");
-	ret = _cdb_logsense(device, page, 0x00, buf, size);
 
 	return ret;
 }
@@ -2478,7 +2486,7 @@ int iokit_modesense(void *device, const unsigned char page, const TC_MP_PC_TYPE 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_MODESENSE));
 	ltfsmsg(LTFS_DEBUG3, 30993D, "modesense", page, priv->drive_serial);
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -2529,7 +2537,7 @@ int iokit_modeselect(void *device, unsigned char *buf, const size_t size)
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_MODESELECT));
 	ltfsmsg(LTFS_DEBUG3, 30992D, "modeselect", priv->drive_serial);
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -2578,7 +2586,7 @@ int iokit_reserve(void *device)
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_RESERVEUNIT));
 	ltfsmsg(LTFS_DEBUG, 30992D, "reserve unit (6)", priv->drive_serial);
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -2650,7 +2658,7 @@ int iokit_release(void *device)
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_RELEASEUNIT));
 	ltfsmsg(LTFS_DEBUG, 30992D, "release unit (6)", priv->drive_serial);
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -2703,7 +2711,7 @@ static int _cdb_prevent_allow_medium_removal(void *device, bool prevent)
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "PREVENT/ALLOW_MEDIUM_REMOVAL";
 	char *msg = NULL;
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -2785,7 +2793,7 @@ int iokit_write_attribute(void *device, const tape_partition_t part,
 	ltfs_u32tobe(buffer, len);
 	memcpy(buffer + 4, buf, size);
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -2847,7 +2855,7 @@ int iokit_read_attribute(void *device, const tape_partition_t part,
 		return -EDEV_NO_MEMORY;
 	}
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -2915,7 +2923,7 @@ int iokit_allow_overwrite(void *device, const struct tc_position pos)
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_ALLOWOVERW));
 	ltfsmsg(LTFS_DEBUG, 30997D, "allow overwrite", (unsigned long long)pos.partition, pos.block, priv->drive_serial);
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -3080,8 +3088,8 @@ int iokit_get_cartridge_health(void *device, struct tc_cartridge_health *cart_he
 
 	/* Issue LogPage 0x37 */
 	cart_health->tape_efficiency  = UNSUPPORTED_CARTRIDGE_HEALTH;
-	ret = iokit_logsense(device, LOG_PERFORMANCE, logdata, LOGSENSEPAGE);
-	if (ret)
+	ret = iokit_logsense(device, LOG_PERFORMANCE, (uint8_t)0, logdata, LOGSENSEPAGE);
+	if (ret < 0)
 		ltfsmsg(LTFS_INFO, 30837I, LOG_PERFORMANCE, ret, "get cart health");
 	else {
 		for(i = 0; i < (int)((sizeof(perfstats)/sizeof(perfstats[0]))); i++) {
@@ -3135,7 +3143,7 @@ int iokit_get_cartridge_health(void *device, struct tc_cartridge_health *cart_he
 	cart_health->read_mbytes      = UNSUPPORTED_CARTRIDGE_HEALTH;
 	cart_health->passes_begin     = UNSUPPORTED_CARTRIDGE_HEALTH;
 	cart_health->passes_middle    = UNSUPPORTED_CARTRIDGE_HEALTH;
-	ret = iokit_logsense(device, LOG_VOLUMESTATS, logdata, LOGSENSEPAGE);
+	ret = iokit_logsense(device, LOG_VOLUMESTATS, (uint8_t)0, logdata, LOGSENSEPAGE);
 	if (ret < 0)
 		ltfsmsg(LTFS_INFO, 30837I, LOG_VOLUMESTATS, ret, "get cart health");
 	else {
@@ -3231,10 +3239,11 @@ int iokit_get_tape_alert(void *device, uint64_t *tape_alert)
 
 	/* Issue LogPage 0x2E */
 	ta = 0;
-	ret = iokit_logsense(device, LOG_TAPE_ALERT, logdata, LOGSENSEPAGE);
+	ret = iokit_logsense(device, LOG_TAPE_ALERT, (uint8_t)0, logdata, LOGSENSEPAGE);
 	if (ret < 0)
 		ltfsmsg(LTFS_INFO, 30837I, LOG_TAPE_ALERT, ret, "get tape alert");
 	else {
+		ret = 0;
 		for(i = 1; i <= 64; i++) {
 			if (_parse_logPage(logdata, (uint16_t) i, &param_size, buf, 16)
 				|| param_size != sizeof(uint8_t)) {
@@ -3287,11 +3296,11 @@ int iokit_get_xattr(void *device, const char *name, char **buf)
 		if (priv->fetch_sec_acq_loss_w == 0 ||
 			((priv->fetch_sec_acq_loss_w + 60 < now.tv_sec) && priv->dirty_acq_loss_w))
 		{
-			ret = _cdb_logsense(device, LOG_PERFORMANCE, LOG_PERFORMANCE_CAPACITY_SUB, logdata, LOGSENSEPAGE);
-
+			ret = iokit_logsense(device, LOG_PERFORMANCE, LOG_PERFORMANCE_CAPACITY_SUB, logdata, LOGSENSEPAGE);
 			if (ret < 0) {
 				ltfsmsg(LTFS_INFO, 30837I, LOG_PERFORMANCE, ret, "get xattr");
 			} else {
+				ret = 0;
 				if (_parse_logPage(logdata, PERF_ACTIVE_CQ_LOSS_W, &param_size, logbuf, 16)) {
 					ltfsmsg(LTFS_INFO, 30838I, LOG_PERFORMANCE,  "get xattr");
 					ret = -LTFS_NO_XATTR;
@@ -3391,7 +3400,7 @@ static int _cdb_read_block_limits(void *device) {
 
 	ltfsmsg(LTFS_DEBUG, 30992D, "read block limits", priv->drive_serial);
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -3519,8 +3528,8 @@ int iokit_get_eod_status(void *device, int part)
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_GETEODSTAT));
 
 	/* Issue LogPage 0x17 */
-	ret = iokit_logsense(device, LOG_VOLUMESTATS, logdata, LOGSENSEPAGE);
-	if (ret) {
+	ret = iokit_logsense(device, LOG_VOLUMESTATS, (uint8_t)0, logdata, LOGSENSEPAGE);
+	if (ret < 0) {
 		ltfsmsg(LTFS_WARN, 30840W, LOG_VOLUMESTATS, ret);
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_GETEODSTAT));
 		return EOD_UNKNOWN;
@@ -3684,7 +3693,7 @@ static int _cdb_spin(void *device, const uint16_t sps, unsigned char **buffer, s
 	char *msg = NULL;
 	size_t len = *size + 4;
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
@@ -3737,7 +3746,7 @@ int _cdb_spout(void *device, const uint16_t sps,
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "SPOUT";
 	char *msg = NULL;
 
-	// Zero out the CDB and the result buffer
+	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
 	memset(&req, 0, sizeof(struct iokit_scsi_request));
 

--- a/src/tape_drivers/osx/iokit/iokit_tape.c
+++ b/src/tape_drivers/osx/iokit/iokit_tape.c
@@ -2416,6 +2416,7 @@ int iokit_logsense(void *device, const uint8_t page, const uint8_t subpage,
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "LOGSENSE";
 	char *msg = NULL;
 
+	unsigned int len = 0;
 	unsigned char *inner_buf = NULL;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOGSENSE));
@@ -2434,7 +2435,7 @@ int iokit_logsense(void *device, const uint8_t page, const uint8_t subpage,
 	cdb[0] = LOG_SENSE;
 	cdb[2] = 0x40 | (page & 0x3F); /* Current value */
 	cdb[3] = subpage;
-	ltfs_u16tobe(cdb + 7, size);
+	ltfs_u16tobe(cdb + 7, MAXLP_SIZE);
 
 	timeout = get_timeout(priv->timeouts, cdb[0]);
 	if (timeout < 0) {
@@ -2457,12 +2458,14 @@ int iokit_logsense(void *device, const uint8_t page, const uint8_t subpage,
 	if (ret < 0){
 		_process_errors(device, ret, msg, cmd_desc, true);
 	} else {
-		if (size > req.actual_xfered)
-			memcpy(buf, inner_buf, req.actual_xfered);
+		len = ((int)inner_buf[2] << 8) + (int)inner_buf[3] + 4;
+
+		if (size > len)
+			memcpy(buf, inner_buf, len);
 		else
 			memcpy(buf, inner_buf, size);
 
-		ret = req.actual_xfered;
+		ret = len;
 	}
 
 	free (inner_buf);

--- a/src/tape_drivers/tape_drivers.h
+++ b/src/tape_drivers/tape_drivers.h
@@ -78,7 +78,7 @@
 #define MAXSENSE                   (255)
 #endif
 
-#define MAXLP_SIZE             (1 * MB)
+#define MAXLP_SIZE             (0xFFFF)
 
 #define MASK_WITH_SENSE_KEY    (0xFFFFFF)
 #define MASK_WITHOUT_SENSE_KEY (0x00FFFF)

--- a/src/tape_drivers/tape_drivers.h
+++ b/src/tape_drivers/tape_drivers.h
@@ -78,6 +78,8 @@
 #define MAXSENSE                   (255)
 #endif
 
+#define MAXLP_SIZE             (1 * MB)
+
 #define MASK_WITH_SENSE_KEY    (0xFFFFFF)
 #define MASK_WITHOUT_SENSE_KEY (0x00FFFF)
 


### PR DESCRIPTION
# Summary of changes

Introduce generic logselect issue I/F via EA by `ltfs.vendor.IBM.logPage.XX.YY`.

XX shall be a hex value like `A0` as page code. YY XX shall be a hex value like `60` as subpage code.

Once LTFS receives a correct VEA, XX and YY can be converted by `strroul()` with `base=16`, LTFS always issues logsense to the drive and return the specified page by binary.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
