### PR TITLE
Fix plugin load error for itdtimg

### DIFF
--- a/src/tape_drivers/generic/itdtimg/itdtimg_tc.c
+++ b/src/tape_drivers/generic/itdtimg/itdtimg_tc.c
@@ -1419,7 +1419,7 @@ int itdtimage_get_serialnumber(void *vstate, char **result)
 	return DEVICE_GOOD;
 }
 
-int filedebug_get_info(void *device, struct tc_drive_info *info)
+int itdtimage_get_info(void *device, struct tc_drive_info *info)
 {
 	/*
 	 * Return dummy data.
@@ -1642,6 +1642,7 @@ struct tape_ops itdtimage_handler = {
 	.is_mountable			= itdtimage_is_mountable,
 	.get_worm_status		= itdtimage_get_worm_status,
 	.get_serialnumber       = itdtimage_get_serialnumber,
+	.get_info               = itdtimage_get_info,
 	.set_profiler           = itdtimage_set_profiler,
 	.get_block_in_buffer    = itdtimage_get_block_in_buffer,
 	.is_readonly 			= itdtimage_is_readonly,


### PR DESCRIPTION
# Summary of changes

Fix plugin load error of `itdtimg` reported by #255.

- Fix of issue #255

# Description

It looks function table is incomplete. So I made a tiny fix.

Fixes #255

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- 
# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
