### PR TITLE
Introduce generic MAM fields capture I/F

### DIFF
--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -4067,6 +4067,32 @@ int ltfs_logpage(const uint8_t page, const uint8_t subpage, unsigned char *buf,
 }
 
 /**
+ * Capture MAM.
+ *
+ * At buffer shortage, this function returns the length of the page. The page is truncated
+ * by size.
+ *
+ * @param vol LTFS volume
+ * @param part partition to capture
+ * @param buf buffer of the contents of logpage
+ * @param size buffer size
+ * @return MAM length on success or a negative value on error
+ */
+int ltfs_mam(const tape_partition_t part, unsigned char *buf,
+			 const size_t size, struct ltfs_volume *vol)
+{
+	int ret = -EDEV_UNKNOWN;
+
+	if (vol->device) {
+		tape_device_lock(vol->device);
+		ret = tape_read_attr(vol->device, part, buf, size);
+		tape_device_unlock(vol->device);
+	}
+
+	return ret;
+}
+
+/**
  * Wait the drive goes to ready state
  *
  * @param vol LTFS volume

--- a/src/libltfs/ltfs.h
+++ b/src/libltfs/ltfs.h
@@ -689,6 +689,8 @@ int ltfs_recover_eod(struct ltfs_volume *vol);
 int ltfs_release_medium(struct ltfs_volume *vol);
 int ltfs_logpage(const uint8_t page, const uint8_t subpage, unsigned char *buf,
 				 const size_t size, struct ltfs_volume *vol);
+int ltfs_mam(const tape_partition_t part, unsigned char *buf,
+			 const size_t size, struct ltfs_volume *vol);
 int ltfs_wait_device_ready(struct ltfs_volume *vol);
 void ltfs_recover_eod_simple(struct ltfs_volume *vol);
 

--- a/src/libltfs/tape.h
+++ b/src/libltfs/tape.h
@@ -222,6 +222,8 @@ int tape_get_attribute_from_cm(struct device_data *dev, struct tape_attr *t_attr
 void tape_load_all_attribute_from_cm(struct device_data *dev, struct tape_attr *t_attr);
 int update_tape_attribute (struct ltfs_volume *vol, const char *new_value, int type, int size);
 int read_tape_attribute (struct ltfs_volume *vol, char **val, const char *name);
+int tape_read_attr(struct device_data *dev, const tape_partition_t part,
+				   unsigned char *buf, const size_t size);
 int tape_is_mountable(struct device_data *dev, char *barcode,
 					  unsigned char cart_type, unsigned char density);
 int tape_is_reformattable(struct device_data *dev, unsigned char cart_type, unsigned char density);

--- a/src/libltfs/tape_ops.h
+++ b/src/libltfs/tape_ops.h
@@ -666,6 +666,8 @@ struct tape_ops {
 	 * Read a MAM parameter from a device.
 	 * For performance reasons, it is recommended that all backends implement MAM parameter support.
 	 * However, this support is technically optional.
+	 * Normally the buffer doesn't include header of contents. But it includes only when the size is
+	 * MAXMAM_SIZE.
 	 * @param device Device handle returned by the backend's open().
 	 * @param part Partition to read the parameter from.
 	 * @param id Attribute ID to read. libltfs uses TC_MAM_PAGE_VCR and TC_MAM_PAGE_COHERENCY.

--- a/src/libltfs/xattr.c
+++ b/src/libltfs/xattr.c
@@ -1158,16 +1158,19 @@ int _xattr_get_virtual(struct dentry *d, char *buf, size_t buf_size, const char 
 
 			char *endptr = NULL;
 
+			part_str[0] = name[25];
+			part_str[1] = name[26];
+
 			if (!strncmp(part_str, "IP", sizeof(part_str))) {
 				part = ltfs_part_id2num(vol->label->partid_ip, vol);
-			} else if (!strncmp(part_str, "IP", sizeof(part_str))) {
+			} else if (!strncmp(part_str, "DP", sizeof(part_str))) {
 				part = ltfs_part_id2num(vol->label->partid_dp, vol);;
 			} else {
 				part = (uint8_t)(strtoul(part_str, &endptr, 16));
 				if (*endptr) return -LTFS_NO_XATTR;
 			}
 
-			if (part < 2) return -LTFS_NO_XATTR;
+			if (part > 1) return -LTFS_NO_XATTR;
 
 			ret = ltfs_mam(part, (unsigned char *)buf, buf_size, vol);
 

--- a/src/libltfs/xattr.c
+++ b/src/libltfs/xattr.c
@@ -806,6 +806,7 @@ bool _xattr_is_virtual(struct dentry *d, const char *name, struct ltfs_volume *v
 			|| ! strcmp(name, "ltfs.vendor.IBM.logLevel")
 			|| ! strcmp(name, "ltfs.vendor.IBM.syslogLevel")
 			|| ! strcmp(name, "ltfs.vendor.IBM.logPage")
+			|| ! strcmp(name, "ltfs.vendor.IBM.mediaMAM")
 			|| ! strncmp(name, "ltfs.vendor", strlen("ltfs.vendor")))
 			return true;
 	}
@@ -1149,6 +1150,26 @@ int _xattr_get_virtual(struct dentry *d, char *buf, size_t buf_size, const char 
 			if (*endptr) return -LTFS_NO_XATTR;
 
 			ret = ltfs_logpage(page, subpage, (unsigned char *)buf, buf_size, vol);
+
+		} else if ( (!strncmp(name, "ltfs.vendor.IBM.mediaMAM.", strlen("ltfs.vendor.IBM.mediaMAM."))) &&
+					(strlen(name) == strlen("ltfs.vendor.IBM.mediaMAM.XX")) ) {
+			char part_str[3] = {0x00, 0x00, 0x00};
+			tape_partition_t part = 0;
+
+			char *endptr = NULL;
+
+			if (!strncmp(part_str, "IP", sizeof(part_str))) {
+				part = ltfs_part_id2num(vol->label->partid_ip, vol);
+			} else if (!strncmp(part_str, "IP", sizeof(part_str))) {
+				part = ltfs_part_id2num(vol->label->partid_dp, vol);;
+			} else {
+				part = (uint8_t)(strtoul(part_str, &endptr, 16));
+				if (*endptr) return -LTFS_NO_XATTR;
+			}
+
+			if (part < 2) return -LTFS_NO_XATTR;
+
+			ret = ltfs_mam(part, (unsigned char *)buf, buf_size, vol);
 
 		} else if (! strncmp(name, "ltfs.vendor", strlen("ltfs.vendor"))) {
 			if (! strncmp(name + strlen("ltfs.vendor."), LTFS_VENDOR_NAME, strlen(LTFS_VENDOR_NAME))) {

--- a/src/tape_drivers/freebsd/cam/cam_tc.c
+++ b/src/tape_drivers/freebsd/cam/cam_tc.c
@@ -1697,7 +1697,7 @@ int camtape_logsense(struct camtape_data *softc, const uint8_t page, const uint8
 	ltfsmsg(LTFS_DEBUG3, 31397D, "logsense",
 			(unsigned long long)page, (unsigned long long)subpage, softc->drive_serial);
 
-	inner_buf = calloc(1, MAXLP_SIZE); /* Assume max length of LP is 1MB */
+	inner_buf = calloc(1, MAXLP_SIZE); /* Assume max length of LP is 0xFFFF */
 	if (!inner_buf)
 		return -LTFS_NO_MEMORY;
 

--- a/src/tape_drivers/freebsd/cam/cam_tc.c
+++ b/src/tape_drivers/freebsd/cam/cam_tc.c
@@ -2070,6 +2070,10 @@ int camtape_read_attribute(void *device, const tape_partition_t part, const uint
 	size_t attr_size;
 	union ccb *ccb = NULL;
 
+	/* TODO: Need to return data with header when size is MAXMAM_SIZE */
+	if (size == MAXMAM_SIZE)
+		return -LTFS_NO_XATTR;
+
 	ltfs_profiler_add_entry(softc->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_READATTR));
 	ltfsmsg(LTFS_DEBUG3, 31397D, "readattr", (unsigned long long)part,
 			(unsigned long long)id, softc->drive_serial);
@@ -2137,6 +2141,7 @@ int camtape_read_attribute(void *device, const tape_partition_t part, const uint
 			id != TC_MAM_APP_FORMAT_VERSION)
 			ltfsmsg(LTFS_INFO, 31260I, rc);
 	} else {
+
 		memcpy(buf, &attr_header[1], size);
 	}
 

--- a/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
+++ b/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
@@ -2548,7 +2548,11 @@ int lin_tape_ibmtape_read_attribute(void *device, const tape_partition_t part, c
 	memset(sense, 0, sizeof(sense));
 
 	/* Prepare Data Buffer */
-	spt.buffer_length = size + 4;
+	if (size == MAXMAM_SIZE)
+		spt.buffer_length = MAXMAM_SIZE;
+	else
+		spt.buffer_length = size + 4;
+
 	spt.buffer = calloc(1, spt.buffer_length);
 	if (spt.buffer == NULL) {
 		ltfsmsg(LTFS_ERR, 10001E, "lin_tape_ibmtape_read_attribute: data buffer");
@@ -2593,7 +2597,13 @@ int lin_tape_ibmtape_read_attribute(void *device, const tape_partition_t part, c
 			id != TC_MAM_APP_FORMAT_VERSION)
 			ltfsmsg(LTFS_INFO, 30460I, rc);
 	} else {
-		memcpy(buf, (spt.buffer + 4), size);
+		if (size == MAXMAM_SIZE) {
+			/* Include header if request size is MAXMAM_SIZE */
+			memcpy(buf, spt.buffer, size);
+		} else {
+			memcpy(buf, (spt.buffer + 4), size);
+		}
+
 		free(spt.buffer);
 	}
 

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -3511,7 +3511,12 @@ int sg_read_attribute(void *device, const tape_partition_t part,
 	ltfsmsg(LTFS_DEBUG3, 30397D, "readattr", (unsigned long long)part, (unsigned long long)id, priv->drive_serial);
 
 	/* Prepare the buffer to transfer */
-	uint32_t len = size + 4;
+	uint32_t len = 0;
+	if (size == MAXMAM_SIZE)
+		len = MAXMAM_SIZE;
+	else
+		len = size + 4;
+
 	unsigned char *buffer = calloc(1, len);
 	if (!buffer) {
 		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
@@ -3569,7 +3574,12 @@ int sg_read_attribute(void *device, const tape_partition_t part,
 			id != TC_MAM_APP_FORMAT_VERSION)
 			ltfsmsg(LTFS_INFO, 30233I, ret);
 	} else {
-		memcpy(buf, buffer + 4, size);
+		if (size == MAXMAM_SIZE) {
+			/* Include header if request size is MAXMAM_SIZE */
+			memcpy(buf, buffer, size);
+		} else {
+			memcpy(buf, buffer + 4, size);
+		}
 	}
 
 	free(buffer);

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -3109,7 +3109,7 @@ int sg_logsense(void *device, const uint8_t page, const uint8_t subpage,
 	ltfsmsg(LTFS_DEBUG3, 30397D, "logsense",
 			(unsigned long long)page, (unsigned long long)subpage, priv->drive_serial);
 
-	inner_buf = calloc(1, MAXLP_SIZE); /* Assume max length of LP is 1MB */
+	inner_buf = calloc(1, MAXLP_SIZE); /* Assume max length of LP is 0xFFFF */
 	if (!inner_buf)
 		return -LTFS_NO_MEMORY;
 
@@ -3147,7 +3147,7 @@ int sg_logsense(void *device, const uint8_t page, const uint8_t subpage,
 	req.usr_ptr         = (void *)cmd_desc;
 
 	ret = sg_issue_cdb_command(&priv->dev, &req, &msg);
-	if (ret < 0){
+	if (ret < 0) {
 		ret_ep = _process_errors(device, ret, msg, cmd_desc, true, true);
 		if (ret_ep < 0)
 			ret = ret_ep;

--- a/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
+++ b/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
@@ -3090,7 +3090,12 @@ int scsipi_ibmtape_read_attribute(void *device, const tape_partition_t part,
 	ltfsmsg(LTFS_DEBUG3, 30397D, "readattr", (unsigned long long)part, (unsigned long long)id, priv->drive_serial);
 
 	/* Prepare the buffer to transfer */
-	uint32_t len = size + 4;
+	uint32_t len = 0;
+	if (size == MAXMAM_SIZE)
+		len = MAXMAM_SIZE;
+	else
+		len = size + 4;
+
 	unsigned char *buffer = calloc(1, len);
 	if (!buffer) {
 		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
@@ -3144,7 +3149,12 @@ int scsipi_ibmtape_read_attribute(void *device, const tape_partition_t part,
 			id != TC_MAM_APP_FORMAT_VERSION)
 			ltfsmsg(LTFS_INFO, 30233I, ret);
 	} else {
-		memcpy(buf, buffer + 4, size);
+		if (size == MAXMAM_SIZE) {
+			/* Include header if request size is MAXMAM_SIZE */
+			memcpy(buf, buffer, size);
+		} else {
+			memcpy(buf, buffer + 4, size);
+		}
 	}
 
 	free(buffer);

--- a/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
+++ b/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
@@ -2720,7 +2720,7 @@ int scsipi_ibmtape_logsense(void *device, const uint8_t page, const uint8_t subp
 	ltfsmsg(LTFS_DEBUG3, 30397D, "logsense", page, subpage, priv->drive_serial);
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_LOGSENSE));
 
-	inner_buf = calloc(1, MAXLP_SIZE); /* Assume max length of LP is 1MB */
+	inner_buf = calloc(1, MAXLP_SIZE); /* Assume max length of LP is 0xFFFF */
 	if (!inner_buf)
 		return -LTFS_NO_MEMORY;
 

--- a/src/tape_drivers/osx/iokit/iokit_tape.c
+++ b/src/tape_drivers/osx/iokit/iokit_tape.c
@@ -2423,7 +2423,7 @@ int iokit_logsense(void *device, const uint8_t page, const uint8_t subpage,
 	ltfsmsg(LTFS_DEBUG3, 30997D, "logsense",
 			(unsigned long long)page, (unsigned long long)subpage, priv->drive_serial);
 
-	inner_buf = calloc(1, MAXLP_SIZE); /* Assume max length of LP is 1MB */
+	inner_buf = calloc(1, MAXLP_SIZE); /* Assume max length of LP is 0xFFFF */
 	if (!inner_buf)
 		return -LTFS_NO_MEMORY;
 

--- a/src/tape_drivers/osx/iokit/iokit_tape.c
+++ b/src/tape_drivers/osx/iokit/iokit_tape.c
@@ -2851,7 +2851,12 @@ int iokit_read_attribute(void *device, const tape_partition_t part,
 	ltfsmsg(LTFS_DEBUG3, 30997D, "readattr", (unsigned long long)part, (unsigned long long)id, priv->drive_serial);
 
 	/* Prepare the buffer to transfer */
-	uint32_t len = size + 4;
+	uint32_t len = 0;
+	if (size == MAXMAM_SIZE)
+		len = MAXMAM_SIZE;
+	else
+		len = size + 4;
+
 	unsigned char *buffer = calloc(1, len);
 	if (!buffer) {
 		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
@@ -2903,7 +2908,12 @@ int iokit_read_attribute(void *device, const tape_partition_t part,
 			id != TC_MAM_APP_FORMAT_VERSION)
 			ltfsmsg(LTFS_INFO, 30836I, ret);
 	} else {
-		memcpy(buf, buffer + 4, size);
+		if (size == MAXMAM_SIZE) {
+			/* Include header if request size is MAXMAM_SIZE */
+			memcpy(buf, buffer, size);
+		} else {
+			memcpy(buf, buffer + 4, size);
+		}
 	}
 
 	free(buffer);

--- a/src/tape_drivers/tape_drivers.h
+++ b/src/tape_drivers/tape_drivers.h
@@ -79,6 +79,7 @@
 #endif
 
 #define MAXLP_SIZE             (0xFFFF)
+#define MAXMAM_SIZE            (0xFFFF)
 
 #define MASK_WITH_SENSE_KEY    (0xFFFFFF)
 #define MASK_WITHOUT_SENSE_KEY (0x00FFFF)


### PR DESCRIPTION
# Summary of changes

Introduce generic MAM fields capture I/F via `ltfs.vendor.IBM.mediaMAM.XX`.

XX shall be one of `00`,  `01` , `IP` or `DP`.

- Fix of issue #256

# Description

The new introduced VEA returns the MAM value by binary. You need to parse it by yourself.

Fixes #256

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
