### PR TITLE
Fix the drive type of Quantum LTO6

### DIFF
--- a/src/tape_drivers/quantum_tape.c
+++ b/src/tape_drivers/quantum_tape.c
@@ -68,7 +68,7 @@ struct supported_device *quantum_supported_drives[] = {
 	TAPEDRIVE( QUANTUM_VENDOR_ID, "ULTRIUM-HH7",  DRIVE_LTO7_HH, "[ULTRIUM-HH7]" ),  /* QUANTUM Ultrium Gen 7 Half-High */
 	TAPEDRIVE( QUANTUM_VENDOR_ID, "ULTRIUM-HH8",  DRIVE_LTO8_HH, "[ULTRIUM-HH8]" ),  /* QUANTUM Ultrium Gen 8 Half-High */
 	TAPEDRIVE( QUANTUM_VENDOR_ID, "ULTRIUM 5",    DRIVE_LTO5_HH, "[ULTRIUM-5]" ),    /* Another QUANTUM Ultrium Gen 5 Half-High */
-	TAPEDRIVE( QUANTUM_VENDOR_ID, "ULTRIUM 6",    DRIVE_LTO5_HH, "[ULTRIUM-6]" ),    /* Another QUANTUM Ultrium Gen 5 Half-High */
+	TAPEDRIVE( QUANTUM_VENDOR_ID, "ULTRIUM 6",    DRIVE_LTO6_HH, "[ULTRIUM-6]" ),    /* Another QUANTUM Ultrium Gen 6 Half-High */
 	/* End of supported_devices */
 	NULL
 };


### PR DESCRIPTION
# Summary of changes

Fix the drive type of Quantum LTO6 drive.

# Description

Fix of issue #265. (Fixes #265)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
