### PR TITLE
Remove AC_CONFIG_MACRO_DIR from configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 ;;  OO_Copyright_BEGIN
 ;;
 ;;
-;;  Copyright 2010, 2020 IBM Corp. All rights reserved.
+;;  Copyright 2010, 2021 IBM Corp. All rights reserved.
 ;;
 ;;  Redistribution and use in source and binary forms, with or without
 ;;   modification, are permitted provided that the following conditions
@@ -40,7 +40,6 @@ AC_INIT([LTFS], [2.4.3.2 (Prelim)], IBM corporation.)
 AC_CONFIG_SRCDIR([src/main.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_MACRO_DIRS([m4])
-AC_CONFIG_MACRO_DIR([m4])
 AC_CANONICAL_HOST
 AC_CANONICAL_BUILD
 AC_CANONICAL_TARGET
@@ -391,7 +390,7 @@ fi
 dnl
 dnl Check for headers, types, structures, compiler characteristics
 dnl
-AC_CHECK_HEADERS([fcntl.h limits.h stddef.h stdint.h stdlib.h string.h sys/ioctl.h sys/mount.h sys/time.h termios.h unistd.h])
+AC_CHECK_HEADERS([fcntl.h limits.h stddef.h stdint.h stdlib.h string.h sys/ioctl.h sys/mount.h sys/time.h termios.h unistd.h sys/sysctl.h])
 AC_HEADER_STDBOOL
 AC_TYPE_MODE_T
 AC_TYPE_OFF_T

--- a/src/libltfs/arch/arch_info.c
+++ b/src/libltfs/arch/arch_info.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2021 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions
@@ -48,7 +48,7 @@
 */
 
 #include "libltfs/ltfs.h"
-#ifndef mingw_PLATFORM
+#ifdef HAVE_SYS_SYSCTL_H
 #include <sys/sysctl.h>
 #endif
 #include <sys/types.h>
@@ -133,7 +133,7 @@ void show_runtime_system_info(void)
 
 	return;
 }
-#elif defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__)
+#elif defined(HAVE_SYS_SYSCTL_H)
 {
 	int mib[2];
 	size_t len;


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Fix of issue #262 

# Description

At this time, `autogen.sh` fails on newer automake/autoconf. This change resolves it. I checked the change on RHEL7 (x86_64) and RHEL8 (x86_64).

Fixes #262

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
