### PR TITLE
Wipe the plugin structure before loading a plugin.

### DIFF
--- a/src/libltfs/plugin.c
+++ b/src/libltfs/plugin.c
@@ -82,7 +82,7 @@ int plugin_load(struct libltfs_plugin *pl, const char *type, const char *name,
 	CHECK_ARG_NULL(name, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(config, -LTFS_NULL_ARG);
 
-	pl->lib_handle = NULL;
+	memset(pl, 0, sizeof(*pl));
 
 	lib_path = config_file_get_lib(type, name, config);
 	if (! lib_path) {


### PR DESCRIPTION

# Summary of changes

- Wipe plugin structure before loading a plugin.
- Fix segfault when unloading plugins with no messages

# Description

This is a general solution to a specific problem I encountered, where a segfault is raised when a plugin is unloaded, if it does not provide icu messages, because the pointer is non-null.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
