### PR TITLE
Correct compare length of vendor IDs

### DIFF
--- a/src/tape_drivers/vendor_compat.c
+++ b/src/tape_drivers/vendor_compat.c
@@ -287,13 +287,13 @@ struct supported_device **get_supported_devs(const char *vendor_str)
 
 	if (! strncmp(vendor_str, IBM_VENDOR_ID, strlen(IBM_VENDOR_ID)))
 		cur = ibm_supported_drives;
-	else if (! strncmp(vendor_str, HP_VENDOR_ID, strlen(IBM_VENDOR_ID)))
+	else if (! strncmp(vendor_str, HP_VENDOR_ID, strlen(HP_VENDOR_ID)))
 		cur = hp_supported_drives;
-	else if (! strncmp(vendor_str, HPE_VENDOR_ID, strlen(IBM_VENDOR_ID)))
+	else if (! strncmp(vendor_str, HPE_VENDOR_ID, strlen(HPE_VENDOR_ID)))
 		cur = hp_supported_drives;
-	else if (! strncmp(vendor_str, TANDBERG_VENDOR_ID, strlen(IBM_VENDOR_ID)))
+	else if (! strncmp(vendor_str, TANDBERG_VENDOR_ID, strlen(TANDBERG_VENDOR_ID)))
 		cur = hp_supported_drives;
-	else if (! strncmp(vendor_str, QUANTUM_VENDOR_ID, strlen(IBM_VENDOR_ID)))
+	else if (! strncmp(vendor_str, QUANTUM_VENDOR_ID, strlen(QUANTUM_VENDOR_ID)))
 		cur = quantum_supported_drives;
 
 	return cur;


### PR DESCRIPTION
# Summary of changes

Fix of #298 (f0575354f60839c1cc0f2774aae8dc41af85b514)

# Description

Change to correct vendor ID length to each vendors.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
