### PR TITLE
Fix fallback to pkg-config when icu-config missing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -341,7 +341,7 @@ ICU_MODULE_CFLAGS="`icu-config --cppflags 2> /dev/null`";
 ICU_MODULE_LIBS="`icu-config --ldflags 2> /dev/null`";
 if test -z "$ICU_MODULE_LIBS"
 then
-    PKG_CHECK_MODULES([ICU_MODULE], [icu >= 0.21])
+    PKG_CHECK_MODULES([ICU_MODULE], [icu-uc >= 0.21])
 fi
 
 AC_MSG_CHECKING([use latest ICU])


### PR DESCRIPTION
This fixes building LTFS on Debian 11.