### PR TITLE
Tiny correction for sync fail

### DIFF
--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -2380,7 +2380,7 @@ int ltfs_write_index(char partition, char *reason, struct ltfs_volume *vol)
 	bool generation_inc = false;
 	struct tc_position physical_selfptr;
 	char *cache_path_save = NULL;
-	bool write_perm = (strcmp(reason, SYNCWRITE_PERM) == 0);
+	bool write_perm = (strcmp(reason, SYNC_WRITE_PERM) == 0);
 	bool update_vollock = false;
 	int volstat = -1, new_volstat = 0;
 	char *bc_print = NULL;

--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -2380,7 +2380,7 @@ int ltfs_write_index(char partition, char *reason, struct ltfs_volume *vol)
 	bool generation_inc = false;
 	struct tc_position physical_selfptr;
 	char *cache_path_save = NULL;
-	bool write_perm = (strcmp(reason, SYNC_WRITE_PERM) == 0);
+	bool write_perm = (strcmp(reason, SYNCWRITE_PERM) == 0);
 	bool update_vollock = false;
 	int volstat = -1, new_volstat = 0;
 	char *bc_print = NULL;
@@ -3549,7 +3549,7 @@ start:
 			ret_r = ltfs_write_index(ltfs_ip_id(vol), SYNC_WRITE_PERM, vol);
 			if (!ret_r) {
 				ltfsmsg(LTFS_INFO, 11344I, bc_print);
-				ret = LTFS_SYNC_FAIL_ON_DP;
+				ret = -LTFS_SYNC_FAIL_ON_DP;
 			} else {
 				ltfsmsg(LTFS_ERR, 11345E, bc_print);
 				ltfsmsg(LTFS_ERR, 11346E, bc_print);


### PR DESCRIPTION
# Summary of changes

Set negative value correctly when sync failure happens.

- Additional fix of issue #315 (#316)

# Description

Currently error code of the sync failure is not correct (return a positive value). But it is wrong, need to return negative value.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
