### PR TITLE
Support `ltfs.hash.*` EAs

### DIFF
--- a/src/libltfs/ltfs_fsops.c
+++ b/src/libltfs/ltfs_fsops.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2021 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions
@@ -47,6 +47,10 @@
 **                  Lucas C. Villa Real
 **                  IBM Almaden Research Center
 **                  lucasvr@us.ibm.com
+**
+**                  Atsushi Abe
+**                  IBM Tokyo Lab., Japan
+**                  piste@jp.ibm.com
 **
 *************************************************************************************
 */
@@ -1037,7 +1041,7 @@ int ltfs_fsops_setxattr(const char *path, const char *name, const char *value, s
 		goto out_free;
 	}
 
-	new_name_strip = _xattr_strip_name(new_name);
+	new_name_strip = xattr_strip_name(new_name);
 	if (! new_name_strip) {
 		/* Namespace is not supported (Linux) */
 		ret = -LTFS_XATTR_NAMESPACE;
@@ -1153,7 +1157,7 @@ int ltfs_fsops_getxattr(const char *path, const char *name, char *value, size_t 
 			ltfsmsg(LTFS_ERR, 11125E, ret);
 		goto out_free;
 	}
-	new_name_strip = _xattr_strip_name(new_name);
+	new_name_strip = xattr_strip_name(new_name);
 	if (! new_name_strip) {
 		/* Namespace is not supported (Linux) */
 		ret = -LTFS_NO_XATTR;
@@ -1305,7 +1309,7 @@ int ltfs_fsops_removexattr(const char *path, const char *name, ltfs_file_id *id,
 			ltfsmsg(LTFS_ERR, 11137E, ret);
 		goto out_free;
 	}
-	new_name_strip = _xattr_strip_name(new_name);
+	new_name_strip = xattr_strip_name(new_name);
 	if (! new_name_strip) {
 		/* Namespace is not supported (Linux) */
 		ret = -LTFS_NO_XATTR;

--- a/src/libltfs/xattr.h
+++ b/src/libltfs/xattr.h
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2021 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions
@@ -48,6 +48,10 @@
 **                  IBM Almaden Research Center
 **                  lucasvr@us.ibm.com
 **
+**                  Atsushi Abe
+**                  IBM Tokyo Lab., Japan
+**                  piste@jp.ibm.com
+**
 *************************************************************************************
 */
 
@@ -73,14 +77,11 @@ int xattr_get(struct dentry *d, const char *name, char *value, size_t size,
 int xattr_list(struct dentry *d, char *list, size_t size, struct ltfs_volume *vol);
 int xattr_remove(struct dentry *d, const char *name, struct ltfs_volume *vol);
 
-int _xattr_get_string(const char *val, char **outval, const char *msg);
-int _xattr_get_u64(uint64_t val, char **outval, const char *msg);
-
 /** For internal use only */
 int xattr_do_set(struct dentry *d, const char *name, const char *value, size_t size,
 	struct xattr_info *xattr);
 int xattr_do_remove(struct dentry *d, const char *name, bool force, struct ltfs_volume *vol);
-const char *_xattr_strip_name(const char *name);
+const char *xattr_strip_name(const char *name);
 int xattr_set_mountpoint_length(struct dentry *d, const char* value, size_t size);
 
 #ifdef __cplusplus


### PR DESCRIPTION


# Summary of changes

Support `ltfs.hash.*` EAs introduced into the LTFS format spec 2.4.

- Fix of issue #297

# Description

This commit also includes the refactoring about xattr.c.

Fixes #297

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
