### PR TITLE
Fix link failure in Debian11

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -572,6 +572,7 @@ fi
 if test "x${host_mac}" = "xno"
 then
     MODULE_CHECK_LD='-Wl,--no-undefined,--as-needed'
+    AM_LDFLAGS="${AM_LDFLAGS} -ldl"
 fi
 
 AM_CFLAGS=`echo ${AM_CFLAGS} | ${SED} 's|-D_FORTIFY_SOURCE=. ||g'`


### PR DESCRIPTION
# Summary of changes

- Fix of issue #328

# Description

The option `-ldl` shall set to the linker option anytime because it is required for loading backend. So we don't expect to be set it by other library's option configuration.

Fixes #328

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
