### PR TITLE
Fix filehandle corruption on LP64

### DIFF
--- a/src/ltfs_fuse.c
+++ b/src/ltfs_fuse.c
@@ -54,6 +54,9 @@
 **
 *************************************************************************************
 */
+
+#include <limits.h> /* for ULONG_MAX */
+
 #include "ltfs_fuse.h"
 #include "libltfs/ltfs_fsops.h"
 #include "libltfs/iosched.h"
@@ -68,7 +71,7 @@
 #include "libltfs/arch/win/win_util.h"
 #endif
 
-#if (__WORDSIZE == 64)
+#if (__WORDSIZE == 64 || ULONG_MAX == 0xffffffffffffffffUL)
 #define FILEHANDLE_TO_STRUCT(fh) ((struct ltfs_file_handle *)(uint64_t)(fh))
 #define STRUCT_TO_FILEHANDLE(de) ((uint64_t)(de))
 #else


### PR DESCRIPTION
Do not take for granted that __WORDSIZE is defined to distinguish between 32 and 64 bit platforms. If undefined on LP64 machine, STRUCT_TO_FILEHANDLE corrupts the filehande.

Instead use ULONG_MAX from <limits.h> which is mandated by ISO C99.
