### PR TITLE
Return an error without issuing GRAO command in LTO9-HH

### DIFF
--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -5040,8 +5040,9 @@ int sg_grao(void *device, unsigned char *buf, const uint32_t len)
 
 	if (IS_LTO(priv->drive_type)) {
 		if ( DRIVE_GEN(priv->drive_type) == 0x05 || DRIVE_GEN(priv->drive_type) == 0x06 ||
-			 DRIVE_GEN(priv->drive_type) == 0x07 || DRIVE_GEN(priv->drive_type) == 0x08 ) {
-			/* LTO6-LTO8 don't support RAO commands */
+			 DRIVE_GEN(priv->drive_type) == 0x07 || DRIVE_GEN(priv->drive_type) == 0x08 ||
+			 DRIVE_GEN(priv->drive_type) == DRIVE_LTO9_HH ) {
+			/* LTO5-LTO8 and LTO9-HH don't support RAO commands */
 			return -EDEV_UNSUPPORETD_COMMAND;
 		}
 	}


### PR DESCRIPTION
# Summary of changes

Return an error without issuing GRAO command in LTO9-HH. 

# Description

LTO9-HH doesn't support RAO feature. At this time, LTFS issues GRAO command even if the drive is LTO9-HH and receive an invalid CDB error. As a result, LTFS captures a drive dump.

Fixes #347

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
