### PR TITLE
Improve error position detention at WRITE PERM

### DIFF
--- a/.github/workflows/build-centos7.yml
+++ b/.github/workflows/build-centos7.yml
@@ -12,6 +12,6 @@ jobs:
         uses: actions/checkout@v1
       - name: Build LTFS
         id: build
-        uses: LinearTapeFileSystem/CentOS7-Build@v1.3
+        uses: LinearTapeFileSystem/CentOS7-Build@v1.4
         with:
           destination: '/tmp/ltfs'

--- a/.github/workflows/build-centos8.yml
+++ b/.github/workflows/build-centos8.yml
@@ -12,6 +12,6 @@ jobs:
         uses: actions/checkout@v1
       - name: Build LTFS
         id: build
-        uses: LinearTapeFileSystem/CentOS8-Build@v1.5
+        uses: LinearTapeFileSystem/CentOS8-Build@v1.6
         with:
           destination: '/tmp/ltfs'

--- a/messages/iosched_unified/root.txt
+++ b/messages/iosched_unified/root.txt
@@ -62,7 +62,8 @@ root:table {
 		13022W:string { "Freeing a dentry priv with outstanding write requests. This is a bug." }
 		//unused 13023W:string { "Failed to copy a request: will stop writing file to the index partition." }
 		13024I:string { "Clean up extents and append index at index partition (%d)." }
-		13025I:string { "Get error position (%d, %d)." }
+		13025I:string { "Truncate extents larger than position (%d, %lld), block size = %ld." }
 		13026E:string { "Write perm handling error : %s (%d)." }
+		13027I:string { "Error position is larger than last index position: (%d, %lld), last index = %lld." }
 	}
 }

--- a/messages/libltfs/root.txt
+++ b/messages/libltfs/root.txt
@@ -429,7 +429,7 @@ root:table {
 		11332I:string { "Load successful." }
 		11333I:string { "A cartridge with write-perm error is detected on %s. Seek the newest index (IP: Gen = %llu, VCR = %llu) (DP: Gen = %llu, VCR = %llu) (VCR = %llu)." }
 		11334I:string { "Remove extent : %s (%llu, %llu)." }
-		11335D:string { "Get physical block position (%d - %d)." }
+		//unused 11335D:string { "Get physical block position (%d - %d)." }
 		11336I:string { "The attribute does not exist. Ignore the expected error." }
 		11337I:string { "Update index-dirty flag (%d) - %s (0x%p)." }
 		11338I:string { "Syncing index of %s %s." }
@@ -833,6 +833,7 @@ v
 		17289I:string { "Skip parsing the final index on IP." }
 		17290I:string { "Partitioning the medium with the destructive method." }
 		17291I:string { "Unpartitioning the medium with the destructive method." }
+		17292I:string { "Current position is (%llu, %llu), Error position is (%llu, %llu)." }
 
 		// For Debug 19999I:string { "%s %s %d." }
 

--- a/src/libltfs/tape.h
+++ b/src/libltfs/tape.h
@@ -165,7 +165,7 @@ int tape_update_position(struct device_data *dev, struct tc_position *pos);
 int tape_seek(struct device_data *dev, struct tc_position *pos);
 int tape_seek_eod(struct device_data *dev, tape_partition_t partition);
 int tape_seek_append_position(struct device_data *dev, tape_partition_t prt, bool unlock_write);
-int tape_get_physical_block_position(struct device_data *dev, struct tc_position *pos);
+int tape_get_first_untransfered_position(struct device_data *dev, struct tc_position *pos);
 
 int tape_spacefm(struct device_data *dev, int count);
 ssize_t tape_read(struct device_data *dev, char *buf, size_t count, const bool unusual_size,

--- a/src/libltfs/tape_ops.h
+++ b/src/libltfs/tape_ops.h
@@ -915,12 +915,12 @@ struct tape_ops {
 	int   (*set_profiler)(void *device, char *work_dir, bool enable);
 
 	/**
-	 * Get block number stored in the drive buffer
+	 * Get first block number which is not transferred to the medium yet in the buffer
 	 * @param device A pointer to the tape device
-	 * @param block Number of blocks stored in the drive buffer
+	 * @param pos Position of the record that is not transferred yet in the buffer
 	 * @return 0 on success or a negative value on error
 	 */
-	int   (*get_block_in_buffer)(void *device, unsigned int *block);
+	int   (*get_next_block_to_xfer)(void *device, struct tc_position *pos);
 
 	/**
 	 * Check if the generation of tape drive and the current loaded cartridge is read-only combination

--- a/src/tape_drivers/freebsd/cam/cam_tc.c
+++ b/src/tape_drivers/freebsd/cam/cam_tc.c
@@ -1193,10 +1193,10 @@ int camtape_unload(void *device, struct tc_position *pos)
 }
 
 /*
- * Get the number of blocks in the buffer on the tape drive after a write.  Eventually it would
+ * Get the first block position that is not transferred to the medium. Eventually it would
  * be nice to include this in status information returned from the sa(4) driver.
  */
-static int camtape_get_block_in_buffer(void *device, uint32_t *block)
+static int camtape_get_next_block_to_xfer(void *device, struct tc_position *pos)
 {
 	int rc;
 	union ccb *ccb = NULL;
@@ -1240,9 +1240,10 @@ static int camtape_get_block_in_buffer(void *device, uint32_t *block)
 	if (rc != DEVICE_GOOD)
 		camtape_process_errors(softc, rc, msg, "READPOS", true);
 	else {
-		*block = scsi_3btoul(ext_data.num_objects);
-		ltfsmsg(LTFS_DEBUG, 30398D, "blocks-in-buffer",
-				(unsigned long long) *block, 0, 0, softc->drive_serial);
+		pos->partition = ext_data.partition;
+		pos->block = scsi_8btou64(ext_data.last_object)
+		ltfsmsg(LTFS_DEBUG, 30398D, "next-block-to-xfer",
+				(unsigned long long) pos->block, 0, 0, softc->drive_serial);
 	}
 
 bailout:
@@ -4170,7 +4171,7 @@ struct tape_ops camtape_drive_handler = {
 	.get_serialnumber		= camtape_get_serialnumber,
 	.get_info               = camtape_get_info,
 	.set_profiler			= camtape_set_profiler,
-	.get_block_in_buffer	= camtape_get_block_in_buffer,
+	.get_next_block_to_xfer = camtape_get_next_block_to_xfer,
 	.is_readonly			= camtape_is_readonly
 };
 

--- a/src/tape_drivers/generic/file/filedebug_tc.c
+++ b/src/tape_drivers/generic/file/filedebug_tc.c
@@ -1873,8 +1873,7 @@ int filedebug_set_xattr(void *device, const char *name, const char *buf, size_t 
 			state->force_writeperm = perm_count;
 			state->clear_by_pc     = false;
 		}
-		//if (state->force_writeperm && state->force_writeperm < THRESHOLD_FORCE_WRITE_NO_WRITE)
-		//	state->force_writeperm = THRESHOLD_FORCE_WRITE_NO_WRITE;
+
 		state->write_counter = 0;
 		ret = DEVICE_GOOD;
 	} else if (! strcmp(name, "ltfs.vendor.IBM.forceErrorType")) {

--- a/src/tape_drivers/generic/file/filedebug_tc.c
+++ b/src/tape_drivers/generic/file/filedebug_tc.c
@@ -814,7 +814,8 @@ int filedebug_write(void *device, const char *buf, size_t count, struct tc_posit
 				return -EDEV_WRITE_PERM;
 		} else if ( state->write_counter > (state->force_writeperm - THRESHOLD_FORCE_WRITE_NO_WRITE) ) {
 			ltfsmsg(LTFS_INFO, 30019I);
-			pos->block++;
+			++state->current_position.block;
+			pos->block = state->current_position.block;
 			return DEVICE_GOOD;
 		}
 	}
@@ -1872,8 +1873,8 @@ int filedebug_set_xattr(void *device, const char *name, const char *buf, size_t 
 			state->force_writeperm = perm_count;
 			state->clear_by_pc     = false;
 		}
-		if (state->force_writeperm && state->force_writeperm < THRESHOLD_FORCE_WRITE_NO_WRITE)
-			state->force_writeperm = THRESHOLD_FORCE_WRITE_NO_WRITE;
+		//if (state->force_writeperm && state->force_writeperm < THRESHOLD_FORCE_WRITE_NO_WRITE)
+		//	state->force_writeperm = THRESHOLD_FORCE_WRITE_NO_WRITE;
 		state->write_counter = 0;
 		ret = DEVICE_GOOD;
 	} else if (! strcmp(name, "ltfs.vendor.IBM.forceErrorType")) {
@@ -2776,9 +2777,13 @@ int filedebug_set_profiler(void *device, char *work_dir, bool enable)
 	return 0;
 }
 
-int filedebug_get_block_in_buffer(void *device, unsigned int *block)
+int filedebug_get_next_block_to_xfer(void *device, struct tc_position *pos)
 {
-	*block = 0;
+	struct filedebug_data *state = (struct filedebug_data *)device;
+
+	pos->partition = state->current_position.partition;
+	pos->block     = state->current_position.block - THRESHOLD_FORCE_WRITE_NO_WRITE;
+
 	return 0;
 }
 
@@ -2837,7 +2842,7 @@ struct tape_ops filedebug_handler = {
 	.get_serialnumber       = filedebug_get_serialnumber,
 	.get_info               = filedebug_get_info,
 	.set_profiler           = filedebug_set_profiler,
-	.get_block_in_buffer    = filedebug_get_block_in_buffer,
+	.get_next_block_to_xfer = filedebug_get_next_block_to_xfer,
 	.is_readonly            = filedebug_is_readonly,
 };
 

--- a/src/tape_drivers/generic/itdtimg/itdtimg_tc.c
+++ b/src/tape_drivers/generic/itdtimg/itdtimg_tc.c
@@ -1457,10 +1457,10 @@ int itdtimage_set_profiler(void *device, char *work_dir, bool enable)
 	return 0;
 }
 
-int itdtimage_get_block_in_buffer(void *device, unsigned int *block)
+int itdtimage_get_next_block_to_xfer(void *device, struct tc_position *pos)
 {
-	*block = 0;
-	return 0;
+	/* This backend never accept write command */
+	return -EDEV_WRITE_PROTECTED;;
 }
 
 /* Local functions */
@@ -1664,7 +1664,7 @@ struct tape_ops itdtimage_handler = {
 	.get_serialnumber       = itdtimage_get_serialnumber,
 	.get_info               = itdtimage_get_info,
 	.set_profiler           = itdtimage_set_profiler,
-	.get_block_in_buffer    = itdtimage_get_block_in_buffer,
+	.get_next_block_to_xfer = itdtimage_get_next_block_to_xfer,
 	.is_readonly 			= itdtimage_is_readonly,
 };
 

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -2749,7 +2749,7 @@ int sg_readpos(void *device, struct tc_position *pos)
 	struct sg_data *priv = (struct sg_data*)device;
 
 	sg_io_hdr_t req;
-	unsigned char cdb[CDB6_LEN];
+	unsigned char cdb[CDB10_LEN];
 	unsigned char sense[MAXSENSE];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "READPOS";
@@ -4956,14 +4956,14 @@ int sg_set_profiler(void *device, char *work_dir, bool enable)
 	return rc;
 }
 
-int sg_get_block_in_buffer(void *device, uint32_t *block)
+int sg_get_next_block_to_xfer(void *device, struct tc_position *pos)
 {
 	int ret = -EDEV_UNKNOWN;
 	int ret_ep = DEVICE_GOOD;
 	struct sg_data *priv = (struct sg_data*)device;
 
 	sg_io_hdr_t req;
-	unsigned char cdb[CDB6_LEN];
+	unsigned char cdb[CDB10_LEN];
 	unsigned char sense[MAXSENSE];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "READPOS";
@@ -4971,6 +4971,8 @@ int sg_get_block_in_buffer(void *device, uint32_t *block)
 	unsigned char buf[REDPOS_EXT_LEN];
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_READPOS));
+
+	memset(pos, 0, sizeof(struct tc_position));
 
 	/* Zero out the CDB and the result buffer */
 	ret = init_sg_io_header(&req);
@@ -4983,6 +4985,7 @@ int sg_get_block_in_buffer(void *device, uint32_t *block)
 	/* Build CDB */
 	cdb[0] = READ_POSITION;
 	cdb[1] = 0x08; /* Extended Format */
+	ltfs_u16tobe(cdb + 7, sizeof(buf)); /* allocation length */
 
 	timeout = get_timeout(priv->timeouts, cdb[0]);
 	if (timeout < 0)
@@ -5001,10 +5004,11 @@ int sg_get_block_in_buffer(void *device, uint32_t *block)
 
 	ret = sg_issue_cdb_command(&priv->dev, &req, &msg);
 	if (ret == DEVICE_GOOD) {
-		*block = (buf[5] << 16) + (buf[6] << 8) + (int)buf[7];
+		pos->partition = (tape_partition_t)buf[1];
+		pos->block     = ltfs_betou64(buf + 16);
 
-		ltfsmsg(LTFS_DEBUG, 30398D, "blocks-in-buffer",
-				(unsigned long long)*block, (unsigned long long)0, (unsigned long long)0, priv->drive_serial);
+		ltfsmsg(LTFS_DEBUG, 30398D, "next-block-to-xfer",
+				(unsigned long long)pos->partition, (unsigned long long)pos->block, (unsigned long long)0, priv->drive_serial);
 	} else {
 		ret_ep = _process_errors(device, ret, msg, cmd_desc, true, true);
 		if (ret_ep < 0)
@@ -5201,7 +5205,7 @@ struct tape_ops sg_handler = {
 	.get_serialnumber       = sg_get_serialnumber,
 	.get_info               = sg_get_info,
 	.set_profiler           = sg_set_profiler,
-	.get_block_in_buffer    = sg_get_block_in_buffer,
+	.get_next_block_to_xfer = sg_get_next_block_to_xfer,
 	.is_readonly            = sg_is_readonly,
 };
 

--- a/src/tape_drivers/osx/iokit/iokit_tape.c
+++ b/src/tape_drivers/osx/iokit/iokit_tape.c
@@ -2116,7 +2116,7 @@ int iokit_readpos(void *device, struct tc_position *pos)
 	struct iokit_data *priv = (struct iokit_data*)device;
 
 	struct iokit_scsi_request req;
-	unsigned char cdb[CDB6_LEN];
+	unsigned char cdb[CDB10_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "READPOS";
 	char *msg = NULL;
@@ -4225,13 +4225,13 @@ int iokit_set_profiler(void *device, char *work_dir, bool enable)
 	return rc;
 }
 
-int iokit_get_block_in_buffer(void *device, uint32_t *block)
+int iokit_get_next_block_to_xfer(void *device, struct tc_position *pos)
 {
 	int ret = -EDEV_UNKNOWN;
 	struct iokit_data *priv = (struct iokit_data*)device;
 
 	struct iokit_scsi_request req;
-	unsigned char cdb[CDB6_LEN];
+	unsigned char cdb[CDB10_LEN];
 	int timeout;
 	char cmd_desc[COMMAND_DESCRIPTION_LENGTH] = "READPOS";
 	char *msg = NULL;
@@ -4239,12 +4239,16 @@ int iokit_get_block_in_buffer(void *device, uint32_t *block)
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_READPOS));
 
+	memset(pos, 0, sizeof(struct tc_position));
+
 	/* Zero out the CDB and the result buffer */
 	memset(cdb, 0, sizeof(cdb));
+	memset(&req, 0, sizeof(struct iokit_scsi_request));
 
 	/* Build CDB */
 	cdb[0] = READ_POSITION;
 	cdb[1] = 0x08; /* Extended Format */
+	ltfs_u16tobe(cdb + 7, sizeof(buf)); /* allocation length */
 
 	timeout = get_timeout(priv->timeouts, cdb[0]);
 	if (timeout < 0)
@@ -4263,10 +4267,10 @@ int iokit_get_block_in_buffer(void *device, uint32_t *block)
 
 	ret = iokit_issue_cdb_command(&priv->dev, &req, &msg);
 	if (ret == DEVICE_GOOD) {
-		*block = (buf[5] << 16) + (buf[6] << 8) + (int)buf[7];
+		pos->partition = (tape_partition_t)buf[1];
+		pos->block     = ltfs_betou64(buf + 16);
 
-		ltfsmsg(LTFS_DEBUG, 30998D, "blocks-in-buffer",
-				(unsigned long long) *block, (unsigned long long)0, (unsigned long long)0, priv->drive_serial);
+		ltfsmsg(LTFS_DEBUG, 30998D, "next-block-to-xfer",
 	} else {
 		_process_errors(device, ret, msg, cmd_desc, true);
 	}
@@ -4332,7 +4336,7 @@ struct tape_ops iokit_handler = {
 	.get_serialnumber       = iokit_get_serialnumber,
 	.get_info               = iokit_get_info,
 	.set_profiler           = iokit_set_profiler,
-	.get_block_in_buffer    = iokit_get_block_in_buffer,
+	.get_next_block_to_xfer = iokit_get_next_block_to_xfer,
 	.is_readonly            = iokit_is_readonly,
 };
 

--- a/src/tape_drivers/osx/iokit/iokit_tape.c
+++ b/src/tape_drivers/osx/iokit/iokit_tape.c
@@ -4271,6 +4271,7 @@ int iokit_get_next_block_to_xfer(void *device, struct tc_position *pos)
 		pos->block     = ltfs_betou64(buf + 16);
 
 		ltfsmsg(LTFS_DEBUG, 30998D, "next-block-to-xfer",
+				(unsigned long long)pos->partition, (unsigned long long)pos->block, (unsigned long long)0, priv->drive_serial);
 	} else {
 		_process_errors(device, ret, msg, cmd_desc, true);
 	}

--- a/src/tape_drivers/tape_drivers.h
+++ b/src/tape_drivers/tape_drivers.h
@@ -89,7 +89,8 @@ typedef int   (*crc_check)(void *buf, size_t n);
 typedef void* (*memcpy_crc_enc)(void *dest, const void *src, size_t n);
 typedef int   (*memcpy_crc_check)(void *dest, const void *src, size_t n);
 
-#define THRESHOLD_FORCE_WRITE_NO_WRITE  (5)
+
+#define THRESHOLD_FORCE_WRITE_NO_WRITE  (20)
 #define DEFAULT_WRITEPERM               (0)
 #define DEFAULT_READPERM                (0)
 #define DEFAULT_ERRORTYPE               (0)


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Fix of issue #36

# Description

 - Changes backend interface for handling write perm
     - Previously, it returns number of records in the drive buffer. Currently, it returns first untransferred record position to tape (In other words written but not transferred to tape yet) and it is used as error position
 - Consider the final index on the partition as error position even if very small number is returned (this is a safeguard to avoid over kill of extents)

Fixes #36

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works

--- 
Test Log

```
On Linux
3135 LTFS11031I Volume mounted successfully. NO_BARCODE : Gen = 2 / (a, 5) -> (b, 8008) / 00013B0119.
3135 LTFS14111I Initial setup completed successfully.
3135 LTFS14112I Invoke 'mount' command to check the result of final setup.
3135 LTFS14113I Specified mount point is listed if succeeded.
314f LTFS14029I Ready to receive file system requests.
3151 LTFS11337I Update index-dirty flag (1) - NO_BARCODE (0x0x1fb51f0).
3152 LTFS30205I WRITE (0x0a) returns -20301.
3152 LTFS30263I WRITE returns Cartridge Fault (-20301) /dev/sg119.
3152 LTFS30261I Taking drive dump in buffer.
3152 LTFS30253I Saving drive dump to /tmp/ltfs_00013B0119_2022_0808_143413.dmp.
3152 LTFS30262I Forcing drive dump.
3152 LTFS30253I Saving drive dump to /tmp/ltfs_00013B0119_2022_0808_143413_f.dmp.
3152 LTFS12045E Cannot write block: backend call failed (-20301). Dropping to read-only mode.
3152 LTFS11072E Cannot write blocks: failed to write to the medium (-20301).
3152 LTFS11077E Cannot write: failed to write blocks to the medium (-20301).
3152 LTFS13014W Data partition writer: failed to write data to the tape (-20301).
3152 LTFS13024I Clean up extents and append index at index partition (-20301).
3152 LTFS17292I Current position is (1, 8715), Error position is (1, 8011).
3152 LTFS13025I Truncate extents larger than position (1, 8011), block size = 524288.
3152 LTFS11334I Remove extent : errfile1 (8011, 369098752).
3152 LTFS11343I Try to write an index on the IP on NO_BARCODE because of a permanent write error on the DP..
3152 LTFS17235I Writing index of NO_BARCODE to a (Reason: Write perm, 4 files) 00013B0119.
3152 LTFS17236I Wrote index of NO_BARCODE (Gen = 3, Part = a, Pos = 8, 00013B0119).
3152 LTFS11337I Update index-dirty flag (0) - NO_BARCODE (0x0x1fb51f0).

On Mac
103 LTFS11031I Volume mounted successfully. NO_BARCODE : Gen = 2 / (a, 5) -> (b, 8008) / 00013B0119.
103 LTFS14111I Initial setup completed successfully.
103 LTFS14112I Invoke 'mount' command to check the result of final setup.
103 LTFS14113I Specified mount point is listed if succeeded.
2203 LTFS14029I Ready to receive file system requests.
3203 LTFS11337I Update index-dirty flag (1) - NO_BARCODE (0x0x7ff446705100).
1803 LTFS30808I WRITE (0x0a) returns -20301.
1803 LTFS30865I WRITE returns Cartridge Fault (-20301) 00013B0119.
1803 LTFS30863I Taking drive dump in buffer.
1803 LTFS30855I Saving drive dump to /tmp/ltfs_00013B0119_2022_0808_145738.dmp.
1803 LTFS30864I Forcing drive dump.
1803 LTFS30855I Saving drive dump to /tmp/ltfs_00013B0119_2022_0808_145738_f.dmp.
1803 LTFS12045E Cannot write block: backend call failed (-20301). Dropping to read-only mode.
1803 LTFS11072E Cannot write blocks: failed to write to the medium (-20301).
1803 LTFS11077E Cannot write: failed to write blocks to the medium (-20301).
1803 LTFS13014W Data partition writer: failed to write data to the tape (-20301).
1803 LTFS13024I Clean up extents and append index at index partition (-20301).
3103 LTFS30803I Failed to execute CDB, The opcode = 00 (-536870187).
3103 LTFS30808I TEST_UNIT_READY (0x00) returns -21700.
3103 LTFS12029E Device is not ready (-21700).
1803 LTFS17292I Current position is (1, 9289), Error position is (1, 8020).
1803 LTFS13025I Truncate extents larger than position (1, 8020), block size = 524288.
1803 LTFS11334I Remove extent : errfile1 (8011, 670040064).
1803 LTFS11343I Try to write an index on the IP on NO_BARCODE because of a permanent write error on the DP..
1903 LTFS30803I Failed to execute CDB, The opcode = 00 (-536870187).
1903 LTFS30808I TEST_UNIT_READY (0x00) returns -21700.
1903 LTFS12029E Device is not ready (-21700).
1803 LTFS17235I Writing index of NO_BARCODE to a (Reason: Write perm, 4 files) 00013B0119.
1803 LTFS17236I Wrote index of NO_BARCODE (Gen = 3, Part = a, Pos = 8, 00013B0119).
1803 LTFS11337I Update index-dirty flag (0) - NO_BARCODE (0x0x7ff446705100).
```