### PR TITLE
Modify linker flags

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -40,7 +40,7 @@ ltfs_SOURCES = main.c ltfs_fuse.c
 ltfs_DEPENDENCIES = libltfs/libltfs.la ../messages/libbin_ltfs_dat.a
 ltfs_CPPFLAGS = @AM_CPPFLAGS@ -I ../ltfs-sde/src -fPIC
 ltfs_LDADD = libltfs/libltfs.la
-ltfs_LDFLAGS = @AM_LDFLAGS@ -L../messages -lbin_ltfs_dat
+ltfs_LDFLAGS = @AM_LDFLAGS@ ../messages/libbin_ltfs_dat.a
 endif
 
 PLAT_DRV =

--- a/src/iosched/Makefile.am
+++ b/src/iosched/Makefile.am
@@ -39,13 +39,13 @@ BASENAMES = libiosched-fcfs libiosched-unified
 AM_LIBTOOLFLAGS = --tag=disable-static
 
 libiosched_fcfs_la_SOURCES = fcfs.c
-libiosched_fcfs_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ -L../../messages/ -liosched_fcfs_dat
+libiosched_fcfs_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ ../../messages/libiosched_fcfs_dat.a
 libiosched_fcfs_la_DEPENDENCIES = ../../messages/libiosched_fcfs_dat.a ../libltfs/libltfs.la
 libiosched_fcfs_la_LIBADD = ../libltfs/libltfs.la
 libiosched_fcfs_la_CPPFLAGS = @AM_CPPFLAGS@ -I ..
 
 libiosched_unified_la_SOURCES = unified.c cache_manager.c
-libiosched_unified_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ -L../../messages/ -liosched_unified_dat
+libiosched_unified_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ ../../messages/libiosched_unified_dat.a
 libiosched_unified_la_DEPENDENCIES = ../../messages/libiosched_unified_dat.a ../libltfs/libltfs.la
 libiosched_unified_la_LIBADD = ../libltfs/libltfs.la
 libiosched_unified_la_CPPFLAGS = @AM_CPPFLAGS@ -I ..

--- a/src/kmi/Makefile.am
+++ b/src/kmi/Makefile.am
@@ -41,13 +41,13 @@ AM_LIBTOOLFLAGS = --tag=disable-static
 libkmi_simple_la_SOURCES = simple.c key_format_ltfs.c
 libkmi_simple_la_DEPENDENCIES = ../../messages/libkmi_simple_dat.a ../libltfs/libltfs.la
 libkmi_simple_la_LIBADD = ../libltfs/libltfs.la
-libkmi_simple_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ -L../../messages -lkmi_simple_dat
+libkmi_simple_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ ../../messages/libkmi_simple_dat.a
 libkmi_simple_la_CPPFLAGS = @AM_CPPFLAGS@ -I .. -DKMI_SIMPLE
 
 libkmi_flatfile_la_SOURCES = flatfile.c key_format_ltfs.c
 libkmi_flatfile_la_DEPENDENCIES = ../../messages/libkmi_flatfile_dat.a ../libltfs/libltfs.la
 libkmi_flatfile_la_LIBADD = ../libltfs/libltfs.la
-libkmi_flatfile_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ -L../../messages -lkmi_flatfile_dat
+libkmi_flatfile_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ ../../messages/libkmi_flatfile_dat.a
 libkmi_flatfile_la_CPPFLAGS = @AM_CPPFLAGS@ -I ..
 
 install-exec-hook:

--- a/src/libltfs/Makefile.am
+++ b/src/libltfs/Makefile.am
@@ -71,7 +71,7 @@ libltfs_la_SOURCES = \
 libltfs_la_DEPENDENCIES = ../../messages/liblibltfs_dat.a ../../messages/libinternal_error_dat.a ../../messages/libtape_common_dat.a
 libltfs_la_LIBADD =
 libltfs_la_CPPFLAGS = @AM_CPPFLAGS@ @AM_EXTRA_CPPFLAGS@ @AM_EXTRA_CPPFLAGS@ -I ..
-libltfs_la_LDFLAGS = @AM_LDFLAGS@ -L../../messages -llibltfs_dat -linternal_error_dat -ltape_common_dat
+libltfs_la_LDFLAGS = @AM_LDFLAGS@ ../../messages/liblibltfs_dat.a ../../messages/libinternal_error_dat.a ../../messages/libtape_common_dat.a
 
 install-data-local:
 	if [ ! -d "$(DESTDIR)$(prefix)/share/snmp" ]; then \

--- a/src/tape_drivers/freebsd/cam/Makefile.am
+++ b/src/tape_drivers/freebsd/cam/Makefile.am
@@ -41,9 +41,9 @@ BASENAMES = libtape-cam
 AM_LIBTOOLFLAGS = --tag=disable-static
 
 libtape_cam_la_SOURCES = cam_cmn.c cam_tc.c vendor_compat.c ibm_tape.c hp_tape.c quantum_tape.c
-libtape_cam_la_DEPENDENCIES = ../../../../messages/libtape_freebsd_cam_dat.a ../../../libltfs/libltfs.la libtape_cam_la-reed_solomon_crc.lo libtape_cam_la-crc32c_crc.lo 
-libtape_cam_la_LIBADD = ../../../libltfs/libltfs.la ./libtape_cam_la-reed_solomon_crc.lo ./libtape_cam_la-crc32c_crc.lo 
-libtape_cam_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ -L../../../../messages -ltape_freebsd_cam_dat
+libtape_cam_la_DEPENDENCIES = ../../../../messages/libtape_freebsd_cam_dat.a ../../../libltfs/libltfs.la libtape_cam_la-reed_solomon_crc.lo libtape_cam_la-crc32c_crc.lo
+libtape_cam_la_LIBADD = ../../../libltfs/libltfs.la ./libtape_cam_la-reed_solomon_crc.lo ./libtape_cam_la-crc32c_crc.lo
+libtape_cam_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ ../../../../messages/libtape_freebsd_cam_dat.a
 libtape_cam_la_CPPFLAGS = @AM_CPPFLAGS@ -I ../../.. -I ../..
 
 vendor_compat.c:

--- a/src/tape_drivers/generic/file/Makefile.am
+++ b/src/tape_drivers/generic/file/Makefile.am
@@ -41,7 +41,7 @@ AM_LIBTOOLFLAGS = --tag=disable-static
 libtape_file_la_SOURCES = filedebug_tc.c filedebug_conf_tc.c ibm_tape.c
 libtape_file_la_DEPENDENCIES = ../../../../messages/libtape_generic_file_dat.a ../../../libltfs/libltfs.la
 libtape_file_la_LIBADD  =../../../libltfs/libltfs.la
-libtape_file_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ -L../../../../messages/ -ltape_generic_file_dat
+libtape_file_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ ../../../../messages/libtape_generic_file_dat.a
 libtape_file_la_CPPFLAGS = @AM_CPPFLAGS@ -I ../../..
 
 ibm_tape.c:

--- a/src/tape_drivers/generic/itdtimg/Makefile.am
+++ b/src/tape_drivers/generic/itdtimg/Makefile.am
@@ -41,7 +41,7 @@ AM_LIBTOOLFLAGS = --tag=disable-static
 libtape_itdtimg_la_SOURCES = itdtimg_tc.c
 libtape_itdtimg_la_DEPENDENCIES = ../../../../messages/libtape_generic_itdtimg_dat.a ../../../libltfs/libltfs.la
 libtape_itdtimg_la_LIBADD = ../../../libltfs/libltfs.la
-libtape_itdtimg_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ -L../../../../messages -ltape_generic_itdtimg_dat
+libtape_itdtimg_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ ../../../../messages/libtape_generic_itdtimg_dat.a
 libtape_itdtimg_la_CPPFLAGS = @AM_CPPFLAGS@ -I ../../..
 
 install-exec-hook:

--- a/src/tape_drivers/linux/lin_tape/Makefile.am
+++ b/src/tape_drivers/linux/lin_tape/Makefile.am
@@ -41,7 +41,7 @@ AM_LIBTOOLFLAGS = --tag=disable-static
 libtape_lin_tape_la_SOURCES = lin_tape_ibmtape.c vendor_compat.c ibm_tape.c hp_tape.c quantum_tape.c
 libtape_lin_tape_la_DEPENDENCIES = ../../../../messages/libtape_linux_lin_tape_dat.a ../../../libltfs/libltfs.la ./libtape_lin_tape_la-reed_solomon_crc.lo ./libtape_lin_tape_la-crc32c_crc.lo
 libtape_lin_tape_la_LIBADD = ../../../libltfs/libltfs.la ./libtape_lin_tape_la-reed_solomon_crc.lo ./libtape_lin_tape_la-crc32c_crc.lo
-libtape_lin_tape_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ -L../../../../messages -ltape_linux_lin_tape_dat
+libtape_lin_tape_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ ../../../../messages/libtape_linux_lin_tape_dat.a
 libtape_lin_tape_la_CPPFLAGS = @AM_CPPFLAGS@ -I ../../.. -I ../..
 
 vendor_compat.c:

--- a/src/tape_drivers/linux/sg/Makefile.am
+++ b/src/tape_drivers/linux/sg/Makefile.am
@@ -41,7 +41,7 @@ AM_LIBTOOLFLAGS = --tag=disable-static
 libtape_sg_la_SOURCES = sg_scsi_tape.c sg_tape.c vendor_compat.c ibm_tape.c hp_tape.c quantum_tape.c open_factor.c
 libtape_sg_la_DEPENDENCIES = ../../../../messages/libtape_linux_sg_dat.a ../../../libltfs/libltfs.la ./libtape_sg_la-reed_solomon_crc.lo ./libtape_sg_la-crc32c_crc.lo
 libtape_sg_la_LIBADD = ../../../libltfs/libltfs.la ./libtape_sg_la-reed_solomon_crc.lo ./libtape_sg_la-crc32c_crc.lo
-libtape_sg_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ -L../../../../messages -ltape_linux_sg_dat
+libtape_sg_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ ../../../../messages/libtape_linux_sg_dat.a
 libtape_sg_la_CPPFLAGS = @AM_CPPFLAGS@ @AM_EXTRA_CPPFLAGS@ -I ../../.. -I ../..
 
 vendor_compat.c:

--- a/src/tape_drivers/netbsd/scsipi-ibmtape/Makefile.am
+++ b/src/tape_drivers/netbsd/scsipi-ibmtape/Makefile.am
@@ -41,7 +41,7 @@ AM_LIBTOOLFLAGS = --tag=disable-static
 libtape_scsipi_ibmtape_la_SOURCES = scsipi_scsi_tape.c scsipi_ibmtape.c vendor_compat.c ibm_tape.c hp_tape.c quantum_tape.c
 libtape_scsipi_ibmtape_la_DEPENDENCIES = ../../../../messages/libtape_linux_sg_ibmtape_dat.a ../../../libltfs/libltfs.la libtape_scsipi_ibmtape_la-reed_solomon_crc.lo libtape_scsipi_ibmtape_la-crc32c_crc.lo
 libtape_scsipi_ibmtape_la_LIBADD = ../../../libltfs/libltfs.la libtape_scsipi_ibmtape_la-reed_solomon_crc.lo libtape_scsipi_ibmtape_la-crc32c_crc.lo
-libtape_scsipi_ibmtape_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ -L../../../../messages -ltape_linux_sg_ibmtape_dat
+libtape_scsipi_ibmtape_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ ../../../../messages/libtape_linux_sg_ibmtape_dat.a
 libtape_scsipi_ibmtape_la_CPPFLAGS = @AM_CPPFLAGS@ @AM_EXTRA_CPPFLAGS@ -I ../../.. -I ../..
 
 vendor_compat.c:

--- a/src/tape_drivers/osx/iokit/Makefile.am
+++ b/src/tape_drivers/osx/iokit/Makefile.am
@@ -41,7 +41,7 @@ AM_LIBTOOLFLAGS = --tag=disable-static
 libtape_iokit_la_SOURCES = iokit_tape.c iokit_scsi.c iokit_service.c vendor_compat.c ibm_tape.c hp_tape.c quantum_tape.c
 libtape_iokit_la_DEPENDENCIES = ../../../../messages/libtape_iokit_dat.a ../../../libltfs/libltfs.la ./libtape_iokit_la-reed_solomon_crc.lo ./libtape_iokit_la-crc32c_crc.lo
 libtape_iokit_la_LIBADD = ../../../libltfs/libltfs.la ./libtape_iokit_la-reed_solomon_crc.lo ./libtape_iokit_la-crc32c_crc.lo
-libtape_iokit_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ -L../../../../messages -ltape_iokit_dat
+libtape_iokit_la_LDFLAGS = -avoid-version -module @AM_LDFLAGS@ ../../../../messages/libtape_iokit_dat.a
 libtape_iokit_la_CPPFLAGS = @AM_CPPFLAGS@ @AM_EXTRA_CPPFLAGS@ -I ../../.. -I ../..
 
 vendor_compat.c:

--- a/src/utils/Makefile.am
+++ b/src/utils/Makefile.am
@@ -42,11 +42,11 @@ noinst_HEADERS =
 mkltfs_SOURCES = mkltfs.c
 mkltfs_DEPENDENCIES = ../libltfs/libltfs.la ../../messages/libbin_mkltfs_dat.a
 mkltfs_LDADD = ../libltfs/libltfs.la
-mkltfs_LDFLAGS = @AM_LDFLAGS@ -L../../messages -lbin_mkltfs_dat
+mkltfs_LDFLAGS = @AM_LDFLAGS@ ../../messages/libbin_mkltfs_dat.a
 mkltfs_CPPFLAGS = @AM_CPPFLAGS@ -I .. -fPIC
 
 ltfsck_SOURCES = ltfsck.c
 ltfsck_DEPENDENCIES = ../libltfs/libltfs.la ../../messages/libbin_ltfsck_dat.a
 ltfsck_LDADD = ../libltfs/libltfs.la
-ltfsck_LDFLAGS = @AM_LDFLAGS@ -L../../messages -lbin_ltfsck_dat
+ltfsck_LDFLAGS = @AM_LDFLAGS@ ../../messages/libbin_ltfsck_dat.a
 ltfsck_CPPFLAGS = @AM_CPPFLAGS@ -I .. -fPIC


### PR DESCRIPTION
# Summary of changes

Current linker flag for creating shared libraries are not good. The linker called from libtool reports errors of unexisted files.

This modifications fixes  linking problem from 3rd party apps which links the shared libraries provided from LTFS.

# Description

Do not link the message bundles with `-l` options. But specify the object files directly.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
