### PR TITLE
Fix a type mismatch bug in ltfs_ordered_copy

### DIFF
--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -334,6 +334,9 @@ if args.DEST == None:
     logger.error('No destination is specified')
     exit(2)
 
+if args.keep_tree is None:
+    args.keep_tree = ''
+
 # Special case:
 #  Copy source is only one file
 if args.recursive == False and len(args.SOURCE) == 1:
@@ -361,7 +364,7 @@ direct_write_threads = 8
 try:
     sig = xattr.get(args.DEST, VEA_PREFIX + LTFS_SIG_VEA)
 
-    if sig.startswith("LTFS"):
+    if sig.startswith(b"LTFS"):
         logger.info("Destination {0} is LTFS".format(args.DEST))
         direct_write_threads = 1
     else:
@@ -384,9 +387,6 @@ if len(args.SOURCE) == 0:
     for line in sys.stdin:
         args.SOURCE.append(line.rstrip('\r\n'))
     logger.log(NOTSET + 1, 'Source: {}'.format(args.SOURCE))
-
-if args.keep_tree is None:
-    args.keep_tree = ''
 
 # Create the list of copy item
 copyq = CopyQueue(logger)


### PR DESCRIPTION
# Summary of changes

There is type mismatch into detecting the code that destination is LTFS or not. The xattr module returns binary data (without NULL termination) so binary compare is required.

This change also includes a bug fix at single file copy. It tries to get a length of `None` type object.

- Fix of issue #370

Fixes #370 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
