### PR TITLE
fix gcc error msg display

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -372,7 +372,7 @@ if test "x${snmp}" != "xno"
 then
     SNMP_ENABLE="-D ENABLE_SNMP"
     SNMP_MODULE_CFLAGS="`net-snmp-config --cflags 2> /dev/null`";
-    SNMP_MODULE_LIBS_A="`net-snmp-config --agent-libs` 2> /dev/null";
+    SNMP_MODULE_LIBS_A="`net-snmp-config --agent-libs 2> /dev/null`";
     SNMP_MODULE_LIBS="`net-snmp-config --libs 2> /dev/null`";
     if test -z "$SNMP_MODULE_LIBS_A"
     then


### PR DESCRIPTION
bug adding extra parameters " 2> /dev/null"  to the gcc command line,


This pull request includes following changes or fixes. 

- Fix of issue #374