### PR TITLE
fix icu-config,  and  package libicu66 cannot be found in Debian10/debian11

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,7 +5,7 @@
 
 sudo apt-get -q -y update
 sudo apt-get -q -y upgrade
-sudo apt-get -y install build-essential automake autoconf libtool pkg-config libicu66 icu-devtools libicu-dev libxml2-dev uuid-dev fuse libfuse-dev libsnmp-dev
+sudo apt-get -y install build-essential automake autoconf libtool pkg-config icu-devtools libicu-dev libxml2-dev uuid-dev fuse libfuse-dev libsnmp-dev
 ./autogen.sh
 ./configure
 make

--- a/build.sh
+++ b/build.sh
@@ -6,7 +6,6 @@
 sudo apt-get -q -y update
 sudo apt-get -q -y upgrade
 sudo apt-get -y install build-essential automake autoconf libtool pkg-config libicu66 icu-devtools libicu-dev libxml2-dev uuid-dev fuse libfuse-dev libsnmp-dev
-sudo cp .github/workflows/icu-config /usr/bin/icu-config
 ./autogen.sh
 ./configure
 make

--- a/configure.ac
+++ b/configure.ac
@@ -329,9 +329,9 @@ dnl
 dnl Check for ICU
 dnl
 AC_MSG_CHECKING(ICU version)
-ICU_MODULE_VERSION="`icu-config --version 2> /dev/null`";
-ICU_MODULE_CFLAGS=" `icu-config --cppflags 2> /dev/null`";
-ICU_MODULE_LIBS="`icu-config --ldflags 2> /dev/null`";
+ICU_MODULE_VERSION="`pkg-config --modversion icu-i18n 2> /dev/null`";
+ICU_MODULE_CFLAGS="`pkg-config --cflags icu-i18n 2> /dev/null`";
+ICU_MODULE_LIBS="`pkg-config --libs icu-i18n 2> /dev/null`";
 AC_MSG_RESULT([$ICU_MODULE_VERSION])
 
 if test -z "$ICU_MODULE_VERSION"


### PR DESCRIPTION
  Replace icu-config with pkg-config， icu-config is no longer needed.