### PR TITLE
Make it work for HP Ultrium 3000 on FreeBSD

### DIFF
--- a/src/tape_drivers/freebsd/cam/cam_tc.c
+++ b/src/tape_drivers/freebsd/cam/cam_tc.c
@@ -1990,7 +1990,7 @@ int camtape_modeselect(void *device, unsigned char *buf, const size_t size)
 						 /*retries*/ 1,
 						 /*cbfcnp*/ NULL,
 						 /*tag_action*/ MSG_SIMPLE_Q_TAG,
-						 /*scsi_page_fmt*/ 0,
+						 /*scsi_page_fmt*/ 1,
 						 /*save_pages*/ 0,
 						 /*param_buf*/ buf,
 						 /*param_len*/ size,


### PR DESCRIPTION
IBM drives do not check PF bit in mode select (from what I see in the document SCSI Reference for IBM LTO Ultrium Tape Drive), but HP drives want it set (at least my HP Ultrium 3000 did not work when PF bit was 0).

The Linux driver is already setting the PF bit in sg_modeselect, but for some reason the CAM driver for FreeBSD noes not set it in camtape_modeselect.

Before this change, I was unable to format nor mount when using my HP drive on FreeBSD:

`
LTFS31213I Error on modeselect: (pass8:mps0:0:6:0): MODE SELECT(10). CDB: 55 00 00 00 00 00 00 00 30 00
(pass8:mps0:0:6:0): CAM status: SCSI Status Error
(pass8:mps0:0:6:0): SCSI status: Check Condition
(pass8:mps0:0:6:0): SCSI sense: ILLEGAL REQUEST asc:24,0 (Invalid field in CDB)
(pass8:mps0:0:6:0): Command byte 1 bit 4 is invalid
`

After this change it works fine. At least when not using encryption (because there are some vendor-specific pages for IBM that do not work in HP drives), but this is a different issue.