### PR TITLE
Add support for FreeBSD to ltfs_ordered_copy

### DIFF
--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -66,14 +66,14 @@ class CopyItem:
 
     def eval(self): #access to the extended attributes present in some operating systems/filesystems by xattr
         try:
-            self.vuuid = xattr.get(self.src, self.vea_pre + 'ltfs.volumeUUID')
+            self.vuuid = xattr.getxattr(self.src, self.vea_pre + 'ltfs.volumeUUID')
         except Exception as e:
             self.vuuid = ''
             return (self.vuuid, self.part, self.start)
 
         try:
-            self.part  = xattr.get(self.src, self.vea_pre + 'ltfs.partition')
-            start_str  = xattr.get(self.src, self.vea_pre + 'ltfs.startblock')
+            self.part  = xattr.getxattr(self.src, self.vea_pre + 'ltfs.partition')
+            start_str  = xattr.getxattr(self.src, self.vea_pre + 'ltfs.startblock')
             self.start = int(start_str)
             self.size  = os.path.getsize(self.src)
         except Exception as e:
@@ -95,12 +95,12 @@ class CopyItem:
                 if self.cp_xattr:
                     # Capture EAs of the source file
                     src_attributes = {}
-                    for key in xattr.list(self.src):
-                        src_attributes[key] = xattr.get(self.src, key)
+                    for key in xattr.listxattr(self.src):
+                        src_attributes[key] = xattr.getxattr(self.src, key)
                     # Set EAs of the destination file
                     (_, filename) = os.path.split(self.src)
                     for key in src_attributes:
-                        xattr.set(self.dst, key, src_attributes[key])
+                        xattr.setxattr(self.dst, key, src_attributes[key])
             else: #Only copy data
                 shutil.copy(self.src, self.dst)
         except Exception as e:
@@ -257,7 +257,7 @@ LTFS_SIG_VEA='ltfs.softwareProduct'
 plat = platform.system()
 if plat == 'Linux':
     VEA_PREFIX='user.'
-elif plat == 'Darwin':
+elif plat == 'Darwin' or plat == 'FreeBSD':
     VEA_PREFIX=''
 else:
     sys.stderr.write("unsupported platform '{0}'\n".format(plat))
@@ -368,7 +368,7 @@ if args.recursive == False and len(args.SOURCE) == 1:
 logger.log(NOTSET + 1, 'Checking destination is LTFS or not')
 direct_write_threads = 8
 try:
-    sig = xattr.get(args.DEST, VEA_PREFIX + LTFS_SIG_VEA)
+    sig = xattr.getxattr(args.DEST, VEA_PREFIX + LTFS_SIG_VEA)
 
     if sig.startswith(b"LTFS"):
         logger.info("Destination {0} is LTFS".format(args.DEST))

--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -34,6 +34,7 @@
 #  OO_Copyright_END
 
 import sys
+import errno
 import platform
 import os.path
 import argparse
@@ -43,6 +44,11 @@ import threading
 
 from logging import getLogger, basicConfig, NOTSET, CRITICAL, ERROR, WARNING, INFO, DEBUG
 from collections import deque
+
+def is_errno(num, names):
+    if not num in errno.errorcode:
+        return False
+    return errno.errorcode[num] in names
 
 class CopyItem:
     """"""
@@ -178,7 +184,7 @@ class CopyQueue:
                 self.logger.log(NOTSET + 1, 'Making a directory {}'.format(d))
                 os.mkdir(d)
             except OSError as e:
-                if e.errno != 17: # Not EEXIST
+                if e.errno != errno.EEXIST:
                     self.logger.error(str(e) + "\n")
                     exit(1)
 
@@ -370,10 +376,10 @@ try:
     else:
         logger.info("Destination {0} is not LTFS\n".format(args.DEST))
 except IOError as e:
-    if e.errno != 61 and e.errno != 93 and e.errno != 95: # Not ENODATA, ENOATTR, EOPNOTSUPP
+    if not is_errno(e.errno, ['ENODATA', 'ENOATTR', 'ENOTSUP', 'EOPNOTSUPP']):
         logger.error('Check destination (I/O):' + str(e))
         exit(2)
-    if e.errno == 95 and args.p:
+    if is_errno(e.errno, ['ENOTSUP', 'EOPNOTSUPP']) and args.p:
         logger.warning("{0} does not support xattr. Cannot use -p. Attributes will not be preserved during copy.".format(args.DEST))
         args.p = False
     logger.warning("Destination {0} is not LTFS".format(args.DEST))


### PR DESCRIPTION
# Summary of changes

- Do not hardcore errno numbers in ltfs_ordered_copy because those are system-dependent. Python has an errno module in its standard library which provides the correct numbers on each platform. I've also put a helper function to check for errno because some may not be present (some systems use ENODATA but other systems do not have it defined and instead use ENOATTR).

- Use methods like getxattr instead of get. The pyxattr library obsoleted those, but by now these are still available, and some systems like FreeBSD use the xattr library which do not have the get method. If, in the future, pyxattr library removes these methods, we could do something like if not hasattr(xattr, 'getxattr'): xattr.getxattr = xattr.get, but by now I think we're fine.
