### PR TITLE
Install a few more headers by `make install`

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -91,9 +91,7 @@ noinst_HEADERS = \
 	libltfs/pathname.h \
 	libltfs/periodic_sync.h \
 	libltfs/xattr.h \
-	libltfs/xml.h \
 	libltfs/xml_libltfs.h \
-	libltfs/arch/errormap.h \
 	libltfs/arch/filename_handling.h \
 	libltfs/arch/uuid_internal.h \
 	libltfs/arch/version.h
@@ -119,9 +117,11 @@ nobase_pkginclude_HEADERS = \
 	libltfs/uthash_ext.h \
 	libltfs/plugin.h \
 	libltfs/tape.h \
+	libltfs/xml.h \
 	libltfs/arch/signal_internal.h \
 	libltfs/arch/arch_info.h \
 	libltfs/arch/time_internal.h \
+	libltfs/arch/errormap.h \
 	tape_drivers/ibm_tape.h \
 	tape_drivers/spc_op_codes.h \
 	tape_drivers/ssc_op_codes.h \


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Fix of issue #385 

# Description

Install a few headers (`xml.h` and `arch/errormap.h`) of the libltfs for using teh libltfs library with dynamic link.
 
Fixes #385 

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
