### PR TITLE
Fuse main log addition

### DIFF
--- a/messages/bin_ltfs/root.txt
+++ b/messages/bin_ltfs/root.txt
@@ -159,6 +159,7 @@ root:table {
 		14120W:string { "Cannot access to directory %s, disabled index capture mode (%d)." }
 		14121I:string { "Index will be captured at %s at update" }
 		14122I:string { "Index will not be captured." }
+		14123W:string { "Fuse main returned the error code: (%d)." }
 
 		// 14150 - 14199 are reserved for LE+
 

--- a/src/main.c
+++ b/src/main.c
@@ -382,7 +382,7 @@ int ltfs_parse_options(void *priv_data, const char *arg, int key, struct fuse_ar
 	struct ltfs_fuse_data *priv = (struct ltfs_fuse_data *) priv_data;
 	const char *fuse_options[] = { "-f", "-d", "-s", NULL };
 	bool valid_fuse_option = false;
-	int i;
+	int i, ret;
 
 	switch(key) {
 		case KEY_VERSION:
@@ -413,8 +413,12 @@ int ltfs_parse_options(void *priv_data, const char *arg, int key, struct fuse_ar
 		default:
 			if (! priv->first_parsing_pass) {
 				fuse_opt_add_arg(outargs, "-h");
-				if (priv->advanced_help)
-					fuse_main(outargs->argc, outargs->argv, &ltfs_ops, NULL);
+				if (priv->advanced_help){
+					ret = fuse_main(outargs->argc, outargs->argv, &ltfs_ops, NULL);
+					if (ret != 0) {
+						ltfsmsg(LTFS_WARN, 14123W, ret)
+					}
+				}	
 				usage(outargs->argv[0], priv);
 				exit(key == KEY_HELP ? 0 : 1);
 			}
@@ -1335,6 +1339,9 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 	ltfsmsg(LTFS_INFO, 14112I);
 	ltfsmsg(LTFS_INFO, 14113I);
 	ret = fuse_main(args->argc, args->argv, &ltfs_ops, priv);
+	if (ret != 0) {
+		ltfsmsg(LTFS_WARN, 14123W, ret);
+	}
 
 	/*  Setup signal handler again to terminate cleanly */
 	ret = ltfs_set_signal_handlers();

--- a/src/main.c
+++ b/src/main.c
@@ -414,7 +414,7 @@ int ltfs_parse_options(void *priv_data, const char *arg, int key, struct fuse_ar
 			if (! priv->first_parsing_pass) {
 				fuse_opt_add_arg(outargs, "-h");
 				if (priv->advanced_help)
-					ret = fuse_main(outargs->argc, outargs->argv, &ltfs_ops, NULL);
+					fuse_main(outargs->argc, outargs->argv, &ltfs_ops, NULL);
 				usage(outargs->argv[0], priv);
 				exit(key == KEY_HELP ? 0 : 1);
 			}

--- a/src/main.c
+++ b/src/main.c
@@ -416,7 +416,7 @@ int ltfs_parse_options(void *priv_data, const char *arg, int key, struct fuse_ar
 				if (priv->advanced_help){
 					ret = fuse_main(outargs->argc, outargs->argv, &ltfs_ops, NULL);
 					if (ret != 0) {
-						ltfsmsg(LTFS_WARN, 14123W, ret)
+						ltfsmsg(LTFS_WARN, 14123W, ret);
 					}
 				}	
 				usage(outargs->argv[0], priv);

--- a/src/main.c
+++ b/src/main.c
@@ -382,7 +382,7 @@ int ltfs_parse_options(void *priv_data, const char *arg, int key, struct fuse_ar
 	struct ltfs_fuse_data *priv = (struct ltfs_fuse_data *) priv_data;
 	const char *fuse_options[] = { "-f", "-d", "-s", NULL };
 	bool valid_fuse_option = false;
-	int i, ret;
+	int i;
 
 	switch(key) {
 		case KEY_VERSION:
@@ -413,12 +413,8 @@ int ltfs_parse_options(void *priv_data, const char *arg, int key, struct fuse_ar
 		default:
 			if (! priv->first_parsing_pass) {
 				fuse_opt_add_arg(outargs, "-h");
-				if (priv->advanced_help){
+				if (priv->advanced_help)
 					ret = fuse_main(outargs->argc, outargs->argv, &ltfs_ops, NULL);
-					if (ret != 0) {
-						ltfsmsg(LTFS_WARN, 14123W, ret);
-					}
-				}	
 				usage(outargs->argv[0], priv);
 				exit(key == KEY_HELP ? 0 : 1);
 			}


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Fix of issue #403 
- Added warning message when fuse main function returns an error code.

# Description

This change is needed to be able to track an error on fuse_main in case it happens. 

Fixes #403 

## Type of change

- New feature: Addition of warning message to show error code returned by fuse_main function. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works
