### PR TITLE
Handle one-shot false `good` against TUR at failover process 

### DIFF
--- a/messages/print_error_messages.py
+++ b/messages/print_error_messages.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import os
 import re

--- a/messages/print_error_messages.py
+++ b/messages/print_error_messages.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 import os
 import re

--- a/messages/tape_linux_sg/root.txt
+++ b/messages/tape_linux_sg/root.txt
@@ -134,6 +134,8 @@ root:table {
 		30292I:string { "Changer %s was reserved from this node but failed to reserve from the current path." }
 		30293I:string { "Changer %s was reserved from another node (%s)." }
 		30294I:string { "Setting up timeout values from %s." }
+		30295I:string { "Have unstable TUR response, start over (Cur = %d, Prev = %d)." }
+		30296I:string { "Capturing a stable TUR at line %d." }
 
 		30392D:string { "Backend %s %s." }
 		30393D:string { "Backend %s: %d %s." }

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -616,6 +616,39 @@ void _clear_por_raw(const int fd)
 	}
 }
 
+#define _get_stable_tur_response(p) _get_stable_tur_response_raw((p)->dev.fd)
+
+int _get_stable_tur_response_raw(const int fd)
+{
+	int i = 0, ret = -1, ret_tur = -1;
+
+	do {
+		ret_tur = _raw_tur(fd);
+		if (i == 0) {
+			/* Keep first return code if it is not an unit attention */
+			if (!IS_UNIT_ATTENTION(-ret_tur)) {
+				ret = ret_tur;
+				i++;
+			}
+		} else if (ret_tur == ret) {
+			/* Increment counter because it is same as previous response */
+			i++;
+		} else {
+			/* TUR response is not stable, start over */
+			ltfsmsg(LTFS_INFO, 30295I, ret_tur, ret);
+			if (IS_UNIT_ATTENTION(-ret_tur)) {
+				ret = -1;
+				i = 0;
+			} else {
+				ret = ret_tur;
+				i = 1;
+			}
+		}
+	} while (i < 3);
+
+	return ret;
+}
+
 /* Forward reference */
 int sg_get_device_list(struct tc_drive_info *buf, int count);
 int sg_reserve(void *device);
@@ -770,7 +803,13 @@ static int _reconnect_device(void *device)
 
 	/* Issue TUR and check reservation conflict happens or not */
 	_clear_por(priv);
-	ret = _raw_tur(priv->dev.fd);
+
+	/*
+	 * !!!!! This is a kind of work around to avoid to fetch false one-shot `good` here.
+	 * Fetch result of TUR until 3 straight same result
+	 */
+	ltfsmsg(LTFS_INFO, 30296I, __LINE__);
+	ret = _get_stable_tur_response(priv);
 	if (ret == -EDEV_RESERVATION_CONFLICT) {
 		/* Select another path, recover reservation */
 		ltfsmsg(LTFS_INFO, 30269I, priv->drive_serial);
@@ -785,23 +824,43 @@ static int _reconnect_device(void *device)
 	} else {
 		/* Read reservation information and print */
 		_clear_por(priv);
-		memset(&r_info, 0x00, sizeof(r_info));
-		f_ret = _fetch_reservation_key(device, &r_info);
-		if (f_ret == -EDEV_NO_RESERVATION_HOLDER) {
-			/* Real POR may happens */
-			ltfsmsg(LTFS_INFO, 30270I, priv->drive_serial);
+
+		/*
+		 * !!!!! This is the code just in case, check TUR response again and restore reservation
+		 * if drive reports `reservation conflict`.
+		 */
+		ltfsmsg(LTFS_INFO, 30296I, __LINE__);
+		ret = _get_stable_tur_response(priv);
+		if (ret == -EDEV_RESERVATION_CONFLICT) {
+			/* Select another path, recover reservation */
+			ltfsmsg(LTFS_INFO, 30269I, priv->drive_serial);
 			_register_key(priv, priv->key);
-			ret = sg_reserve(device);
+			ret = _cdb_pro(device, PRO_ACT_PREEMPT_ABORT, PRO_TYPE_EXCLUSIVE,
+						   priv->key, priv->key);
 			if (!ret) {
 				ltfsmsg(LTFS_INFO, 30272I, priv->drive_serial);
 				_clear_por(priv);
-				ret = -EDEV_REAL_POWER_ON_RESET;
+				ret = -EDEV_NEED_FAILOVER;
 			}
 		} else {
-			/* Select same path */
-			ltfsmsg(LTFS_INFO, 30271I, priv->drive_serial);
-			_clear_por(priv);
-			ret = -EDEV_NEED_FAILOVER;
+			memset(&r_info, 0x00, sizeof(r_info));
+			f_ret = _fetch_reservation_key(device, &r_info);
+			if (f_ret == -EDEV_NO_RESERVATION_HOLDER) {
+				/* Real POR may happens */
+				ltfsmsg(LTFS_INFO, 30270I, priv->drive_serial);
+				_register_key(priv, priv->key);
+				ret = sg_reserve(device);
+				if (!ret) {
+					ltfsmsg(LTFS_INFO, 30272I, priv->drive_serial);
+					_clear_por(priv);
+				ret = -EDEV_REAL_POWER_ON_RESET;
+				}
+			} else {
+				/* Select same path */
+				ltfsmsg(LTFS_INFO, 30271I, priv->drive_serial);
+				_clear_por(priv);
+				ret = -EDEV_NEED_FAILOVER;
+			}
 		}
 	}
 


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Fix of issue #409 

# Description

Try to fetch the stable (3 straight same response) from the drive for detecting the new path for failover is as same as previous path or not.

Fixes #409 

## Type of change

Please delete items that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Especially this change is a kind of workaround, LTFS doesn't expects one-shot false `good` response from the drive at all

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have confirmed my fix is effective or that my feature works
