### PR TITLE
Fuse main log addition to v2.4 stable branch

### DIFF
--- a/messages/bin_ltfs/root.txt
+++ b/messages/bin_ltfs/root.txt
@@ -153,7 +153,8 @@ root:table {
 		14114E:string { "Cannot initialize the open file table." }
 		14115E:string { "Invalid scsi_append_only_mode option: %s." }
                 14116E:string { "This medium is not supported (%d)." }
-
+		14123W:string { "The main function of FUSE returned error (%d)." }
+		
 		// 14150 - 14199 are reserved for LE+
 
 		// Help messages

--- a/src/main.c
+++ b/src/main.c
@@ -1242,6 +1242,9 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 	ltfsmsg(LTFS_INFO, 14112I);
 	ltfsmsg(LTFS_INFO, 14113I);
 	ret = fuse_main(args->argc, args->argv, &ltfs_ops, priv);
+	if (ret != 0) {
+		ltfsmsg(LTFS_WARN, 14123W, ret);
+	}
 
 	/*  Setup signal handler again to terminate cleanly */
 	ret = ltfs_set_signal_handlers();


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Fix of issue #403 
- Added warning message when fuse main function returns an error code.

# Description

This change is needed to be able to track an error on fuse_main in case it happens.  This PR is to apply the change to v2.4-stable change. 

Fixes #403 

## Type of change

- New feature: Addition of warning message to show error code returned by fuse_main function. 

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works
