### PR TITLE
Fix a memory leak at `tape_read_attr()`

### DIFF
--- a/src/libltfs/tape.c
+++ b/src/libltfs/tape.c
@@ -3553,6 +3553,8 @@ int tape_read_attr(struct device_data *dev, const tape_partition_t part,
 		ret = len;
 	}
 
+	free(inner_buf);
+
 	return ret;
 }
 


### PR DESCRIPTION
# Summary of changes

Free the buffer for fetching MAM correctly.

- Fix of issue #414

# Description

Fix a memory leak found by `valgrind`.

Fixes #414

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
