### PR TITLE
Linux Jaguar 7 Tape and TS1170 Drive Support

### DIFF
--- a/src/libltfs/tape_ops.h
+++ b/src/libltfs/tape_ops.h
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2023 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions
@@ -166,6 +166,7 @@ enum {
 	TC_DC_JAG5    = 0x55,
 	TC_DC_JAG5A   = 0x56,
 	TC_DC_JAG6    = 0x57,
+	TC_DC_JAG7    = 0x59,
 	TC_DC_JAG1E   = 0x71,
 	TC_DC_JAG2E   = 0x72,
 	TC_DC_JAG3E   = 0x73,
@@ -173,6 +174,7 @@ enum {
 	TC_DC_JAG5E   = 0x75,
 	TC_DC_JAG5AE  = 0x76,
 	TC_DC_JAG6E   = 0x77,
+	TC_DC_JAG7E   = 0x79,
 };
 
 #define ALL_MEDIA_DENSITY      0

--- a/src/tape_drivers/generic/file/filedebug_tc.c
+++ b/src/tape_drivers/generic/file/filedebug_tc.c
@@ -1427,6 +1427,7 @@ static inline int _sanitize_tape(struct filedebug_data *state)
 				break;
 			case TC_MP_JV:
 				state->is_worm = true;
+				break;
 			default:
 				ltfsmsg(LTFS_INFO, 30086I, "TS1170", state->conf.cart_type);
 				state->is_worm = false;

--- a/src/tape_drivers/generic/file/filedebug_tc.c
+++ b/src/tape_drivers/generic/file/filedebug_tc.c
@@ -1418,6 +1418,22 @@ static inline int _sanitize_tape(struct filedebug_data *state)
 				ret = -EDEV_MEDIUM_FORMAT_ERROR;
 				break;
 		}
+	} else if (gen == DRIVE_GEN_JAG7) {
+		switch (state->conf.cart_type) {
+			case TC_MP_JE:
+			case TC_MP_JM:
+			case TC_MP_JF:
+				state->is_worm = false;
+				break;
+			case TC_MP_JV:
+				state->is_worm = true;
+			default:
+				ltfsmsg(LTFS_INFO, 30086I, "TS1170", state->conf.cart_type);
+				state->is_worm = false;
+				state->unsupported_tape = true;
+				ret = -EDEV_MEDIUM_FORMAT_ERROR;
+				break;
+		}
 	} else {
 		ltfsmsg(LTFS_INFO, 30086I, "Unexpected Drive", state->conf.cart_type);
 		state->is_worm = false;

--- a/src/tape_drivers/ibm_tape.c
+++ b/src/tape_drivers/ibm_tape.c
@@ -64,6 +64,16 @@
 #include "libltfs/ltfs_endian.h"
 
 DRIVE_DENSITY_SUPPORT_MAP jaguar_drive_density[] = {
+	/* TS1170 */
+	{ DRIVE_GEN_JAG7,  TC_MP_JF, TC_DC_JAG7,    MEDIUM_PERFECT_MATCH },
+	{ DRIVE_GEN_JAG7,  TC_MP_JF, TC_DC_UNKNOWN, MEDIUM_PROBABLY_WRITABLE },
+	{ DRIVE_GEN_JAG7,  TC_MP_JE, TC_DC_JAG6,    MEDIUM_WRITABLE },
+	{ DRIVE_GEN_JAG7,  TC_MP_JE, TC_DC_UNKNOWN, MEDIUM_WRITABLE },
+	{ DRIVE_GEN_JAG7,  TC_MP_JV, TC_DC_JAG6,    MEDIUM_WRITABLE },
+	{ DRIVE_GEN_JAG7,  TC_MP_JV, TC_DC_UNKNOWN, MEDIUM_WRITABLE },
+	{ DRIVE_GEN_JAG7,  TC_MP_JM, TC_DC_JAG6,    MEDIUM_WRITABLE },
+	{ DRIVE_GEN_JAG7,  TC_MP_JM, TC_DC_UNKNOWN, MEDIUM_WRITABLE },
+
 	/* TS1160 */
 	{ DRIVE_GEN_JAG6,  TC_MP_JE, TC_DC_JAG6,    MEDIUM_PERFECT_MATCH },
 	{ DRIVE_GEN_JAG6,  TC_MP_JE, TC_DC_UNKNOWN, MEDIUM_PROBABLY_WRITABLE },
@@ -141,6 +151,10 @@ DRIVE_DENSITY_SUPPORT_MAP jaguar_drive_density[] = {
 };
 
 DRIVE_DENSITY_SUPPORT_MAP jaguar_drive_density_strict[] = {
+	/* TS1170 */
+	{ DRIVE_GEN_JAG7,  TC_MP_JF, TC_DC_JAG7,    MEDIUM_PERFECT_MATCH },
+	{ DRIVE_GEN_JAG7,  TC_MP_JF, TC_DC_UNKNOWN, MEDIUM_PROBABLY_WRITABLE },
+
 	/* TS1160 */
 	{ DRIVE_GEN_JAG6,  TC_MP_JE, TC_DC_JAG6,    MEDIUM_PERFECT_MATCH },
 	{ DRIVE_GEN_JAG6,  TC_MP_JE, TC_DC_UNKNOWN, MEDIUM_PROBABLY_WRITABLE },
@@ -256,13 +270,16 @@ const unsigned char supported_cart[] = {
 	TC_MP_JE,
 	TC_MP_JV,
 	TC_MP_JM,
+	TC_MP_JF,
 };
 
 const unsigned char supported_density[] = {
+	TC_DC_JAG7E,
 	TC_DC_JAG6E,
 	TC_DC_JAG5AE,
 	TC_DC_JAG5E,
 	TC_DC_JAG4E,
+	TC_DC_JAG7,
 	TC_DC_JAG6,
 	TC_DC_JAG5A,
 	TC_DC_JAG5,
@@ -315,6 +332,8 @@ struct supported_device *ibm_supported_drives[] = {
 		TAPEDRIVE( IBM_VENDOR_ID, "0359260F",     DRIVE_TS1160,  "[0359260F]" ),     /* IBM TS1160 */
 		TAPEDRIVE( IBM_VENDOR_ID, "0359260E",     DRIVE_TS1160,  "[0359260E]" ),     /* IBM TS1160 */
 		TAPEDRIVE( IBM_VENDOR_ID, "0359260S",     DRIVE_TS1160,  "[0359260S]" ),     /* IBM TS1160 */
+		TAPEDRIVE( IBM_VENDOR_ID, "0359270F",     DRIVE_TS1170,  "[0359270F]" ),     /* IBM TS1170 */
+		TAPEDRIVE( IBM_VENDOR_ID, "0359270S",     DRIVE_TS1170,  "[0359270S]" ),     /* IBM TS1170 */
 		/* End of supported_devices */
 		NULL
 };
@@ -794,6 +813,26 @@ static struct _timeout_tape timeout_1160[] = {
 	{-1, -1}
 };
 
+static struct _timeout_tape timeout_1170[] = {
+	{ XCOPY,                           176820 },
+	{ ERASE,                           175900 },
+	{ FORMAT_MEDIUM,                   3120   },
+	{ LOAD_UNLOAD,                     900    },
+	{ LOCATE10,                        2280   },
+	{ LOCATE16,                        2240   },
+	{ READ,                            2340   },
+	{ READ_BUFFER,                     480    },
+	{ REWIND,                          600    },
+	{ SEND_DIAGNOSTIC,                 2280   },
+	{ SPACE6,                          2280   },
+	{ SPACE16,                         2240   },
+	{ VERIFY,                          176820 },
+	{ WRITE,                           1440   },
+	{ WRITE_BUFFER,                    540    },
+	{ WRITE_FILEMARKS6,                1380   },
+	{-1, -1}
+};
+
 static int _create_table_tape(struct timeout_tape **result,
 							  struct _timeout_tape* base,
 							  struct _timeout_tape* override)
@@ -882,6 +921,9 @@ int ibm_tape_init_timeout(struct timeout_tape** table, int type)
 		case DRIVE_TS1160:
 			ret = _create_table_tape(table, timeout_11x0, timeout_1160);
 			break;
+		case DRIVE_TS1170:
+			ret = _create_table_tape(table, timeout_11x0, timeout_1170);
+			break;
 		default:
 			ret = _create_table_tape(table, timeout_lto, timeout_lto7_hh);
 			break;
@@ -929,6 +971,9 @@ static inline unsigned char _assume_cartridge_type(char product, char btype)
 				break;
 			case 'M':
 				ctype = TC_MP_JM;
+				break;
+			case 'F':
+				ctype = TC_MP_JF;
 				break;
 			default:
 				break;
@@ -1032,6 +1077,9 @@ char* ibm_tape_assume_cart_name(unsigned char type)
 			break;
 		case TC_MP_JM:
 			name = "JM";
+			break;
+		case TC_MP_JF:
+			name = "JF";
 			break;
 		default:
 			name = "L5";
@@ -1295,6 +1343,7 @@ bool ibm_tape_is_supported_firmware(int drive_type, const unsigned char * const 
 	case DRIVE_LTO7_HH:
 	case DRIVE_TS1150:
 	case DRIVE_TS1160:
+	case DRIVE_TS1170:
 	default:
 		break;
 	}

--- a/src/tape_drivers/ibm_tape.c
+++ b/src/tape_drivers/ibm_tape.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2023 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/tape_drivers/tape_drivers.h
+++ b/src/tape_drivers/tape_drivers.h
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2023 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions
@@ -197,6 +197,7 @@ enum {
 	DRIVE_TS1150      = 0x1105, /* TS1150 */
 	DRIVE_TS1155      = 0x5105, /* TS1155 */
 	DRIVE_TS1160      = 0x1106, /* TS1160 */
+	DRIVE_TS1170      = 0x1107, /* TS1170 */
 };
 
 enum {
@@ -210,6 +211,7 @@ enum {
 	DRIVE_GEN_JAG5    = 0x1005,
 	DRIVE_GEN_JAG5A   = 0x5005,
 	DRIVE_GEN_JAG6    = 0x1006,
+	DRIVE_GEN_JAG7    = 0x1007,
 };
 
 /* LTO cartridge type in mode page header */
@@ -254,6 +256,8 @@ enum {
 	TC_MP_JE          = 0x95,   /* IBM TS11x0 JE cartridge */
 	TC_MP_JV          = 0xA5,   /* IBM TS11x0 JV cartridge */
 	TC_MP_JM          = 0xB4,   /* IBM TS11x0 JM cartridge */
+	/* 6th gen */
+	TC_MP_JF          = 0x96,   /* IBM TS11x0 JF cartridge */
 };
 
 #define IS_REFORMATTABLE_TAPE(t) \
@@ -268,6 +272,7 @@ enum {
 	  t == TC_MP_JE ||			 \
 	  t == TC_MP_JV ||			 \
 	  t == TC_MP_JM ||			 \
+	  t == TC_MP_JF ||			 \
 	  t == TC_MP_LTO7D_CART )
 
 #endif // __tape_drivers_h


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes

- JF Tape support
- TS1170 Drive support

# Description

Includes:
- Jag7 plain and encrypted density codes
- JF Tape table timeout
- TS1170 drive compatibility with JF tapes, and backwards compatibility with JE, JV and JM tapes.

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works
