### PR TITLE
bugfix: ambiguous python shebang

### DIFF
--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 #  OO_Copyright_BEGIN


### PR DESCRIPTION
ambiguous python shebang in ltfs_ordered_copy. Change it to python3 explicitly.

# Description

Fixes #424 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
