### PR TITLE
freebsd: add missing semicolon in cam_tc

### DIFF
--- a/src/tape_drivers/freebsd/cam/cam_tc.c
+++ b/src/tape_drivers/freebsd/cam/cam_tc.c
@@ -1244,7 +1244,7 @@ static int camtape_get_next_block_to_xfer(void *device, struct tc_position *pos)
 		camtape_process_errors(softc, rc, msg, "READPOS", true);
 	else {
 		pos->partition = ext_data.partition;
-		pos->block = scsi_8btou64(ext_data.last_object)
+		pos->block = scsi_8btou64(ext_data.last_object);
 		ltfsmsg(LTFS_DEBUG, 30398D, "next-block-to-xfer",
 				(unsigned long long) pos->block, 0, 0, softc->drive_serial);
 	}


### PR DESCRIPTION
# Summary of changes

Add a missed semicolon that prevents compilation on FreeBSD

# Description

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have confirmed my fix is effective or that my feature works
