### PR TITLE
Change the `sync` behavior to fit the LTFS format Spec 2.5

### DIFF
--- a/src/iosched/unified.c
+++ b/src/iosched/unified.c
@@ -2291,6 +2291,7 @@ int _unified_write_index_after_perm(int write_ret, struct unified_data *priv)
 		return ret;
 	}
 
+	ltfs_set_commit_message_reason(SYNC_WRITE_PERM, priv->vol);
 	ret = ltfs_write_index(ltfs_ip_id(priv->vol), SYNC_WRITE_PERM, priv->vol);
 
 	return ret;

--- a/src/libltfs/ltfs.h
+++ b/src/libltfs/ltfs.h
@@ -730,6 +730,9 @@ int ltfs_profiler_set(uint64_t source, struct ltfs_volume *vol);
 int ltfs_get_rao_list(char *path, struct ltfs_volume *vol);
 int ltfs_build_fullpath(char **dest, struct dentry *d);
 
+void ltfs_set_commit_message_reason(char *reason, struct ltfs_volume *vol);
+void ltfs_set_commit_message_reason_unlocked(char *reason, struct ltfs_volume *vol);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/libltfs/ltfs_fsops.c
+++ b/src/libltfs/ltfs_fsops.c
@@ -2106,6 +2106,10 @@ int ltfs_fsops_volume_sync(char *reason, struct ltfs_volume *vol)
 	if (ret < 0)
 		return ret;
 
+	ltfs_mutex_lock(&vol->index->dirty_lock);
+	ltfs_set_commit_message_reason_unlocked(reason, vol);
+	ltfs_mutex_unlock(&vol->index->dirty_lock);
+
 	ret = ltfs_sync_index(reason, true, vol);
 
 	return ret;

--- a/src/libltfs/ltfs_internal.c
+++ b/src/libltfs/ltfs_internal.c
@@ -1323,6 +1323,7 @@ int ltfs_check_medium(bool fix, bool deep, bool recover_extra, bool recover_syml
 				}
 			}
 			/* write to data partition if it doesn't end in an index file */
+			ltfs_set_commit_message_reason(SYNC_RECOVERY, vol);
 			if (! dp_have_index || dp_blocks_after) {
 				ltfsmsg(LTFS_INFO, 17259I, "DP", vol->index->selfptr.partition, (unsigned long long)vol->index->selfptr.block);
 				ret = ltfs_write_index(vol->label->partid_dp, SYNC_RECOVERY, vol);
@@ -1407,12 +1408,15 @@ int ltfs_write_index_conditional(char partition, struct ltfs_volume *vol)
 
 	CHECK_ARG_NULL(vol, -LTFS_NULL_ARG);
 
-	if (partition == ltfs_ip_id(vol) && ! vol->ip_index_file_end)
+	if (partition == ltfs_ip_id(vol) && ! vol->ip_index_file_end) {
+		ltfs_set_commit_message_reason(SYNC_CASCHE_PRESSURE, vol);
 		ret = ltfs_write_index(partition, SYNC_CASCHE_PRESSURE, vol);
-	else if (partition == ltfs_dp_id(vol) &&
+	} else if (partition == ltfs_dp_id(vol) &&
 	         (! vol->dp_index_file_end ||
-	          (vol->ip_index_file_end && vol->index->selfptr.partition == ltfs_ip_id(vol))))
+	          (vol->ip_index_file_end && vol->index->selfptr.partition == ltfs_ip_id(vol)))) {
+		ltfs_set_commit_message_reason(SYNC_CASCHE_PRESSURE, vol);
 		ret = ltfs_write_index(partition, SYNC_CASCHE_PRESSURE, vol);
+	}
 
 	return ret;
 }

--- a/src/libltfs/periodic_sync.c
+++ b/src/libltfs/periodic_sync.c
@@ -101,6 +101,7 @@ ltfs_thread_return periodic_sync_thread(void* data)
 			ltfsmsg(LTFS_WARN, 17063W, __FUNCTION__);
 		}
 
+		ltfs_set_commit_message_reason(SYNC_PERIODIC, priv->vol);
 		ret = ltfs_sync_index(SYNC_PERIODIC, true, priv->vol);
 		if (ret < 0) {
 			ltfsmsg(LTFS_INFO, 11030I, ret);

--- a/src/libltfs/xattr.c
+++ b/src/libltfs/xattr.c
@@ -881,6 +881,7 @@ static int _xattr_get_virtual(struct dentry *d, char *buf, size_t buf_size, cons
 				ret = _xattr_get_vendorunique_xattr(&val, name, vol);
 			}
 		} else if (! strcmp(name, "ltfs.sync")) {
+			ltfs_set_commit_message_reason(SYNC_EA, vol);
 			ret = ltfs_sync_index(SYNC_EA, false, vol);
 		}
 	}
@@ -915,9 +916,8 @@ static int _xattr_set_virtual(struct dentry *d, const char *name, const char *va
 {
 	int ret = 0;
 
-	if (! strcmp(name, "ltfs.sync") && d == vol->index->root)
-		ret = ltfs_sync_index(SYNC_EA, false, vol);
-	else if (! strcmp(name, "ltfs.commitMessage") && d == vol->index->root) {
+	if ((! strcmp(name, "ltfs.commitMessage") || ! strcmp(name, "ltfs.sync"))
+		&& d == vol->index->root) {
 		char *value_null_terminated, *new_value;
 
 		if (size > INDEX_MAX_COMMENT_LEN) {
@@ -945,12 +945,16 @@ static int _xattr_set_virtual(struct dentry *d, const char *name, const char *va
 			ret = pathname_format(value_null_terminated, &new_value, false, true);
 			free(value_null_terminated);
 			if (ret < 0) {
+				/* Try to sync index even if the value is not valid */
+				ltfs_set_commit_message_reason_unlocked(SYNC_EA, vol);
 				ltfs_mutex_unlock(&vol->index->dirty_lock);
+
+				ret = ltfs_sync_index(SYNC_EA, false, vol);
 				return ret;
 			}
 			ret = 0;
 
-			/* Update the commit message in the index */
+			/* Update THE commit message in the index */
 			if (vol->index->commit_message)
 				free(vol->index->commit_message);
 			vol->index->commit_message = new_value;
@@ -958,6 +962,8 @@ static int _xattr_set_virtual(struct dentry *d, const char *name, const char *va
 
 		ltfs_set_index_dirty(false, false, vol->index);
 		ltfs_mutex_unlock(&vol->index->dirty_lock);
+
+		ret = ltfs_sync_index(SYNC_EA, false, vol);
 
 	} else if (! strcmp(name, "ltfs.volumeName") && d == vol->index->root) {
 		char *value_null_terminated, *new_value;
@@ -1228,6 +1234,8 @@ static int _xattr_set_virtual(struct dentry *d, const char *name, const char *va
 			vol->lock_status = new;
 
 			ltfs_set_index_dirty(false, false, vol->index);
+			ltfs_set_commit_message_reason_unlocked(SYNC_ADV_LOCK, vol);
+
 			ret = ltfs_sync_index(SYNC_ADV_LOCK, false, vol);
 			ret = tape_device_lock(vol->device);
 			if (ret < 0) {
@@ -1486,9 +1494,10 @@ int xattr_set(struct dentry *d, const char *name, const char *value, size_t size
 
 	releasewrite_mrsw(&d->meta_lock);
 
-	if (write_idx)
+	if (write_idx) {
+		ltfs_set_commit_message_reason(SYNC_EA, vol);
 		ret = ltfs_sync_index(SYNC_EA, false, vol);
-	else
+	} else
 		ret = 0;
 
 out_unlock:

--- a/src/ltfs_fuse.c
+++ b/src/ltfs_fuse.c
@@ -1169,6 +1169,7 @@ void ltfs_fuse_umount(void *userdata)
 	if (kmi_initialized(priv->data))
 		kmi_destroy(priv->data);
 
+	ltfs_set_commit_message_reason(SYNC_UNMOUNT, priv->data);
 	ltfs_unmount(SYNC_UNMOUNT, priv->data);
 
 	ltfs_request_trace(FUSE_REQ_EXIT(REQ_UNMOUNT), 0, 0);

--- a/src/ltfs_fuse.c
+++ b/src/ltfs_fuse.c
@@ -450,8 +450,10 @@ int ltfs_fuse_release(const char *path, struct fuse_file_info *fi)
 
 	open_write = (((fi->flags & O_WRONLY) == O_WRONLY) || ((fi->flags & O_RDWR) == O_RDWR));
 	ret = ltfs_fsops_close(file->file_info->dentry_handle, dirty, open_write, true, priv->data);
-	if (write_index)
+	if (write_index) {
+		ltfs_set_commit_message_reason(SYNC_CLOSE, priv->data);
 		ltfs_sync_index(SYNC_CLOSE, true, priv->data);
+	}
 
 	_file_close(file->file_info, priv);
 	_free_ltfs_file_handle(file);

--- a/src/utils/ltfsck.c
+++ b/src/utils/ltfsck.c
@@ -711,6 +711,7 @@ int check_ltfs_volume(struct ltfs_volume *vol, struct other_check_opts *opt)
 		return LTFSCK_UNCORRECTED;
 	} else {
 		print_criteria_info(vol);
+		ltfs_set_commit_message_reason(SYNC_CHECK, vol);
 		ltfs_unmount(SYNC_CHECK, vol);
 		ltfsmsg(LTFS_INFO, 16022I);
 		return LTFSCK_CORRECTED;
@@ -1174,6 +1175,7 @@ int _rollback_dp(struct ltfs_volume *vol, struct other_check_opts *opt, struct t
 		if (ret != LTFSCK_NO_ERRORS)
 			ltfsmsg(LTFS_ERR, 16055E, ret);
 	} else {
+		ltfs_set_commit_message_reason(SYNC_ROLLBACK, vol);
 		ret = ltfs_write_index(ltfs_dp_id(vol), SYNC_ROLLBACK, vol);
 		if (ret < 0) {
 			ltfsmsg(LTFS_ERR, 16056E, ret);
@@ -1288,6 +1290,7 @@ int rollback(struct ltfs_volume *vol, struct other_check_opts *opt)
 		r.current_pos = ltfs_get_index_selfpointer(vol);
 		ltfsmsg(LTFS_DEBUG, 16081D, ltfs_get_index_generation(vol),
 				(int)r.current_pos.partition, (unsigned long long)r.current_pos.block);
+		ltfs_set_commit_message_reason(SYNC_ROLLBACK, vol);
 		ltfs_unmount(SYNC_ROLLBACK, vol);
 		vol->index = NULL;
 	}


### PR DESCRIPTION
# Summary of changes

In the LTFS format spec 2.5, behavior of sync is changed. 

- Sync index when `ltfs.commitMessage` is written
- Sync index with a written message as a commit message via `ltfs.sync` 

# Description

The changes in this PR make commit massage more specific. It means specified message is always written down to the tape. So there is no need to take care about carry over of the message.

In this PR, I made the changes below.

1. `commit message` is always specified implicitly or explicitly
2. In the implicit case, like periodic, unmount etc., the message is automatically generated based on the reason of `sync`

Fixes #455 

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works<