### PR TITLE
Fix potential use after free issues

### DIFF
--- a/src/libltfs/ltfstrace.c
+++ b/src/libltfs/ltfstrace.c
@@ -363,8 +363,8 @@ void ltfs_admin_function_trace_completed(uint32_t tid)
 static void ltfs_function_trace_destroy(void)
 {
 	if (fs_tr_list) {
-		struct filesystem_trace_list *fsitem;
-		for (fsitem=fs_tr_list; fsitem != NULL; fsitem=fsitem->hh.next) {
+		struct filesystem_trace_list *fsitem, *tmp;
+		HASH_ITER(hh, fs_tr_list, fsitem, tmp) {
 			destroy_mrsw(&fsitem->fn_entry->trace_lock);
 			free(fsitem->fn_entry);
 			free(fsitem);
@@ -372,8 +372,8 @@ static void ltfs_function_trace_destroy(void)
 		fs_tr_list = NULL;
 	}
 	if (admin_tr_list) {
-		struct admin_trace_list *aditem;
-		for (aditem=admin_tr_list; aditem != NULL; aditem=aditem->hh.next) {
+		struct admin_trace_list *aditem, *tmp;
+		HASH_ITER(hh, admin_tr_list, aditem, tmp) {
 			destroy_mrsw(&aditem->fn_entry->trace_lock);
 			free(aditem->fn_entry);
 			free(aditem);
@@ -381,8 +381,8 @@ static void ltfs_function_trace_destroy(void)
 		admin_tr_list = NULL;
 	}
 	if (acomp) {
-		struct admin_completed_function_trace *tailq_item;
-		TAILQ_FOREACH (tailq_item, acomp, list) {
+		struct admin_completed_function_trace *tailq_item, *tmp;
+		TAILQ_FOREACH_SAFE(tailq_item, acomp, list, tmp) {
 			destroy_mrsw(&tailq_item->trace_lock);
 			free(tailq_item->fn_entry);
 			free(tailq_item);


### PR DESCRIPTION
The problem was found by code scan. Use delete safe iteration instead.

# Summary of changes

This pull request includes following changes or fixes. 

- Fix of issue #457 

# Description

The CodeQL on the GitHub found three `potential use after free` issues. All are same flavor, it 
means, use a pointer after free. So change the logic from normal iteration to delete safe iteration.

This fix might be good to merge to the `v2.4-stable` branch also.

Fixes #457

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
