### PR TITLE
Introduce incremental index write down in XML format

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -185,11 +185,22 @@ AC_ARG_ENABLE([buggy_ifs],
 AC_MSG_RESULT([$buggy_ifs])
 
 dnl
+dnl Handle --enable-xml-indent (default:no)
+dnl
+AC_MSG_CHECKING([whether to enable xml indentation for index])
+AC_ARG_ENABLE([xml_indent],
+    [AS_HELP_STRING([--enable-xml-indent],[Enable XML indentation for index])],
+    [xml_indent=$enableval],
+    [xml_indent=no]
+)
+AC_MSG_RESULT([$xml_indent])
+
+dnl
 dnl Handle --enable-format-spec25 (default:no)
 dnl
 AC_MSG_CHECKING([whether to enable format spec 2.5 support or not])
 AC_ARG_ENABLE([format_spec25],
-    [AS_HELP_STRING([--enable-formst-spec25],[Support format spec 2.5])],
+    [AS_HELP_STRING([--enable-format-spec25],[Support format spec 2.5])],
     [format_spec25=$enableval],
     [format_spec25=no]
 )
@@ -508,6 +519,11 @@ fi
 if test "x$livelink" = "xno"
 then
     AM_CPPFLAGS="${AM_CPPFLAGS} -DPOSIXLINK_ONLY"
+fi
+
+if test "x$xml_indent" = "xyes"
+then
+    AM_CPPFLAGS="${AM_CPPFLAGS} -DINDENT_INDEXES"
 fi
 
 if test "x$format_spec25" = "xyes"

--- a/configure.ac
+++ b/configure.ac
@@ -185,6 +185,17 @@ AC_ARG_ENABLE([buggy_ifs],
 AC_MSG_RESULT([$buggy_ifs])
 
 dnl
+dnl Handle --enable-format-spec25 (default:no)
+dnl
+AC_MSG_CHECKING([whether to enable format spec 2.5 support or not])
+AC_ARG_ENABLE([format_spec25],
+    [AS_HELP_STRING([--enable-formst-spec25],[Support format spec 2.5])],
+    [format_spec25=$enableval],
+    [format_spec25=no]
+)
+AC_MSG_RESULT([$format_spec25])
+
+dnl
 dnl Handle extra compile flags for tape driver
 dnl
 if test "x${buggy_ifs}" = "xyes"
@@ -497,6 +508,11 @@ fi
 if test "x$livelink" = "xno"
 then
     AM_CPPFLAGS="${AM_CPPFLAGS} -DPOSIXLINK_ONLY"
+fi
+
+if test "x$format_spec25" = "xyes"
+then
+    AM_CPPFLAGS="${AM_CPPFLAGS} -DFORMAT_SPEC25"
 fi
 
 dnl

--- a/contrib/ut-incindex/README.md
+++ b/contrib/ut-incindex/README.md
@@ -1,0 +1,13 @@
+# Unit Tests for incremental index
+
+This is a directory for having unit tests for incremental index feature.
+
+## How to run
+
+### Basic operation test
+
+  1. `cd` to this directory
+  2. Run the basic test with `./ut-basic.sh [mount_point]`
+      - The test script formats a (filebackend) tape under `/tmp/ltfstape`, start ltfs and stop ltfs automatically.
+      - If `[mount_point]` is not specified, the script uses `/tmp/mnt`
+      - You can pass the specific `ltfs` binary directory with teh environmental value `LTFS_BIN_PATH`

--- a/contrib/ut-incindex/ut-basic.sh
+++ b/contrib/ut-incindex/ut-basic.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+
+source ./utils.sh
+
+MOUNTPOINT='/tmp/mnt'
+TAPE_PATH='/tmp/ltfstape'
+
+if [ $# == 1 ]; then
+    MOUNTPOINT=$1
+elif [ $# -gt 2 ]; then
+    MOUNTPOINT=$1
+    TAPE_PATH=$2
+fi
+
+# Format LTFS
+FormatLTFS ${TAPE_PATH}
+if [ $? != 0 ]; then
+    exit 1
+fi
+
+# Launch LTFS
+LaunchLTFS ${MOUNTPOINT} ${TAPE_PATH}
+if [ $? != 0 ]; then
+    exit 1
+fi
+
+# 1. CREATE DIRS
+# Create a few dirs and files but all objects are handles by new dirs
+echo "1. CREATE DIRS"
+mkdir -p ${MOUNTPOINT}/dir1/dir11
+mkdir -p ${MOUNTPOINT}/dir1/dir12
+mkdir -p ${MOUNTPOINT}/dir2/dir21
+mkdir -p ${MOUNTPOINT}/dir2/dir22
+echo "AAA" > ${MOUNTPOINT}/dir1/file11
+echo "AAA" > ${MOUNTPOINT}/dir1/dir11/file111
+echo "AAA" > ${MOUNTPOINT}/dir1/dir11/file112
+IncrementalSync ${MOUNTPOINT} '1.CREATE_DIRS'
+if [ $? != 0 ]; then
+    exit 1
+fi
+
+# 2. CREATE FILES
+# Create files for checking file creation and directory traverse
+echo "2. CREATE FILES"
+echo "AAA" > ${MOUNTPOINT}/dir1/dir11/file113
+echo "AAA" > ${MOUNTPOINT}/dir1/dir12/file121
+echo "AAA" > ${MOUNTPOINT}/dir2/dir22/file221
+echo "AAA" > ${MOUNTPOINT}/dir2/file21
+IncrementalSync ${MOUNTPOINT} '2.CREATE_FILES'
+if [ $? != 0 ]; then
+    exit 1
+fi
+
+# 3. MODIFY FILES
+# Modify contents of files. Need to check  /dir2 doesn't have meta-data on the incremental index
+echo "3. MODIFY FILES"
+echo "BBB" > ${MOUNTPOINT}/dir1/dir11/file111
+echo "BBB" > ${MOUNTPOINT}/dir2/dir22/file221
+echo "BBB" > ${MOUNTPOINT}/dir1/file11
+IncrementalSync ${MOUNTPOINT} '3.MODIFY_FILES'
+if [ $? != 0 ]; then
+    exit 1
+fi
+
+# 4. MODIFY DIRS
+# Modify directory's meta-data. Need to check both /dir1 and /dir1/dir11 has meta-data
+# on the incremental index
+echo "4. MODIFY DIRS"
+AddXattr ${MOUNTPOINT}/dir1 'ut-attr1' 'val1'
+echo "CCC" > ${MOUNTPOINT}/dir1/dir11/file111
+IncrementalSync ${MOUNTPOINT} '4.MODIFY_DIRS'
+if [ $? != 0 ]; then
+    exit 1
+fi
+
+# 5. DELETE FILES
+echo "5. DELETE FILES"
+rm ${MOUNTPOINT}/dir1/dir11/*
+IncrementalSync ${MOUNTPOINT} '5.DELETE_FILES'
+if [ $? != 0 ]; then
+    exit 1
+fi
+
+# 6. DELETE DIR
+echo "5. DELETE DIR"
+rm -rf ${MOUNTPOINT}/dir1/dir11
+IncrementalSync ${MOUNTPOINT} '6.DELETE_DIR'
+if [ $? != 0 ]; then
+    exit 1
+fi
+
+# Stop LTFS
+StopLTFS ${MOUNTPOINT} ${TAPE_PATH}
+if [ $? != 0 ]; then
+    exit 1
+fi

--- a/contrib/ut-incindex/utils.sh
+++ b/contrib/ut-incindex/utils.sh
@@ -1,0 +1,197 @@
+#!/bin/sh
+
+PLATFORM=`uname`
+ECHO='/bin/echo'
+
+if [ "x${LTFS_BIN_PATH}" == 'x' ]; then
+    LTFS_BIN_PATH='/usr/local/bin'
+fi
+
+AddXattr()
+{
+    if [ "x$1" == "x" ]; then
+        "Need to a target to set xattr"
+        return 1
+    else
+        TARGET=$1
+    fi
+
+    if [ "x$2" == "x" ]; then
+        "Need to a name to set xattr"
+        return 1
+    else
+        NAME=$2
+    fi
+
+    if [ "x$3" == "x" ]; then
+        "Need to a value to set xattr"
+        return 1
+    else
+        VAL=$2
+    fi
+
+    ${ECHO} -n "Setting a xattr ${NAME} to ${TARGET} ... "
+    if [ "$PLATFORM" == "Darwin" ]; then
+        /usr/bin/xattr -w ${NAME} ${VAL} ${TARGET}
+    else
+        /usr/bin/attr -s ${NAME} -V ${VAL} ${TARGET}
+    fi
+
+    if [ $? == 0 ]; then
+        ${ECHO} "Done"
+        return 0
+    else
+        ${ECHO} "Failed"
+        return 1
+    fi
+
+}
+
+IncrementalSync()
+{
+    if [ "x$1" == "x" ]; then
+        MOUNTPOINT='/tmp/mnt'
+    else
+        MOUNTPOINT=$1
+    fi
+
+    if [ "x$2" == "x" ]; then
+        MSG='Incremental Sync'
+    else
+        MSG=$2
+    fi
+
+    ${ECHO} -n "Syncing LTFS (Incremental) ... "
+    if [ "$PLATFORM" == "Darwin" ]; then
+        /usr/bin/xattr -w ltfs.vendor.IBM.IncrementalSync ${MSG} ${MOUNTPOINT}
+    else
+        /usr/bin/attr -s ltfs.vendor.IBM.IncrementalSync -V ${MSG} ${MOUNTPOINT}
+    fi
+
+    if [ $? == 0 ]; then
+        ${ECHO} "Done"
+        return 0
+    else
+        ${ECHO} "Failed"
+        return 1
+    fi
+}
+
+FullSync()
+{
+    if [ "x$1" == "x" ]; then
+        MOUNTPOINT='/tmp/mnt'
+    else
+        MOUNTPOINT=$1
+    fi
+
+    if [ "x$2" == "x" ]; then
+        MSG='Full Sync'
+    else
+        MSG=$2
+    fi
+
+    ${ECHO} "Syncing LTFS (Full) ... "
+    if [ "$PLATFORM" == "Darwin" ]; then
+        /usr/bin/xattr -w ltfs.vendor.IBM.FullSync ${MSG} ${MOUNTPOINT}
+    else
+        /usr/bin/attr -s ltfs.vendor.IBM.FullSync -V ${MSG} ${MOUNTPOINT}
+    fi
+
+    if [ $? == 0 ]; then
+        ${ECHO} "Done"
+        return 0
+    else
+        ${ECHO} "Failed"
+        return 1
+    fi
+}
+
+FormatLTFS()
+{
+    if [ "x$1" == "x" ]; then
+        TAPE_PATH='/tmp/ltfstape'
+    else
+        TAPE_PATH=$1
+    fi
+
+    if [ ! -d ${TAPE_PATH} ]; then
+        ${ECHO} "Creating tape directory for file backend: ${TAPE_PATH}"
+        mkdir -p ${TAPE_PATH}
+        if [ $? != 0 ]; then
+            ${ECHO} "Failed to create a tape path: ${TAPE_PATH}"
+            return 1
+        fi
+    fi
+
+    ${ECHO} "Formatting tape directory with the file backend on ${TAPE_PATH} ... "
+    ${LTFS_BIN_PATH}/mkltfs -f -e file -d ${TAPE_PATH}
+    if [ $? != 0 ]; then
+        ${ECHO} "Failed to format a tape path: ${TAPE_PATH}"
+        return 1
+    fi
+
+    ${ECHO} "Formatted the file backend on ${TAPE_PATH}"
+    return 0
+}
+
+LaunchLTFS()
+{
+    if [ "x$1" == "x" ]; then
+        MOUNTPOINT='/tmp/mnt'
+    else
+        MOUNTPOINT=$1
+    fi
+
+    if [ "x$2" == "x" ]; then
+        TAPE_PATH='/tmp/ltfstape'
+    else
+        TAPE_PATH=$2
+    fi
+
+    if [ ! -d ${MOUNTPOINT} ]; then
+        ${ECHO} "Creating mount point for LTFS: ${MOUNTPOINT}"
+        mkdir -p ${MOUNTPOINT}
+        if [ $? != 0 ]; then
+            ${ECHO} "Failed to create a mount point"
+            return 1
+        fi
+    fi
+
+    if [ ! -d ${TAPE_PATH} ]; then
+        ${ECHO} "Creating tape directory for file backend: ${TAPE_PATH}"
+        mkdir -p ${TAPE_PATH}
+        if [ $? != 0 ]; then
+            ${ECHO} "Failed to create a tape path: ${TAPE_PATH}"
+            return 1
+        fi
+
+        ${ECHO} "Formatting tape directory with the file backend"
+        ${LTFS_BIN_PATH}/mkltfs -f -e file -d ${TAPE_PATH}
+        if [ $? != 0 ]; then
+            ${ECHO} "Failed to format a tape path: ${TAPE_PATH}"
+            return 1
+        fi
+    fi
+
+    ${ECHO} "Launching LTFS with the file backend"
+    ${LTFS_BIN_PATH}/ltfs -o tape_backend=file -o sync_type=unmount -o devname=${TAPE_PATH} ${MOUNTPOINT}
+    if [ $? != 0 ]; then
+        ${ECHO} "Failed to launch LTFS on ${MOUNTPOINT}"
+        return 1
+    fi
+
+    ${ECHO} "LTFS is launched on ${MOUNTPOINT}"
+    return 0
+}
+
+StopLTFS()
+{
+    if [ "x$1" == "x" ]; then
+        MOUNTPOINT='/tmp/mnt'
+    else
+        MOUNTPOINT=$1
+    fi
+
+    sudo umount ${MOUNTPOINT}
+}

--- a/messages/internal_error/root.txt
+++ b/messages/internal_error/root.txt
@@ -309,6 +309,7 @@ root:table {
 		I5048E:string{ "Unexpected partition map in a label." }
 		I5049E:string{ "Unexpected blocksize in a label." }
 		I5050E:string{ "Unexpected compression in a label." }
+		I5051E:string{ "Unsupported index type is specified." }
 
 		// Special error codes
 		I9997E:string{ "Child process error (ltfsck/mkltfs): %s (%d)." }

--- a/messages/libltfs/root.txt
+++ b/messages/libltfs/root.txt
@@ -836,6 +836,12 @@ v
 		17292I:string { "Current position is (%llu, %llu), Error position is (%llu, %llu)." }
 		17293E:string { "UUID in the index does not match the label." }
 
+		17300D:string { "Path Helper: Pushed %s to 0x%llx (head = 0x%llx, last = 0x%llx)." }
+		17301D:string { "Path Helper: Poped from 0x%llx (head = 0x%llx, last = 0x%llx)." }
+		17302D:string { "Path Helper: Compare 0x%llx and 0x%llx (Matched)." }
+		17303D:string { "Path Helper: Compare 0x%llx and 0x%llx (matched = %d, pop = %d, perfect_match = %d)." }
+		17304D:string { "Processing %s." }
+
 		// For Debug 19999I:string { "%s %s %d." }
 
 		// DO NOT place messages with IDs 20000 or higher here!

--- a/messages/libltfs/root.txt
+++ b/messages/libltfs/root.txt
@@ -836,11 +836,13 @@ v
 		17292I:string { "Current position is (%llu, %llu), Error position is (%llu, %llu)." }
 		17293E:string { "UUID in the index does not match the label." }
 
-		17300D:string { "Path Helper: Pushed %s to 0x%llx (head = 0x%llx, last = 0x%llx)." }
-		17301D:string { "Path Helper: Poped from 0x%llx (head = 0x%llx, last = 0x%llx)." }
-		17302D:string { "Path Helper: Compare 0x%llx and 0x%llx (Matched)." }
-		17303D:string { "Path Helper: Compare 0x%llx and 0x%llx (matched = %d, pop = %d, perfect_match = %d)." }
-		17304D:string { "Processing %s." }
+		17300I:string { "Wrote inc-index of %s (Gen = %lld, Part = %c, Pos = %lld, %s)." }
+		17301I:string { "Info inc-index, Gen = %lld, Full Part = %c, Full Pos = %lld, Back Part = %c, Back Pos = %lld)." }
+		17302E:string { "Path helper: Provided path must be an absolute path (%s)." }
+		17303E:string { "Unexpected value was found in the reason of inc-journal entry (%d)." }
+		17304E:string { "Unexpected value was provided to _xml_write_incremental_delete (%d)." }
+		17305E:string { "Failed to construct a path helper (push: %d)." }
+		17306E:string { "Failed to find a corresponded directory in path helper (push: %d)." }
 
 		// For Debug 19999I:string { "%s %s %d." }
 

--- a/src/iosched/unified.c
+++ b/src/iosched/unified.c
@@ -2292,7 +2292,7 @@ int _unified_write_index_after_perm(int write_ret, struct unified_data *priv)
 	}
 
 	ltfs_set_commit_message_reason(SYNC_WRITE_PERM, priv->vol);
-	ret = ltfs_write_index(ltfs_ip_id(priv->vol), SYNC_WRITE_PERM, priv->vol);
+	ret = ltfs_write_index(ltfs_ip_id(priv->vol), SYNC_WRITE_PERM, LTFS_FULL_INDEX, priv->vol);
 
 	return ret;
 }

--- a/src/libltfs/arch/errormap.c
+++ b/src/libltfs/arch/errormap.c
@@ -342,6 +342,7 @@ static struct error_map fuse_error_list[] = {
 	{ LTFS_XML_WRONG_PART_MAP,       "I5048E", EINVAL},
 	{ LTFS_XML_WRONG_BLOCKSIZE,      "I5049E", EINVAL},
 	{ LTFS_XML_WRONG_COMP,           "I5050E", EINVAL},
+    { LTFS_BAD_INDEX_TYPE,           "I5051E", EINVAL},
 	{ EDEV_NO_SENSE,                 "D0000E", EIO},
 	{ EDEV_OVERRUN,                  "D0002E", EIO},
 	{ EDEV_UNDERRUN,                 "D0003E", ENODATA},

--- a/src/libltfs/inc_journal.c
+++ b/src/libltfs/inc_journal.c
@@ -514,7 +514,7 @@ int incj_create_path_helper(const char *dpath, struct incj_path_helper **pm, str
 	for (dname = strtok_r(wp, "/", &tmp); dname != NULL; dname = strtok_r(NULL, "/", &tmp)) {
 		ret = incj_push_directory(dname, ipm);
 		if (ret < 0) {
-			ltfsmsg(LTFS_ERR, 17305E);
+			ltfsmsg(LTFS_ERR, 17305E, ret);
 			free(wp);
 			incj_destroy_path_helper(ipm);
 			return ret;

--- a/src/libltfs/inc_journal.c
+++ b/src/libltfs/inc_journal.c
@@ -599,10 +599,13 @@ int incj_pop_directory(struct incj_path_manager *pm)
 	return 0;
 }
 
-int incj_compare_path(struct incj_path_manager *p1, struct incj_path_manager *p2)
+int incj_compare_path(struct incj_path_manager *p1, struct incj_path_manager *p2,
+					  int *matches, int *pops)
 {
-	int ret = 0, matches = 0;
+	int ret = 0;
 	struct incj_path_element *cur1 = NULL, *cur2 = NULL;
+
+	*matches = 0;
 
 	cur1 = p1->head;
 	cur2 = p2->head;
@@ -620,16 +623,9 @@ int incj_compare_path(struct incj_path_manager *p1, struct incj_path_manager *p2
 		cur2++;
 	}
 
-	if (cur2) {
-		/* cur1 is shorter than cur2, need to push. -> positive value */
-		ret = 1;
-		while (cur2) {
-			ret++;
-			cur2++;
-		}
-	} else {
+	if (!cur2) {
 		/* cur1 is equal or longer than cur2. -> zero for perfect match, other wise pop for negative value */
-		ret = matches - p1->elems;
+		*pops = p1->elems - *matches;
 	}
 
 	return ret;

--- a/src/libltfs/inc_journal.c
+++ b/src/libltfs/inc_journal.c
@@ -171,7 +171,7 @@ int incj_modify(char *path, struct dentry *d, struct ltfs_volume *vol)
 	}
 
 	/* Skip journal modification because it is already existed */
-	HASH_FIND(hh, vol->journal, &ent->id, sizeof(struct jentry), ent);
+	HASH_FIND(hh, vol->journal, &d->uid, sizeof(struct jentry), ent);
 	if (ent) {
 		return 0;
 	}
@@ -655,13 +655,10 @@ int incj_compare_path(struct incj_path_helper *now, struct incj_path_helper *nex
 	}
 
 	*matches = matched;
+	*pops = now->elems - *matches;
 
-	if (!cur2) {
-		/* now is equal or longer than next. -> zero for perfect match, other wise how many pops */
-		*pops = now->elems - *matches;
-		if (!cur1)
-			*perfect_match = true;
-	}
+	if (!cur1 && !cur2)
+		*perfect_match = true;
 
 	return ret;
 }

--- a/src/libltfs/inc_journal.h
+++ b/src/libltfs/inc_journal.h
@@ -124,7 +124,8 @@ int incj_create_path_manager(const char *path, struct incj_path_manager **pm, st
 int incj_destroy_path_manager(struct incj_path_manager *pm);
 int incj_push_directory(char *name, struct incj_path_manager *pm);
 int incj_pop_directory(struct incj_path_manager *pm);
-int incj_compare_path(struct incj_path_manager *p1, struct incj_path_manager *p2);
+int incj_compare_path(struct incj_path_manager *p1, struct incj_path_manager *p2,
+					  int *matches, int *pops);
 char* incj_get_path(struct incj_path_manager *pm);
 
 #ifdef __cplusplus

--- a/src/libltfs/inc_journal.h
+++ b/src/libltfs/inc_journal.h
@@ -95,12 +95,37 @@ struct jcreated_entry {
 	char *path;
 };
 
+/**
+ *
+ */
+struct incj_path_element {
+	struct incj_path_element *prev;
+	struct incj_path_element *next;
+	char* name;
+	struct dentry *d;
+};
+
+struct incj_path_manager {
+	struct incj_path_element *head;
+	struct incj_path_element *tail;
+	struct ltfs_volume *vol;
+	unsigned int elems;
+};
+
 int incj_create(char *ppath, struct dentry *d, struct ltfs_volume *vol);
 int incj_modify(char *path, struct dentry *d, struct ltfs_volume *vol);
 int incj_rmfile(char *path, struct dentry *d, struct ltfs_volume *vol);
 int incj_rmdir(char *path, struct dentry *d, struct ltfs_volume *vol);
 int incj_clear(struct ltfs_volume *vol);
+void incj_sort(struct ltfs_volume *vol);
 void incj_dump(struct ltfs_volume *vol);
+
+int incj_create_path_manager(const char *path, struct incj_path_manager **pm, struct ltfs_volume *vol);
+int incj_destroy_path_manager(struct incj_path_manager *pm);
+int incj_push_directory(char *name, struct incj_path_manager *pm);
+int incj_pop_directory(struct incj_path_manager *pm);
+int incj_compare_path(struct incj_path_manager *p1, struct incj_path_manager *p2);
+char* incj_get_path(struct incj_path_manager *pm);
 
 #ifdef __cplusplus
 }

--- a/src/libltfs/inc_journal.h
+++ b/src/libltfs/inc_journal.h
@@ -81,9 +81,9 @@ struct journal_id {
  * Journal entry
  */
 struct jentry {
-	struct journal_id     id;      /**< ID of the journal entry (key of the hash table) */
-	enum   journal_reason reason;  /**< Reason of the entry */
-	struct dentry         *dentry; /**< Target dentry if required */
+	struct journal_id     id;           /**< ID of the journal entry (key of the hash table) */
+	enum   journal_reason reason;       /**< Reason of the entry */
+	struct dentry         *dentry;      /**< Target dentry if required */
 	UT_hash_handle        hh;
 };
 
@@ -105,7 +105,7 @@ struct incj_path_element {
 	struct dentry *d;
 };
 
-struct incj_path_manager {
+struct incj_path_helper {
 	struct incj_path_element *head;
 	struct incj_path_element *tail;
 	struct ltfs_volume *vol;
@@ -116,17 +116,18 @@ int incj_create(char *ppath, struct dentry *d, struct ltfs_volume *vol);
 int incj_modify(char *path, struct dentry *d, struct ltfs_volume *vol);
 int incj_rmfile(char *path, struct dentry *d, struct ltfs_volume *vol);
 int incj_rmdir(char *path, struct dentry *d, struct ltfs_volume *vol);
+int incj_dispose_jentry(struct jentry *ent);
 int incj_clear(struct ltfs_volume *vol);
 void incj_sort(struct ltfs_volume *vol);
 void incj_dump(struct ltfs_volume *vol);
 
-int incj_create_path_manager(const char *path, struct incj_path_manager **pm, struct ltfs_volume *vol);
-int incj_destroy_path_manager(struct incj_path_manager *pm);
-int incj_push_directory(char *name, struct incj_path_manager *pm);
-int incj_pop_directory(struct incj_path_manager *pm);
-int incj_compare_path(struct incj_path_manager *p1, struct incj_path_manager *p2,
-					  int *matches, int *pops);
-char* incj_get_path(struct incj_path_manager *pm);
+int incj_create_path_helper(const char *path, struct incj_path_helper **pm, struct ltfs_volume *vol);
+int incj_destroy_path_helper(struct incj_path_helper *pm);
+int incj_push_directory(char *name, struct incj_path_helper *pm);
+int incj_pop_directory(struct incj_path_helper *pm);
+int incj_compare_path(struct incj_path_helper *p1, struct incj_path_helper *p2,
+					  int *matches, int *pops, bool *perfect_match);
+char* incj_get_path(struct incj_path_helper *pm);
 
 #ifdef __cplusplus
 }

--- a/src/libltfs/inc_journal.h
+++ b/src/libltfs/inc_journal.h
@@ -84,6 +84,7 @@ struct jentry {
 	struct journal_id     id;           /**< ID of the journal entry (key of the hash table) */
 	enum   journal_reason reason;       /**< Reason of the entry */
 	struct dentry         *dentry;      /**< Target dentry if required */
+	struct ltfs_name      name;         /**< Name of entry for delete */
 	UT_hash_handle        hh;
 };
 

--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -2733,7 +2733,18 @@ int ltfs_write_index(char partition, char *reason, enum ltfs_index_type type, st
 		incj_clear(vol); /* Clear incremental journal data */
 		ltfs_unset_index_dirty(true, vol->index);
 	} else {
-		/* TODO: May be need to do something... */
+		ltfsmsg(LTFS_INFO, 17300I,
+				bc_print,
+				(unsigned long long)vol->index->generation,
+				vol->index->selfptr_inc.partition,
+				(unsigned long long)vol->index->selfptr_inc.block,
+				tape_get_serialnumber(vol->device));
+		ltfsmsg(LTFS_INFO, 17301I,
+				(unsigned long long)vol->index->generation,
+				vol->index->backptr.partition,
+				(unsigned long long)vol->index->backptr.block,
+				vol->index->backptr_inc.partition,
+				(unsigned long long)vol->index->backptr_inc.block);
 	}
 
 out_write_perm:

--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -3635,6 +3635,10 @@ int ltfs_sync_index(char *reason, bool index_locking, enum ltfs_index_type type,
 	bool dp_index_file_end, ip_index_file_end;
 	char *bc_print = NULL;
 
+#ifndef FORMAT_SPEC25
+	type = LTFS_FULL_INDEX;
+#endif
+
 start:
 	ret = ltfs_get_partition_readonly(ltfs_dp_id(vol), vol);
 	if (ret < 0 && ret != -LTFS_LESS_SPACE)

--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -2564,10 +2564,8 @@ int ltfs_write_index(char partition, char *reason, enum ltfs_index_type type, st
 
 	/* update index generation */
 	if (ltfs_is_dirty(vol)) {
-		if (type == LTFS_FULL_INDEX) {
-			generation_inc = true;
-			++vol->index->generation;
-		}
+		generation_inc = true;
+		++vol->index->generation;
 		modtime_old = vol->index->mod_time;
 		get_current_timespec(&vol->index->mod_time);
 	}

--- a/src/libltfs/ltfs.h
+++ b/src/libltfs/ltfs.h
@@ -177,9 +177,9 @@ struct device_data;
 #define INDEX_MAX_COMMENT_LEN         65536 /* Maximum comment field length (per LTFS Format) */
 
 enum ltfs_index_type {
-	LTFS_INDEX_AUTO = 0,   /*< Select index type to write based on specified options */
-	LTFS_FULL_INDEX,       /*< Forcibly write full index */
-	LTFS_INCREMENTAL_INDEX /*< Forcibly write incremental index */
+	LTFS_INDEX_AUTO = 0,   /**< Select index type to write based on specified options */
+	LTFS_FULL_INDEX,       /**< Forcibly write full index */
+	LTFS_INCREMENTAL_INDEX /**< Forcibly write incremental index */
 };
 
 #define LTFS_NO_BARCODE               "NO_BARCODE"

--- a/src/libltfs/ltfs_error.h
+++ b/src/libltfs/ltfs_error.h
@@ -317,6 +317,7 @@
 #define LTFS_XML_WRONG_PART_MAP   5048  /* Unexpected partition map in a label */
 #define LTFS_XML_WRONG_BLOCKSIZE  5049  /* Unexpected blocksize in a label */
 #define LTFS_XML_WRONG_COMP       5050  /* Unexpected compression in a label */
+#define LTFS_BAD_INDEX_TYPE       5051  /* Unsupported index type is specified */
 
 #define LTFS_ERR_MAX              19999
 

--- a/src/libltfs/ltfs_fsops.c
+++ b/src/libltfs/ltfs_fsops.c
@@ -2110,7 +2110,7 @@ int ltfs_fsops_volume_sync(char *reason, struct ltfs_volume *vol)
 	ltfs_set_commit_message_reason_unlocked(reason, vol);
 	ltfs_mutex_unlock(&vol->index->dirty_lock);
 
-	ret = ltfs_sync_index(reason, true, vol);
+	ret = ltfs_sync_index(reason, true, LTFS_INDEX_AUTO, vol);
 
 	return ret;
 }

--- a/src/libltfs/ltfs_internal.c
+++ b/src/libltfs/ltfs_internal.c
@@ -1326,11 +1326,11 @@ int ltfs_check_medium(bool fix, bool deep, bool recover_extra, bool recover_syml
 			ltfs_set_commit_message_reason(SYNC_RECOVERY, vol);
 			if (! dp_have_index || dp_blocks_after) {
 				ltfsmsg(LTFS_INFO, 17259I, "DP", vol->index->selfptr.partition, (unsigned long long)vol->index->selfptr.block);
-				ret = ltfs_write_index(vol->label->partid_dp, SYNC_RECOVERY, vol);
+				ret = ltfs_write_index(vol->label->partid_dp, SYNC_RECOVERY, LTFS_FULL_INDEX, vol);
 			}
 			if (!ret) {
 				ltfsmsg(LTFS_INFO, 17259I, "IP", vol->index->selfptr.partition, (unsigned long long)vol->index->selfptr.block);
-				ltfs_write_index(vol->label->partid_ip, SYNC_RECOVERY, vol);
+				ltfs_write_index(vol->label->partid_ip, SYNC_RECOVERY, LTFS_FULL_INDEX, vol);
 			}
 		} else {
 			ltfsmsg(LTFS_ERR, 11231E);
@@ -1410,12 +1410,12 @@ int ltfs_write_index_conditional(char partition, struct ltfs_volume *vol)
 
 	if (partition == ltfs_ip_id(vol) && ! vol->ip_index_file_end) {
 		ltfs_set_commit_message_reason(SYNC_CASCHE_PRESSURE, vol);
-		ret = ltfs_write_index(partition, SYNC_CASCHE_PRESSURE, vol);
+		ret = ltfs_write_index(partition, SYNC_CASCHE_PRESSURE, LTFS_FULL_INDEX, vol);
 	} else if (partition == ltfs_dp_id(vol) &&
 	         (! vol->dp_index_file_end ||
 	          (vol->ip_index_file_end && vol->index->selfptr.partition == ltfs_ip_id(vol)))) {
 		ltfs_set_commit_message_reason(SYNC_CASCHE_PRESSURE, vol);
-		ret = ltfs_write_index(partition, SYNC_CASCHE_PRESSURE, vol);
+		ret = ltfs_write_index(partition, SYNC_CASCHE_PRESSURE, LTFS_FULL_INDEX, vol);
 	}
 
 	return ret;

--- a/src/libltfs/periodic_sync.c
+++ b/src/libltfs/periodic_sync.c
@@ -102,7 +102,8 @@ ltfs_thread_return periodic_sync_thread(void* data)
 		}
 
 		ltfs_set_commit_message_reason(SYNC_PERIODIC, priv->vol);
-		ret = ltfs_sync_index(SYNC_PERIODIC, true, priv->vol);
+
+		ret = ltfs_sync_index(SYNC_PERIODIC, true, LTFS_INDEX_AUTO, priv->vol);
 		if (ret < 0) {
 			ltfsmsg(LTFS_INFO, 11030I, ret);
 			priv->keepalive = false;

--- a/src/libltfs/xattr.c
+++ b/src/libltfs/xattr.c
@@ -882,7 +882,7 @@ static int _xattr_get_virtual(struct dentry *d, char *buf, size_t buf_size, cons
 			}
 		} else if (! strcmp(name, "ltfs.sync")) {
 			ltfs_set_commit_message_reason(SYNC_EA, vol);
-			ret = ltfs_sync_index(SYNC_EA, false, vol);
+			ret = ltfs_sync_index(SYNC_EA, false, LTFS_FULL_INDEX, vol);
 		}
 	}
 
@@ -915,8 +915,12 @@ static int _xattr_set_virtual(struct dentry *d, const char *name, const char *va
 							  size_t size, struct ltfs_volume *vol)
 {
 	int ret = 0;
+	enum ltfs_index_type idx_type = LTFS_INDEX_AUTO;
 
-	if ((! strcmp(name, "ltfs.commitMessage") || ! strcmp(name, "ltfs.sync"))
+	if ((! strcmp(name, "ltfs.commitMessage") ||
+		 ! strcmp(name, "ltfs.sync") ||
+		 ! strcmp(name, "ltfs.vendor.IBM.SyncFullIndex") ||
+		 ! strcmp(name, "ltfs.vendor.IBM.SyncIncremental"))
 		&& d == vol->index->root) {
 		char *value_null_terminated, *new_value;
 
@@ -924,6 +928,11 @@ static int _xattr_set_virtual(struct dentry *d, const char *name, const char *va
 			ltfsmsg(LTFS_ERR, 11308E);
 			ret = -LTFS_LARGE_XATTR;
 		}
+
+		if (! strcmp(name, "ltfs.vendor.IBM.SyncFullIndex"))
+			idx_type = LTFS_FULL_INDEX;
+		else if (! strcmp(name, "ltfs.vendor.IBM.SyncIncremental"))
+			idx_type = LTFS_INCREMENTAL_INDEX;
 
 		ltfs_mutex_lock(&vol->index->dirty_lock);
 		if (! vol->index->dirty) {
@@ -953,12 +962,12 @@ static int _xattr_set_virtual(struct dentry *d, const char *name, const char *va
 					ltfs_set_commit_message_reason_unlocked(SYNC_EA, vol);
 					ltfs_mutex_unlock(&vol->index->dirty_lock);
 
-					ret = ltfs_sync_index(SYNC_EA, false, vol);
+					ret = ltfs_sync_index(SYNC_EA, false, LTFS_FULL_INDEX, vol);
 					return ret;
 				}
 				ret = 0;
 
-				/* Update THE commit message in the index */
+				/* Update the commit message in the index */
 				if (vol->index->commit_message)
 					free(vol->index->commit_message);
 				vol->index->commit_message = new_value;
@@ -968,7 +977,7 @@ static int _xattr_set_virtual(struct dentry *d, const char *name, const char *va
 		}
 
 		ltfs_mutex_unlock(&vol->index->dirty_lock);
-		ret = ltfs_sync_index(SYNC_EA, false, vol);
+		ret = ltfs_sync_index(SYNC_EA, false, idx_type, vol);
 
 	} else if (! strcmp(name, "ltfs.volumeName") && d == vol->index->root) {
 		char *value_null_terminated, *new_value;
@@ -1187,7 +1196,7 @@ static int _xattr_set_virtual(struct dentry *d, const char *name, const char *va
 
 		lock = strtoull(v, &invalid_start, 0);
 		if( (*invalid_start == '\0') && v ) {
-			mam_lockval new = UNLOCKED_MAM;
+			mam_lockval_t new = UNLOCKED_MAM;
 			char status_mam[TC_MAM_LOCKED_MAM_SIZE];
 
 			switch (vol->t_attr->vollock) {
@@ -1241,13 +1250,13 @@ static int _xattr_set_virtual(struct dentry *d, const char *name, const char *va
 			ltfs_set_index_dirty(false, false, vol->index);
 			ltfs_set_commit_message_reason_unlocked(SYNC_ADV_LOCK, vol);
 
-			ret = ltfs_sync_index(SYNC_ADV_LOCK, false, vol);
+			ret = ltfs_sync_index(SYNC_ADV_LOCK, false, LTFS_FULL_INDEX, vol);
 			ret = tape_device_lock(vol->device);
 			if (ret < 0) {
 				ltfsmsg(LTFS_ERR, 12010E, __FUNCTION__);
 				return ret;
 			}
-			ret = ltfs_write_index(ltfs_ip_id(vol), SYNC_EA, vol);
+			ret = ltfs_write_index(ltfs_ip_id(vol), SYNC_EA, LTFS_FULL_INDEX, vol);
 			tape_device_unlock(vol->device);
 		} else
 			ret = -LTFS_STRING_CONVERSION;
@@ -1501,7 +1510,7 @@ int xattr_set(struct dentry *d, const char *name, const char *value, size_t size
 
 	if (write_idx) {
 		ltfs_set_commit_message_reason(SYNC_EA, vol);
-		ret = ltfs_sync_index(SYNC_EA, false, vol);
+		ret = ltfs_sync_index(SYNC_EA, false, LTFS_INDEX_AUTO, vol);
 	} else
 		ret = 0;
 

--- a/src/libltfs/xattr.c
+++ b/src/libltfs/xattr.c
@@ -919,8 +919,8 @@ static int _xattr_set_virtual(struct dentry *d, const char *name, const char *va
 
 	if ((! strcmp(name, "ltfs.commitMessage") ||
 		 ! strcmp(name, "ltfs.sync") ||
-		 ! strcmp(name, "ltfs.vendor.IBM.SyncFullIndex") ||
-		 ! strcmp(name, "ltfs.vendor.IBM.SyncIncremental"))
+		 ! strcmp(name, "ltfs.vendor.IBM.FullSync") ||
+		 ! strcmp(name, "ltfs.vendor.IBM.IncrementalSync"))
 		&& d == vol->index->root) {
 		char *value_null_terminated, *new_value;
 
@@ -929,10 +929,16 @@ static int _xattr_set_virtual(struct dentry *d, const char *name, const char *va
 			ret = -LTFS_LARGE_XATTR;
 		}
 
-		if (! strcmp(name, "ltfs.vendor.IBM.SyncFullIndex"))
+#ifdef FORMAT_SPEC25
+		if (! strcmp(name, "ltfs.vendor.IBM.FullSync"))
 			idx_type = LTFS_FULL_INDEX;
-		else if (! strcmp(name, "ltfs.vendor.IBM.SyncIncremental"))
+		else if (! strcmp(name, "ltfs.vendor.IBM.IncrementalSync"))
 			idx_type = LTFS_INCREMENTAL_INDEX;
+#else
+		if (! strcmp(name, "ltfs.vendor.IBM.FullSync") ||
+			! strcmp(name, "ltfs.vendor.IBM.IncrementalSync")) {
+		}
+#endif
 
 		ltfs_mutex_lock(&vol->index->dirty_lock);
 		if (! vol->index->dirty) {

--- a/src/libltfs/xml_libltfs.h
+++ b/src/libltfs/xml_libltfs.h
@@ -83,7 +83,7 @@ xmlBufferPtr xml_make_label(const char *creator, tape_partition_t partition,
 xmlBufferPtr xml_make_schema(const char *creator, const struct ltfs_index *idx);
 int xml_schema_to_file(const char *filename, const char *creator,
 					   const char *reason, const struct ltfs_index *idx);
-int xml_schema_to_tape(char *reason, struct ltfs_volume *vol);
+int xml_schema_to_tape(char *reason, int type, struct ltfs_volume *vol);
 
 /* Functions for reading XML files. See xml_reader_libltfs.c */
 int xml_label_from_file(const char *filename, struct ltfs_label *label);

--- a/src/libltfs/xml_writer_libltfs.c
+++ b/src/libltfs/xml_writer_libltfs.c
@@ -642,9 +642,9 @@ static int _xml_write_incremental_schema(xmlTextWriterPtr writer, const char *cr
 	xml_mktag(xmlTextWriterWriteElement(writer, BAD_CAST "updatetime", BAD_CAST update_time), -1);
 	xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "location"), -1);
 	xml_mktag(xmlTextWriterWriteFormatElement(
-		writer, BAD_CAST "partition", "%c", idx->selfptr.partition), -1);
+		writer, BAD_CAST "partition", "%c", idx->selfptr_inc.partition), -1);
 	xml_mktag(xmlTextWriterWriteFormatElement(
-		writer, BAD_CAST "startblock", "%"PRIu64, idx->selfptr.block), -1);
+		writer, BAD_CAST "startblock", "%"PRIu64, idx->selfptr_inc.block), -1);
 	xml_mktag(xmlTextWriterEndElement(writer), -1);
 	if (idx->backptr.block) {
 		xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "previousgenerationlocation"), -1);
@@ -658,9 +658,9 @@ static int _xml_write_incremental_schema(xmlTextWriterPtr writer, const char *cr
 	if (idx->backptr_inc.block) {
 		xml_mktag(xmlTextWriterStartElement(writer, BAD_CAST "previousincrementallocation"), -1);
 		xml_mktag(xmlTextWriterWriteFormatElement(
-			writer, BAD_CAST "partition", "%c", idx->backptr.partition), -1);
+			writer, BAD_CAST "partition", "%c", idx->backptr_inc.partition), -1);
 		xml_mktag(xmlTextWriterWriteFormatElement(
-			writer, BAD_CAST "startblock", "%"PRIu64, idx->backptr.block), -1);
+			writer, BAD_CAST "startblock", "%"PRIu64, idx->backptr_inc.block), -1);
 		xml_mktag(xmlTextWriterEndElement(writer), -1);
 	}
 

--- a/src/libltfs/xml_writer_libltfs.c
+++ b/src/libltfs/xml_writer_libltfs.c
@@ -339,9 +339,10 @@ static int _xml_write_file(xmlTextWriterPtr writer, struct dentry *file, struct 
 	/* Write dirty file list */
 	if (sync_list->fp && file->dirty) {
 		fprintf(sync_list->fp, "%s,%"PRIu64"\n", file->name.name, file->size);
-		file->dirty = false;
 		sync_list->count++;
 	}
+
+	file->dirty = false;
 
 	return 0;
 }

--- a/src/ltfs_fuse.c
+++ b/src/ltfs_fuse.c
@@ -452,7 +452,7 @@ int ltfs_fuse_release(const char *path, struct fuse_file_info *fi)
 	ret = ltfs_fsops_close(file->file_info->dentry_handle, dirty, open_write, true, priv->data);
 	if (write_index) {
 		ltfs_set_commit_message_reason(SYNC_CLOSE, priv->data);
-		ltfs_sync_index(SYNC_CLOSE, true, priv->data);
+		ltfs_sync_index(SYNC_CLOSE, true, LTFS_INDEX_AUTO, priv->data);
 	}
 
 	_file_close(file->file_info, priv);

--- a/src/utils/ltfsck.c
+++ b/src/utils/ltfsck.c
@@ -1154,7 +1154,7 @@ int _rollback_ip(struct ltfs_volume *vol, struct other_check_opts *opt, struct t
 		if (ret != LTFSCK_NO_ERRORS)
 			ltfsmsg(LTFS_ERR, 16059E, ret);
 	} else {
-		ret = ltfs_write_index(ltfs_ip_id(vol), SYNC_ROLLBACK, vol);
+		ret = ltfs_write_index(ltfs_ip_id(vol), SYNC_ROLLBACK, LTFS_FULL_INDEX, vol);
 		if (ret < 0) {
 			ltfsmsg(LTFS_ERR, 16060E, ret);
 			ret = LTFSCK_OPERATIONAL_ERROR;
@@ -1176,7 +1176,7 @@ int _rollback_dp(struct ltfs_volume *vol, struct other_check_opts *opt, struct t
 			ltfsmsg(LTFS_ERR, 16055E, ret);
 	} else {
 		ltfs_set_commit_message_reason(SYNC_ROLLBACK, vol);
-		ret = ltfs_write_index(ltfs_dp_id(vol), SYNC_ROLLBACK, vol);
+		ret = ltfs_write_index(ltfs_dp_id(vol), SYNC_ROLLBACK, LTFS_FULL_INDEX, vol);
 		if (ret < 0) {
 			ltfsmsg(LTFS_ERR, 16056E, ret);
 			ret = LTFSCK_OPERATIONAL_ERROR;


### PR DESCRIPTION
# Summary of changes

Introduce incremental index writing feature by XML. 

# Description

- Generate an incremental index via VEA `ltfs.vendor.IBM.IncrementalSync`
- This feature is kicked only from VEA at this time
- Need to enable `--enable-format-spec25` to the `configure` script
- Introduce `--enable-xml-indent` option to the `configure` script for better XML debug
- Introduce unit test scripts under `contrib/ut-incindex`

Fixes #452 

## Type of change

- New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
