### PR TITLE
Add RHEL9 build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,26 @@ make install
 
 In some systems, you might need `sudo ldconfig -v` after `make install` to load the shared libraries correctly.
 
+## Build and install on RHEL9
+
+```
+sudo yum -y groupinstall 'Development Tools'
+sudo yum -y install autoconf libtool libuuid libuuid-devel net-snmp net-snmp-devel libxml2 libxml2-devel icu libicu libicu-devel
+wget https://github.com/libfuse/libfuse/releases/download/fuse-2.9.9/fuse-2.9.9.tar.gz
+tar xzvf fuse-2.9.9.tar.gz
+rm fuse-2.9.9.tar.gz
+cd fuse-2.9.9
+wget https://github.com/libfuse/libfuse/commit/ae2352bca9b4e607538412da0cc2a9625cd8b692.patch
+git apply ae2352bca9b4e607538412da0cc2a9625cd8b692.patch
+autoreconf -f -i
+./configure
+make && sudo make install
+cd ..
+./autogen.sh
+./configure
+make
+```
+
 ### Buildable Linux distributions
 
   | Dist                               | Arch    | Status                                                                                                                           |


### PR DESCRIPTION
# Summary of changes

Added build instructions for RHEL9.

# Description

Since fuse3 is the default package on RHEL9, ltfs won't build. This requires building fuse 2.99 from source.

## Type of change

- Documentation

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works
