### PR TITLE
Changed skip flags when calling _ltfs_search_index_wp

### DIFF
--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -1658,7 +1658,8 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 						(unsigned long long)vol->dp_coh.volume_change_ref,
 						(unsigned long long)volume_change_ref);
 
-				ret = _ltfs_search_index_wp(recover_symlink, false, &seekpos, vol);
+				/* Index of IP could be corrupted. So set skip flag to true */
+				ret = _ltfs_search_index_wp(recover_symlink, true, &seekpos, vol);
 				if (ret < 0)
 					goto out_unlock;
 
@@ -1687,8 +1688,8 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 						(unsigned long long)vol->dp_coh.volume_change_ref,
 						(unsigned long long)volume_change_ref);
 
-				/* Index of IP could be corrupted. So set skip flag */
-				ret = _ltfs_search_index_wp(recover_symlink, true, &seekpos, vol);
+				/* Index of DP could be corrupted. So set skip flag to false */
+				ret = _ltfs_search_index_wp(recover_symlink, false, &seekpos, vol);
 				if (ret < 0)
 					goto out_unlock;
 


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Fix issue #479
- Changed flags for `_ltfs_search_index_wp`

# Description

When a tape cartridge with a write permanent error is trying to be mounted and the MAM (cartridge memory) attribute of the Index Partion (IP) stores a generation number **different** than the MAM attribute of the Data Partition (DP), the mount process fails even when ltfs can still search for the index in the other partition. 

The code that belongs to the logic that handles WP happens on IP, defined "can_skip_ip" flag as false and it shall be **true**. On the other hand, the code that handles WP happens on DP, defined the "can_skip_ip" as true and it should be false. The logic is now adjusted. 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
