### PR TITLE
ltfs_ordered_copy now sorts files in the correct order before copying

### DIFF
--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -171,9 +171,9 @@ class CopyQueue:
             dst = dest + "/" + t
             dst = os.path.normpath(dst)
 
-            for d in dirs:
+            for d in sorted(dirs):
                 walk_dirs.append(os.path.join(dst, d))
-            for f in files:
+            for f in sorted(files):
                 self.logger.log(NOTSET + 1, 'Creating a copy item for file {}'.format(f))
                 c = CopyItem(os.path.join(root, f), os.path.join(dst, f), VEA_PREFIX,
                              cp_attr, cp_xattr, logger)

--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -397,7 +397,7 @@ if len(args.SOURCE) == 0:
     logger.log(NOTSET + 1, 'Source: {}'.format(args.SOURCE))
 
 # Create the list of copy item
-copyq = CopyQueue(logger, args.get('sort_files', False))
+copyq = CopyQueue(logger, args.sort_files)
 for s in args.SOURCE:
     dst = args.DEST
     if os.path.isfile(s):

--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -116,11 +116,12 @@ class CopyQueue:
     """"""
     HalfMegaByte = 512 * 1024
 
-    def __init__(self, logger): #initialization
+    def __init__(self, logger, sort_files = False): #initialization
         self.direct = deque([])
         self.tape_dict = {}
         self.items = 0
         self.logger = logger
+        self.sort_files = sort_files
 
     def add_copy_item(self, c):
         (u, p, s) = c.eval()
@@ -171,9 +172,9 @@ class CopyQueue:
             dst = dest + "/" + t
             dst = os.path.normpath(dst)
 
-            for d in sorted(dirs):
+            for d in sorted(dirs) if self.sort_files else dirs:
                 walk_dirs.append(os.path.join(dst, d))
-            for f in sorted(files):
+            for f in sorted(files) if self.sort_files else files:
                 self.logger.log(NOTSET + 1, 'Creating a copy item for file {}'.format(f))
                 c = CopyItem(os.path.join(root, f), os.path.join(dst, f), VEA_PREFIX,
                              cp_attr, cp_xattr, logger)
@@ -284,6 +285,7 @@ parser.add_argument('-a','--all', help='achieve files recursively and preserve a
 parser.add_argument('-v', help='Verbose output. Set VERBOSE level 5', action='store_true')
 parser.add_argument('--verbose', help='Configure verbosity of logger. VERBOSE shall be 0-6. default is 4', default = str(logger_info))
 parser.add_argument('-q','--quiet', help='No message output', action='store_true')
+parser.add_argument('--sort-files', help='Sort the file list before copying', action='store_true')
 
 args=parser.parse_args()
 
@@ -395,7 +397,7 @@ if len(args.SOURCE) == 0:
     logger.log(NOTSET + 1, 'Source: {}'.format(args.SOURCE))
 
 # Create the list of copy item
-copyq = CopyQueue(logger)
+copyq = CopyQueue(logger, args.get('sort_files', False))
 for s in args.SOURCE:
     dst = args.DEST
     if os.path.isfile(s):


### PR DESCRIPTION
# Summary of changes

ltfs_ordered_copy now sorts files in the correct order before copying

# Description

The os.walkdir generator in use by ltfs_ordered_copy uses os.listdir - which returns path names in an arbitrary order. Effectively copying files to tape in a completely random order. This simple change resolves this problem by sorting listed paths.

Expected result:
```
Tape order aware copy for LTFS
Destination /mnt/ltfs/20_04_2025 is LTFS
On disk sources: 9
Source tapes: 0
Copying on 9 disk files with 1 threads
"/home/ubuntu/ltfs_cache/Photos/Photos.7z.001" -> "/mnt/ltfs/20_04_2025/Photos/Photos.7z.001"
"/home/ubuntu/ltfs_cache/Photos/Photos.7z.002" -> "/mnt/ltfs/20_04_2025/Photos/Photos.7z.002"
"/home/ubuntu/ltfs_cache/Photos/Photos.7z.003" -> "/mnt/ltfs/20_04_2025/Photos/Photos.7z.003"
"/home/ubuntu/ltfs_cache/Photos/Photos.7z.004" -> "/mnt/ltfs/20_04_2025/Photos/Photos.7z.004"
"/home/ubuntu/ltfs_cache/Photos/Photos.7z.005" -> "/mnt/ltfs/20_04_2025/Photos/Photos.7z.005"
"/home/ubuntu/ltfs_cache/Photos/Photos.7z.006" -> "/mnt/ltfs/20_04_2025/Photos/Photos.7z.006"
"/home/ubuntu/ltfs_cache/Photos/Photos.7z.007" -> "/mnt/ltfs/20_04_2025/Photos/Photos.7z.007"
"/home/ubuntu/ltfs_cache/Photos/Photos.7z.008" -> "/mnt/ltfs/20_04_2025/Photos/Photos.7z.008"
"/home/ubuntu/ltfs_cache/Photos/Photos.7z.009" -> "/mnt/ltfs/20_04_2025/Photos/Photos.7z.009"
Copied 9 files.
```

Actual result:
```
Tape order aware copy for LTFS
Destination /mnt/ltfs/20_04_2025 is LTFS
On disk sources: 9
Source tapes: 0
Copying on 9 disk files with 1 threads
"/home/ubuntu/ltfs_cache/Photos/Photos.7z.006" -> "/mnt/ltfs/20_04_2025/Photos/Photos.7z.006"
"/home/ubuntu/ltfs_cache/Photos/Photos.7z.002" -> "/mnt/ltfs/20_04_2025/Photos/Photos.7z.002"
"/home/ubuntu/ltfs_cache/Photos/Photos.7z.001" -> "/mnt/ltfs/20_04_2025/Photos/Photos.7z.001"
"/home/ubuntu/ltfs_cache/Photos/Photos.7z.005" -> "/mnt/ltfs/20_04_2025/Photos/Photos.7z.005"
"/home/ubuntu/ltfs_cache/Photos/Photos.7z.009" -> "/mnt/ltfs/20_04_2025/Photos/Photos.7z.009"
"/home/ubuntu/ltfs_cache/Photos/Photos.7z.004" -> "/mnt/ltfs/20_04_2025/Photos/Photos.7z.004"
"/home/ubuntu/ltfs_cache/Photos/Photos.7z.007" -> "/mnt/ltfs/20_04_2025/Photos/Photos.7z.007"
"/home/ubuntu/ltfs_cache/Photos/Photos.7z.003" -> "/mnt/ltfs/20_04_2025/Photos/Photos.7z.003"
"/home/ubuntu/ltfs_cache/Photos/Photos.7z.008" -> "/mnt/ltfs/20_04_2025/Photos/Photos.7z.008"
Copied 9 files.
```

## Type of change

Please delete items that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [*] My code follows the style guidelines of this project
- [*] I have performed a self-review of my own code
- [*] I have commented my code, particularly in hard-to-understand areas
- [*] I have made corresponding changes to the documentation
- [*] My changes generate no new warnings
- [*] I have confirmed my fix is effective or that my feature works
