### PR TITLE
Fix: strdup memory check

### DIFF
--- a/src/libltfs/arch/filename_handling.c
+++ b/src/libltfs/arch/filename_handling.c
@@ -130,7 +130,7 @@ void update_platform_safe_name(struct dentry* dentry, bool handle_invalid_char, 
 		}
 	}
 #else
-	// Checkup not needed here, memory error handling happens after function calls.
+	/* Checkup not needed here, memory error handling happens after function call. */
 	dentry->platform_safe_name = strdup(dentry->name.name);
 #endif
 }

--- a/src/libltfs/arch/filename_handling.c
+++ b/src/libltfs/arch/filename_handling.c
@@ -246,8 +246,9 @@ char * _generate_target_file_name(const char *prefix, const char *extension, int
 			if (!target) {
 				ltfsmsg(LTFS_ERR, 10001E, "_generate_target_file_name: target assign");
 				ret = -1;
+			} else {
+				ret = strlen(target);
 			}
-			ret = target ? strlen(target) : -1;
 		}
 	}
 

--- a/src/libltfs/arch/filename_handling.c
+++ b/src/libltfs/arch/filename_handling.c
@@ -130,6 +130,7 @@ void update_platform_safe_name(struct dentry* dentry, bool handle_invalid_char, 
 		}
 	}
 #else
+	// Checkup not needed here, memory error handling happens after function calls.
 	dentry->platform_safe_name = strdup(dentry->name.name);
 #endif
 }
@@ -242,6 +243,10 @@ char * _generate_target_file_name(const char *prefix, const char *extension, int
 			ret = asprintf(&target, "%s.%s", prefix, extension);
 		else {
 			target = strdup(prefix);
+			if (!target) {
+				ltfsmsg(LTFS_ERR, 10001E, "_generate_target_file_name: target assign");
+				ret = -1;
+			}
 			ret = target ? strlen(target) : -1;
 		}
 	}

--- a/src/libltfs/arch/filename_handling.c
+++ b/src/libltfs/arch/filename_handling.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/libltfs/fs.c
+++ b/src/libltfs/fs.c
@@ -89,7 +89,7 @@ static char* generate_hash_key_name(const char *src_str, int *rc)
 	} else
 		free(uchar_name);
 #else
-	// Chek not needed here for strdup because the error is handled where the function is called
+	/* Checkup not needed here, memory error handling happens after function call. */
 	key_name = strdup(src_str);
 	*rc = 0;
 #endif

--- a/src/libltfs/fs.c
+++ b/src/libltfs/fs.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/libltfs/fs.c
+++ b/src/libltfs/fs.c
@@ -89,6 +89,7 @@ static char* generate_hash_key_name(const char *src_str, int *rc)
 	} else
 		free(uchar_name);
 #else
+	// Chek not needed here for strdup because the error is handled where the function is called
 	key_name = strdup(src_str);
 	*rc = 0;
 #endif

--- a/src/libltfs/index_criteria.c
+++ b/src/libltfs/index_criteria.c
@@ -288,19 +288,19 @@ int index_criteria_parse_name(const char *criteria, size_t len, struct index_cri
 	/* Assign rules to the glob_patterns[] array */
 	rule = rule+5;
 	for (delim = rule; *delim; delim++) {
-		bool doDelimAssign = false;
-		bool doRuleAdd = false;
+		bool do_delim_assign = false;
+		bool do_rule_add = false;
 		if (*delim == ':') {
-			doDelimAssign = true;
-			doRuleAdd = true;
+			do_delim_assign = true;
+			do_rule_add = true;
 		}
 		else if (*delim == '/') {
-			doDelimAssign = true;
+			do_delim_assign = true;
 		}
 		else if (! (*(delim+1) == '\0')) {
 			continue;
 		}
-		if (doDelimAssign) *delim = '\0';
+		if (do_delim_assign) *delim = '\0';
 		rule_ptr->percent_encode = fs_is_percent_encode_required(rule);
 		rule_ptr->name = strdup(rule);
 		if (! rule_ptr->name) {
@@ -309,24 +309,7 @@ int index_criteria_parse_name(const char *criteria, size_t len, struct index_cri
 				return -EDEV_NO_MEMORY;
 		}
 		rule_ptr++;
-		if (doRuleAdd) rule = delim+1;
-		/*
-		if (*delim == ':') {
-			*delim = '\0';
-			rule_ptr->percent_encode = fs_is_percent_encode_required(rule);
-			rule_ptr->name = strdup(rule);
-			rule_ptr++;
-			rule = delim+1;
-		} else if (*delim == '/') {
-			*delim = '\0';
-			rule_ptr->percent_encode = fs_is_percent_encode_required(rule);
-			rule_ptr->name = strdup(rule);
-			rule_ptr++;
-		} else if (*(delim+1) == '\0') {
-			rule_ptr->percent_encode = fs_is_percent_encode_required(rule);
-			rule_ptr->name = strdup(rule);
-			rule_ptr++;
-		}*/
+		if (do_rule_add) rule = delim+1;
 	}
 
 	if (ic->glob_patterns == rule_ptr) {

--- a/src/libltfs/index_criteria.c
+++ b/src/libltfs/index_criteria.c
@@ -288,7 +288,7 @@ int index_criteria_parse_name(const char *criteria, size_t len, struct index_cri
 	/* Assign rules to the glob_patterns[] array */
 	rule = rule+5;
 	for (delim = rule; *delim; delim++) {
-		/*bool doDelimAssign = false;
+		bool doDelimAssign = false;
 		bool doRuleAdd = false;
 		if (*delim == ':') {
 			doDelimAssign = true;
@@ -309,7 +309,8 @@ int index_criteria_parse_name(const char *criteria, size_t len, struct index_cri
 				return -EDEV_NO_MEMORY;
 		}
 		rule_ptr++;
-		if (doRuleAdd) rule = delim+1;*/
+		if (doRuleAdd) rule = delim+1;
+		/*
 		if (*delim == ':') {
 			*delim = '\0';
 			rule_ptr->percent_encode = fs_is_percent_encode_required(rule);
@@ -325,7 +326,7 @@ int index_criteria_parse_name(const char *criteria, size_t len, struct index_cri
 			rule_ptr->percent_encode = fs_is_percent_encode_required(rule);
 			rule_ptr->name = strdup(rule);
 			rule_ptr++;
-		}
+		}*/
 	}
 
 	if (ic->glob_patterns == rule_ptr) {

--- a/src/libltfs/index_criteria.c
+++ b/src/libltfs/index_criteria.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/libltfs/index_criteria.c
+++ b/src/libltfs/index_criteria.c
@@ -288,27 +288,30 @@ int index_criteria_parse_name(const char *criteria, size_t len, struct index_cri
 	/* Assign rules to the glob_patterns[] array */
 	rule = rule+5;
 	for (delim = rule; *delim; delim++) {
-		if (*delim == ':') {
-			*delim = '\0';
+			if (*delim == ':' || *delim == '/') {
+				*delim = '\0';
+			}
 			rule_ptr->percent_encode = fs_is_percent_encode_required(rule);
 			rule_ptr->name = strdup(rule);
+			if (! rule_ptr->name) {
+					ltfsmsg(LTFS_ERR, 10001E, "index_criteria_parse_name: rule assign");
+					free(rule_ptr->name);
+					return -EDEV_NO_MEMORY;
+			}
 			rule_ptr++;
-			rule = delim+1;
-		} else if (*delim == '/') {
-			*delim = '\0';
-			rule_ptr->percent_encode = fs_is_percent_encode_required(rule);
-			rule_ptr->name = strdup(rule);
-			rule_ptr++;
-		} else if (*(delim+1) == '\0') {
-			rule_ptr->percent_encode = fs_is_percent_encode_required(rule);
-			rule_ptr->name = strdup(rule);
-			rule_ptr++;
-		}
+			if (*delim == ':') {
+				rule = delim+1;
+			}
 	}
 
 	if (ic->glob_patterns == rule_ptr) {
 		rule_ptr->percent_encode = fs_is_percent_encode_required(rule);
 		rule_ptr->name = strdup(rule);
+		if (! rule_ptr->name) {
+			ltfsmsg(LTFS_ERR, 10001E, "index_criteria_parse_name: glob_patterns assign");
+			free(rule_ptr->name);
+			return -EDEV_NO_MEMORY;
+		}
 	}
 
 	/* Validate rules */

--- a/src/libltfs/index_criteria.c
+++ b/src/libltfs/index_criteria.c
@@ -304,9 +304,9 @@ int index_criteria_parse_name(const char *criteria, size_t len, struct index_cri
 		rule_ptr->percent_encode = fs_is_percent_encode_required(rule);
 		rule_ptr->name = strdup(rule);
 		if (! rule_ptr->name) {
-				ltfsmsg(LTFS_ERR, 10001E, "index_criteria_parse_name: rule assign");
-				free(rule_ptr->name);
-				return -EDEV_NO_MEMORY;
+			ltfsmsg(LTFS_ERR, 10001E, "index_criteria_parse_name: rule assign");
+			free(rule_ptr->name);
+			return -LTFS_NO_MEMORY;
 		}
 		rule_ptr++;
 		if (do_rule_add) rule = delim+1;

--- a/src/libltfs/index_criteria.c
+++ b/src/libltfs/index_criteria.c
@@ -288,20 +288,44 @@ int index_criteria_parse_name(const char *criteria, size_t len, struct index_cri
 	/* Assign rules to the glob_patterns[] array */
 	rule = rule+5;
 	for (delim = rule; *delim; delim++) {
-			if (*delim == ':' || *delim == '/') {
-				*delim = '\0';
-			}
+		/*bool doDelimAssign = false;
+		bool doRuleAdd = false;
+		if (*delim == ':') {
+			doDelimAssign = true;
+			doRuleAdd = true;
+		}
+		else if (*delim == '/') {
+			doDelimAssign = true;
+		}
+		else if (! (*(delim+1) == '\0')) {
+			continue;
+		}
+		if (doDelimAssign) *delim = '\0';
+		rule_ptr->percent_encode = fs_is_percent_encode_required(rule);
+		rule_ptr->name = strdup(rule);
+		if (! rule_ptr->name) {
+				ltfsmsg(LTFS_ERR, 10001E, "index_criteria_parse_name: rule assign");
+				free(rule_ptr->name);
+				return -EDEV_NO_MEMORY;
+		}
+		rule_ptr++;
+		if (doRuleAdd) rule = delim+1;*/
+		if (*delim == ':') {
+			*delim = '\0';
 			rule_ptr->percent_encode = fs_is_percent_encode_required(rule);
 			rule_ptr->name = strdup(rule);
-			if (! rule_ptr->name) {
-					ltfsmsg(LTFS_ERR, 10001E, "index_criteria_parse_name: rule assign");
-					free(rule_ptr->name);
-					return -EDEV_NO_MEMORY;
-			}
 			rule_ptr++;
-			if (*delim == ':') {
-				rule = delim+1;
-			}
+			rule = delim+1;
+		} else if (*delim == '/') {
+			*delim = '\0';
+			rule_ptr->percent_encode = fs_is_percent_encode_required(rule);
+			rule_ptr->name = strdup(rule);
+			rule_ptr++;
+		} else if (*(delim+1) == '\0') {
+			rule_ptr->percent_encode = fs_is_percent_encode_required(rule);
+			rule_ptr->name = strdup(rule);
+			rule_ptr++;
+		}
 	}
 
 	if (ic->glob_patterns == rule_ptr) {

--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2025 IBM Corp. All rights reserved.
+**  Copyright 2010, 2020 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions
@@ -1658,8 +1658,7 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 						(unsigned long long)vol->dp_coh.volume_change_ref,
 						(unsigned long long)volume_change_ref);
 
-				/* Index of IP could be corrupted. So set skip flag to true */
-				ret = _ltfs_search_index_wp(recover_symlink, true, &seekpos, vol);
+				ret = _ltfs_search_index_wp(recover_symlink, false, &seekpos, vol);
 				if (ret < 0)
 					goto out_unlock;
 
@@ -1669,7 +1668,7 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 				seekpos.block = vol->dp_coh.set_id;
 			}
 		} else {
-			if (vol->ip_coh.count > vol->dp_coh.count && vollock != PWE_MAM_DP && vollock != PWE_MAM) {
+			if (vollock != PWE_MAM_DP && vollock != PWE_MAM) {
 				/*
 				 * The index on IP is newer but MAM shows write perm doesn't happen in DP.
 				 * LTFS already have written an index on DP when it is writing an index on IP,
@@ -1688,13 +1687,8 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 						(unsigned long long)vol->dp_coh.volume_change_ref,
 						(unsigned long long)volume_change_ref);
 
-				if (vollock == PWE_MAM_BOTH) {
-					/* Index of IP could be corrupted (because of double write perm). So set skip flag to true */
-					ret = _ltfs_search_index_wp(recover_symlink, true, &seekpos, vol);
-				} else {
-					/* Index of DP could be corrupted. So set skip flag to false */
-					ret = _ltfs_search_index_wp(recover_symlink, false, &seekpos, vol);
-				}
+				/* Index of IP could be corrupted. So set skip flag */
+				ret = _ltfs_search_index_wp(recover_symlink, true, &seekpos, vol);
 				if (ret < 0)
 					goto out_unlock;
 

--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -1658,6 +1658,7 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 						(unsigned long long)vol->dp_coh.volume_change_ref,
 						(unsigned long long)volume_change_ref);
 
+				/* Index of IP could be corrupted. So set skip flag to true */
 				ret = _ltfs_search_index_wp(recover_symlink, false, &seekpos, vol);
 				if (ret < 0)
 					goto out_unlock;

--- a/src/libltfs/ltfs.c
+++ b/src/libltfs/ltfs.c
@@ -1669,8 +1669,7 @@ int ltfs_mount(bool force_full, bool deep_recovery, bool recover_extra, bool rec
 				seekpos.block = vol->dp_coh.set_id;
 			}
 		} else {
-			if (vollock != PWE_MAM_DP && vollock != PWE_MAM) {
-				/*
+			if (vol->ip_coh.count > vol->dp_coh.count && vollock != PWE_MAM_DP && vollock != PWE_MAM) {				/*
 				 * The index on IP is newer but MAM shows write perm doesn't happen in DP.
 				 * LTFS already have written an index on DP when it is writing an index on IP,
 				 * so this condition wouldn't happen logically.

--- a/src/libltfs/ltfs_fsops.c
+++ b/src/libltfs/ltfs_fsops.c
@@ -1912,7 +1912,12 @@ int ltfs_fsops_symlink_path(const char* to, const char* from, ltfs_file_id *id, 
 
 	id->uid = d->uid;
 	id->ino = d->ino;
+	// TODO: Check if the return error is needed or can be skipped.
 	d->target.name = strdup(to);
+	if (! d->target.name) {
+		ltfsmsg(LTFS_ERR, 10001E, "ltfs_fsops_symlink_path: d target name");
+		return -LTFS_NO_MEMORY;
+	}
 	d->target.percent_encode = fs_is_percent_encode_required(to);
 	d->isslink = true;
 

--- a/src/libltfs/ltfs_fsops.c
+++ b/src/libltfs/ltfs_fsops.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2021 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/libltfs/ltfs_internal.c
+++ b/src/libltfs/ltfs_internal.c
@@ -1313,6 +1313,10 @@ int ltfs_split_symlink( struct ltfs_volume *vol )
 	}
 	ret = ltfs_fsops_close( workd, true, true, use_iosche, vol);
 	path=strdup(lfdir);
+	if (! path) {
+		ltfsmsg(LTFS_ERR, 10001E, "ltfs_split_symlink: path assign");
+		return -LTFS_NO_MEMORY;
+	}
 
 	/* loop for conflicted files */
 	for( i=0; i<(vol->index->symerr_count); i++ ){

--- a/src/libltfs/ltfs_internal.c
+++ b/src/libltfs/ltfs_internal.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/libltfs/ltfslogging.c
+++ b/src/libltfs/ltfslogging.c
@@ -489,6 +489,11 @@ int ltfsmsg_internal(bool print_id, int level, char **msg_out, const char *_id, 
 		vsprintf(msg_buf, output_buf, argp);
 		va_end(argp);
 		*msg_out = strdup(msg_buf);
+		// TODO: Check if the return -1 is needed, or the program can just continue
+		if (!(*msg_out)) {
+			ltfsmsg(LTFS_ERR, 10001E, "ltfsmsg_internal: msg_out assign");
+			return -1;
+		}
 	}
 
 #ifdef ENABLE_SNMP

--- a/src/libltfs/ltfslogging.c
+++ b/src/libltfs/ltfslogging.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/libltfs/ltfssnmp.c
+++ b/src/libltfs/ltfssnmp.c
@@ -122,6 +122,10 @@ int read_trap_def_file(char *deffile)
 					return -LTFS_NO_MEMORY;
 				}
 				entry->id = strdup(tok);
+				if (!entry->id) {
+					ltfsmsg(LTFS_ERR, 10001E, "read_trap_def_file: entry id assign");
+					return -LTFS_NO_MEMORY;
+				}
 				TAILQ_INSERT_TAIL(&trap_entries, entry, list);
 			}
 		}

--- a/src/libltfs/ltfssnmp.c
+++ b/src/libltfs/ltfssnmp.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/libltfs/pathname.c
+++ b/src/libltfs/pathname.c
@@ -954,7 +954,7 @@ int _pathname_utf8_to_system_icu(const char *src, char **dest)
 	if (! strcmp(syslocale, "UTF-8")) {
 		*dest = strdup(src);
 		if (! (*dest)) {
-			ltfsmsg(LTFS_ERR, 10001E, "_pathname_utf8_to_system_icu: dest assign");
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 		return 0;

--- a/src/libltfs/pathname.c
+++ b/src/libltfs/pathname.c
@@ -953,8 +953,10 @@ int _pathname_utf8_to_system_icu(const char *src, char **dest)
 	syslocale = ucnv_getDefaultName();
 	if (! strcmp(syslocale, "UTF-8")) {
 		*dest = strdup(src);
-		if (! *dest)
+		if (! (*dest)) {
+			ltfsmsg(LTFS_ERR, 10001E, "_pathname_utf8_to_system_icu: dest assign");
 			return -LTFS_NO_MEMORY;
+		}
 		return 0;
 	}
 

--- a/src/libltfs/pathname.c
+++ b/src/libltfs/pathname.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/libltfs/tape.c
+++ b/src/libltfs/tape.c
@@ -1895,6 +1895,10 @@ int tape_get_media_pool_info(struct ltfs_volume *vol, char **media_name, char **
 			name = strndup(vol->t_attr->media_pool, add_start);
 		}
 		info = strdup(&(vol->t_attr->media_pool[add_start+1]));
+		if (!info) {
+			ltfsmsg(LTFS_ERR, 10001E, __FILE__);
+			return -LTFS_NO_MEMORY;
+		}
 		len = strlen(info);
 		info[len-1] = '\0';
 	}
@@ -3508,7 +3512,7 @@ int read_tape_attribute(struct ltfs_volume *vol, char **val, const char *name)
 		*val = strdup(vol->t_attr->media_pool);
 	}
 
-	if (!*val) {
+	if (!(*val)) {
 		ltfsmsg(LTFS_ERR, 10001E, "read_tape_attribute: *val");
 		return -LTFS_UNEXPECTED_VALUE;
 	}

--- a/src/libltfs/tape.c
+++ b/src/libltfs/tape.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/libltfs/tape.c
+++ b/src/libltfs/tape.c
@@ -1896,7 +1896,7 @@ int tape_get_media_pool_info(struct ltfs_volume *vol, char **media_name, char **
 		}
 		info = strdup(&(vol->t_attr->media_pool[add_start+1]));
 		if (!info) {
-			ltfsmsg(LTFS_ERR, 10001E, __FILE__);
+			ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 			return -LTFS_NO_MEMORY;
 		}
 		len = strlen(info);

--- a/src/libltfs/xml_reader_libltfs.c
+++ b/src/libltfs/xml_reader_libltfs.c
@@ -154,6 +154,10 @@ static int decode_entry_name(char **new_name, const char *name)
 	tmp_name[j] = '\0';
 
 	*new_name = strdup(tmp_name);
+	if (! (*new_name)) {
+		ltfsmsg(LTFS_ERR, 10001E, "decode_entry_name: new name assign");
+		return -LTFS_NO_MEMORY;
+	}
 	free(tmp_name);
 
 	return 0;

--- a/src/libltfs/xml_reader_libltfs.c
+++ b/src/libltfs/xml_reader_libltfs.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/libltfs/xml_reader_libltfs.c
+++ b/src/libltfs/xml_reader_libltfs.c
@@ -155,7 +155,7 @@ static int decode_entry_name(char **new_name, const char *name)
 
 	*new_name = strdup(tmp_name);
 	if (! (*new_name)) {
-		ltfsmsg(LTFS_ERR, 10001E, "decode_entry_name: new name assign");
+		ltfsmsg(LTFS_ERR, 10001E, __FUNCTION__);
 		return -LTFS_NO_MEMORY;
 	}
 	free(tmp_name);

--- a/src/libltfs/xml_writer_libltfs.c
+++ b/src/libltfs/xml_writer_libltfs.c
@@ -131,6 +131,10 @@ static int encode_entry_name(char **new_name, const char *name)
 	tmp_name[j] = '\0';
 
 	*new_name = strdup(tmp_name);
+	if (! (*new_name)) {
+		ltfsmsg(LTFS_ERR, 10001E, "encode_entry_name: new name assign");
+		return -LTFS_NO_MEMORY;
+	}
 	free(tmp_name);
 
 	return 0;

--- a/src/libltfs/xml_writer_libltfs.c
+++ b/src/libltfs/xml_writer_libltfs.c
@@ -98,6 +98,10 @@ static int encode_entry_name(char **new_name, const char *name)
 	len = strlen(name);
 
 	tmp_name = malloc(len * 3 * sizeof(UChar));
+	if (! tmp_name) {
+		ltfsmsg(LTFS_ERR, 10001E, "encode_entry_name: tmp name assign");
+		return -LTFS_NO_MEMORY;
+	}
 	buf_encode[2] = '\0';
 
 	while (i < len) {

--- a/src/libltfs/xml_writer_libltfs.c
+++ b/src/libltfs/xml_writer_libltfs.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/tape_drivers/freebsd/cam/cam_cmn.c
+++ b/src/tape_drivers/freebsd/cam/cam_cmn.c
@@ -3,7 +3,7 @@
 **  OS_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2018 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **  Copyright (c) 2013-2018 Spectra Logic Corporation. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without

--- a/src/tape_drivers/freebsd/cam/cam_cmn.c
+++ b/src/tape_drivers/freebsd/cam/cam_cmn.c
@@ -189,6 +189,10 @@ int camtape_ioctlrc2err(void *device, int fd, struct scsi_sense_data *sense_data
 
 			if (msg) {
 				*msg = strdup("No Sense Information");
+				if (! (*msg)) {
+					ltfsmsg(LTFS_ERR, 10001E, "camtape_ioctlrc2err: msg assign");
+					// TODO: Check if error return is needed
+				}
 			}
 			rc = -EDEV_NO_SENSE;
 		} else {
@@ -217,6 +221,10 @@ int camtape_ioctlrc2err(void *device, int fd, struct scsi_sense_data *sense_data
 		ltfsmsg(LTFS_INFO, 31212I, rc_sense);
 		if (msg)
 			*msg = strdup("Cannot get sense information");
+			if (! (*msg)) {
+				ltfsmsg(LTFS_ERR, 10001E, "camtape_ioctlrc2err: msg assign");
+				// TODO: Check if error return is needed
+			}
 
 		rc = -EDEV_CANNOT_GET_SENSE;
 	}

--- a/src/tape_drivers/freebsd/cam/cam_cmn.h
+++ b/src/tape_drivers/freebsd/cam/cam_cmn.h
@@ -3,7 +3,7 @@
 **  OS_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2018 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **  Copyright (c) 2013-2018 Spectra Logic Corporation. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without

--- a/src/tape_drivers/freebsd/cam/cam_cmn.h
+++ b/src/tape_drivers/freebsd/cam/cam_cmn.h
@@ -515,6 +515,10 @@ static inline int _sense2errcode(uint32_t sense, struct error_table *table, char
 			rc  = table[i].err_code;
 			if (msg)
 				*msg = strdup(table[i].msg);
+				if (! (*msg)) {
+					ltfsmsg(LTFS_ERR, 10001E, "_sense2errcode: msg assign");
+					// TODO: Check if error return is needed
+				}
 			break;
 		}
 		i++;
@@ -524,7 +528,10 @@ static inline int _sense2errcode(uint32_t sense, struct error_table *table, char
 		rc = DEVICE_GOOD;
 	else if (table[i].sense == 0xFFFFFF && table[i].err_code == rc && msg)
 		*msg = strdup(table[i].msg);
-
+		if (! (*msg)) {
+			ltfsmsg(LTFS_ERR, 10001E, "_sense2errcode: msg assign");
+			// TODO: Check if error return is needed
+		}
 	return rc;
 }
 
@@ -545,6 +552,10 @@ static inline int camtape_send_ccb(struct camtape_data *softc, union ccb *ccb, c
 
 		snprintf(tmpstr, sizeof(tmpstr), "cam_send_ccb() failed: %s", strerror(errno));
 		*msg = strdup(tmpstr);
+		if (! (*msg)) {
+			ltfsmsg(LTFS_ERR, 10001E, "camtape_send_ccb: msg assign");
+			// TODO: Check if error return is needed
+		}
 		rc = -errno;
 	} else
 		rc = camtape_ccb2rc(softc, ccb);

--- a/src/tape_drivers/freebsd/cam/cam_tc.c
+++ b/src/tape_drivers/freebsd/cam/cam_tc.c
@@ -3,7 +3,7 @@
 **  OS_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2018 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **  Copyright (c) 2013-2018 Spectra Logic Corporation. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without

--- a/src/tape_drivers/freebsd/cam/cam_tc.c
+++ b/src/tape_drivers/freebsd/cam/cam_tc.c
@@ -1298,11 +1298,19 @@ static int camtape_load_attr(struct mt_status_data *mtinfo, xmlDocPtr doc, xmlAt
 				nv = malloc(sizeof(*nv));
 				if (nv == NULL) {
 					*msg = strdup("Unable to allocate memory");
+					if (! (*msg)) {
+						ltfsmsg(LTFS_ERR, 10001E, "camtape_load_attr: msg assign");
+						// TODO: Check if error return is needed
+					}
 					retval = -EDEV_NO_MEMORY;
 					goto bailout;
 				}
 				memset(nv, 0, sizeof(*nv));
 				nv->name = strdup((char *)xattr->name);
+				if (! nv->name) {
+					ltfsmsg(LTFS_ERR, 10001E, "camtape_load_attr: nv name assign");
+					// TODO: Check if error return is needed
+				}
 				nv->value = str;
 				STAILQ_INSERT_TAIL(&entry->nv_list, nv, links);
 				need_free = 0;
@@ -1331,6 +1339,10 @@ static int camtape_load_elements(struct mt_status_data *mtinfo, xmlDocPtr doc, x
 			if ((u_int)mtinfo->level > sizeof(mtinfo->cur_entry) /
 			    sizeof(mtinfo->cur_entry[0])) {
 				*msg = strdup("Too many nesting levels");
+				if (! (*msg)) {
+					ltfsmsg(LTFS_ERR, 10001E, "camtape_load_elements: msg assign");
+					// TODO: Check if error return is needed
+				}
 				retval = -EDEV_INVALID_ARG;
 				goto bailout;
 			}
@@ -1338,6 +1350,10 @@ static int camtape_load_elements(struct mt_status_data *mtinfo, xmlDocPtr doc, x
 			entry = malloc(sizeof(*entry));
 			if (entry == NULL) {
 				*msg = strdup("Unable to allocate memory");
+				if (! (*msg)) {
+					ltfsmsg(LTFS_ERR, 10001E, "camtape_load_elements: msg assign");
+					// TODO: Check if error return is needed
+				}
 				retval = -EDEV_NO_MEMORY;
 				goto bailout;
 			}
@@ -1345,6 +1361,10 @@ static int camtape_load_elements(struct mt_status_data *mtinfo, xmlDocPtr doc, x
 			STAILQ_INIT(&entry->nv_list);
 			STAILQ_INIT(&entry->child_entries);
 			entry->entry_name = strdup((char *)xnode->name);
+			if (! entry->entry_name) {
+				ltfsmsg(LTFS_ERR, 10001E, "camtape_load_elements: entry name assign");
+				// TODO: Check if error return is needed
+			}
 			mtinfo->cur_entry[mtinfo->level] = entry;
 			if (mtinfo->cur_entry[mtinfo->level - 1] == NULL) {
 				STAILQ_INSERT_TAIL(&mtinfo->entries, entry, links);
@@ -1413,6 +1433,10 @@ extget_retry:
 	xml_str = malloc(alloc_size);
 	if (xml_str == NULL) {
 		*msg = strdup("Unable to allocate memory");
+		if (! (*msg)) {
+			ltfsmsg(LTFS_ERR, 10001E, "camtape_get_mtinfo: msg assign");
+			// TODO: Check if error return is needed
+		}
 		retval = -EDEV_NO_MEMORY;
 		goto bailout;
 	}
@@ -1425,6 +1449,10 @@ extget_retry:
 		snprintf(tmpstr, sizeof(tmpstr), "ioctl error from sa(4) driver: %s",
 		    strerror(errno));
 		*msg = strdup(tmpstr);
+		if (! (*msg)) {
+			ltfsmsg(LTFS_ERR, 10001E, "camtape_get_mtinfo: msg assign");
+			// TODO: Check if error return is needed
+		}
 		retval = -errno;
 		goto bailout;
 	}
@@ -1445,6 +1473,10 @@ extget_retry:
 		snprintf(tmpstr, sizeof(tmpstr), "Error getting status data from sa(4) driver: status = %d",
 			extget.status);
 		*msg = strdup(tmpstr);
+		if (! (*msg)) {
+			ltfsmsg(LTFS_ERR, 10001E, "camtape_get_mtinfo: msg assign");
+			// TODO: Check if error return is needed
+		}
 		goto bailout;
 	}
 
@@ -1453,6 +1485,10 @@ extget_retry:
 	ctx = xmlNewParserCtxt();
 	if (ctx == NULL) {
 		*msg = strdup("Unable to create new XML parser context");
+		if (! (*msg)) {
+			ltfsmsg(LTFS_ERR, 10001E, "camtape_get_mtinfo: msg assign");
+			// TODO: Check if error return is needed
+		}
 		retval = -EDEV_NO_MEMORY;
 		goto bailout;
 	}
@@ -1460,11 +1496,19 @@ extget_retry:
 	doc = xmlCtxtReadMemory(ctx, xml_str, strlen(xml_str), NULL, NULL, 0);
 	if (doc == NULL) {
 		*msg = strdup("Unable to parse XML");
+		if (! (*msg)) {
+			ltfsmsg(LTFS_ERR, 10001E, "camtape_get_mtinfo: msg assign");
+			// TODO: Check if error return is needed
+		}
 		retval = -EDEV_DRIVER_ERROR;
 		goto bailout;
 	} else {
 		if (ctx->valid == 0) {
 			*msg = strdup("XML parsing result is: not valid");
+			if (! (*msg)) {
+				ltfsmsg(LTFS_ERR, 10001E, "camtape_get_mtinfo: msg assign");
+				// TODO: Check if error return is needed
+			}
 			retval = -EDEV_INVALID_ARG;
 			goto bailout;
 		}
@@ -1537,6 +1581,10 @@ int camtape_getstatus(struct camtape_data *softc, struct mt_status_data *mtinfo,
 
 			snprintf(tmpstr, sizeof(tmpstr), "Unable to fetch sa(4) status item %s", name);
 			*msg = strdup(tmpstr);
+			if (! (*msg)) {
+				ltfsmsg(LTFS_ERR, 10001E, "camtape_getstatus: msg assign");
+				// TODO: Check if error return is needed
+			}
 			retval = -EDEV_INVALID_ARG;
 			goto bailout;
 		}
@@ -2403,6 +2451,10 @@ int camtape_set_default(void *device)
 	 */
 	if (ioctl(softc->fd_sa, MTIOCPARAMSET, &sili_param) == -1) {
 		msg = strdup("Error returned from MTIOCPARAMSET ioctl to set the SILI bit");
+		if (! (*msg)) {
+			ltfsmsg(LTFS_ERR, 10001E, "camtape_set_default: msg assign");
+			// TODO: Check if error return is needed
+		}
 		rc = -EDEV_DRIVER_ERROR;
 		camtape_process_errors(device, rc, msg, "set default parameter", true);
 		goto bailout;
@@ -2437,6 +2489,10 @@ int camtape_set_default(void *device)
 	eot_model = 1;
 	if (ioctl(softc->fd_sa, MTIOCSETEOTMODEL, &eot_model) == -1) {
 		msg = strdup("Error returned from MTIOCSETEOTMODEL ioctl to set the EOT model to 1FM");
+		if (! (*msg)) {
+			ltfsmsg(LTFS_ERR, 10001E, "camtape_set_default: msg assign");
+			// TODO: Check if error return is needed
+		}
 		rc = -EDEV_DRIVER_ERROR;
 		camtape_process_errors(device, rc, msg, "set default parameter", true);
 		goto bailout;
@@ -3946,6 +4002,10 @@ int camtape_set_lbp(void *device, bool enable)
 	entry = mt_status_entry_find(&mtinfo, tmpname);
 	if (entry == NULL) {
 		msg = strdup("Cannot find sa(4) protection.protection_supported parameter");
+		if (! (*msg)) {
+			ltfsmsg(LTFS_ERR, 10001E, "camtape_set_lbp: msg assign");
+			// TODO: Check if error return is needed
+		}
 		rc = -EDEV_INVALID_ARG;
 		camtape_process_errors(device, rc, msg, "get lbp", true);
 		goto bailout;
@@ -3965,6 +4025,10 @@ int camtape_set_lbp(void *device, bool enable)
 	prot_entry = mt_status_entry_find(&mtinfo, MT_PROTECTION_NAME);
 	if (prot_entry == NULL) {
 		msg = strdup("Cannot find sa(4) protection node!");
+		if (! (*msg)) {
+			ltfsmsg(LTFS_ERR, 10001E, "camtape_set_lbp: msg assign");
+			// TODO: Check if error return is needed
+		}
 		rc = -EDEV_INVALID_ARG;
 		camtape_process_errors(device, rc, msg, "get lbp", true);
 		goto bailout;
@@ -3998,6 +4062,10 @@ int camtape_set_lbp(void *device, bool enable)
 		entry = mt_entry_find(prot_entry, __DECONST(char *, protect_list[i].name));
 		if (entry == NULL) {
 			msg = strdup("Cannot find all protection information entries");
+			if (! (*msg)) {
+				ltfsmsg(LTFS_ERR, 10001E, "camtape_set_lbp: msg assign");
+				// TODO: Check if error return is needed
+			}
 			rc = -EDEV_INVALID_ARG;
 			camtape_process_errors(device, rc, msg, "get lbp", true);
 			goto bailout;
@@ -4020,6 +4088,10 @@ int camtape_set_lbp(void *device, bool enable)
 		snprintf(tmpstr, sizeof(tmpstr), "Error returned from MTIOCSETLIST ioctl to set "
 			"protection parameters: %s", strerror(errno));
 		msg = strdup(tmpstr);
+		if (! (*msg)) {
+			ltfsmsg(LTFS_ERR, 10001E, "camtape_set_lbp: msg assign");
+			// TODO: Check if error return is needed
+		}
 		rc = -errno;
 		camtape_process_errors(device, rc, msg, "get lbp", true);
 		goto bailout;

--- a/src/tape_drivers/generic/file/filedebug_tc.c
+++ b/src/tape_drivers/generic/file/filedebug_tc.c
@@ -439,8 +439,13 @@ int filedebug_open(const char *name, void **handle)
 		}
 
 		/* Run on file mode */
-		if (devname == NULL)
+		if (devname == NULL) {
 			devname = strdup(name);
+			if (!devname) {
+				ltfsmsg(LTFS_ERR, 10001E, "filedebug_open: devname");
+				return -EDEV_NO_MEMORY;
+			}
+		}
 		ltfsmsg(LTFS_INFO, 30001I, devname);
 		state->fd = open(devname, O_RDWR | O_BINARY);
 		if (state->fd < 0) {
@@ -2657,9 +2662,9 @@ int filedebug_get_device_list(struct tc_drive_info *buf, int count)
 
 		if (buf && deventries < count) {
 			tmp = strdup(entry->d_name);
-			if (! *tmp) {
+			if (! tmp) {
 				ltfsmsg(LTFS_ERR, 10001E, "filedebug_get_device_list");
-				return -ENOMEM;
+				return -LTFS_NO_MEMORY;
 			}
 
 			for (i = strlen(tmp) - 1; i > 0; --i) {
@@ -2767,7 +2772,7 @@ int filedebug_get_serialnumber(void *device, char **result)
 	else
 		*result = strdup("DUMMY");
 
-	if (! *result)
+	if (! (*result))
 		return -EDEV_NO_MEMORY;
 
 	return DEVICE_GOOD;

--- a/src/tape_drivers/generic/file/filedebug_tc.c
+++ b/src/tape_drivers/generic/file/filedebug_tc.c
@@ -2664,7 +2664,7 @@ int filedebug_get_device_list(struct tc_drive_info *buf, int count)
 			tmp = strdup(entry->d_name);
 			if (! tmp) {
 				ltfsmsg(LTFS_ERR, 10001E, "filedebug_get_device_list");
-				return -LTFS_NO_MEMORY;
+				return -EDEV_NO_MEMORY;
 			}
 
 			for (i = strlen(tmp) - 1; i > 0; --i) {

--- a/src/tape_drivers/generic/file/filedebug_tc.c
+++ b/src/tape_drivers/generic/file/filedebug_tc.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
+++ b/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
+++ b/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
@@ -730,7 +730,7 @@ int lin_tape_ibmtape_get_serialnumber(void *device, char **result)
 	ltfs_profiler_add_entry(priv->profiler, NULL, CHANGER_REQ_ENTER(REQ_TC_GETSER));
 
 	*result = strdup((const char *) priv->drive_serial);
-	if (! *result) {
+	if (! (*result)) {
 		ltfsmsg(LTFS_ERR, 10001E, "lin_tape_ibmtape_get_serialnumber: result");
 		ltfs_profiler_add_entry(priv->profiler, NULL, CHANGER_REQ_EXIT(REQ_TC_GETSER));
 		return -EDEV_NO_MEMORY;
@@ -1018,6 +1018,10 @@ int lin_tape_ibmtape_open(const char *devname, void **handle)
 	if (!ret) {
 		/* Specified file is existed. Use it as a device file name */
 		devfile = strdup(devname);
+		if (! devfile) {
+			ltfsmsg(LTFS_ERR, 10001E, "lin_tape_ibmtape_open: devfile");
+			return -EDEV_NO_MEMORY;
+		}
 	} else {
 		/* Search device by serial number (Assume devname has a drive serial) */
 		devs = lin_tape_ibmtape_get_device_list(NULL, 0);
@@ -1143,6 +1147,10 @@ int lin_tape_ibmtape_open(const char *devname, void **handle)
 
 	priv->loaded = false; /* Assume tape is not loaded until a successful load call. */
 	priv->devname = strdup(devname);
+	if (! priv->devname) {
+		ltfsmsg(LTFS_ERR, 10001E, "lin_tape_ibmtape_open: devname");
+		return -EDEV_NO_MEMORY;
+	}
 
 	priv->clear_by_pc     = false;
 	priv->force_writeperm = DEFAULT_WRITEPERM;

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -4960,7 +4960,7 @@ int sg_get_serialnumber(void *device, char **result)
 	ltfs_profiler_add_entry(priv->profiler, NULL, CHANGER_REQ_ENTER(REQ_TC_GETSER));
 
 	*result = strdup((const char *) priv->drive_serial);
-	if (! *result) {
+	if (! (*result)) {
 		ltfsmsg(LTFS_ERR, 10001E, "sg_get_serialnumber: result");
 		ltfs_profiler_add_entry(priv->profiler, NULL, CHANGER_REQ_EXIT(REQ_TC_GETSER));
 		return -EDEV_NO_MEMORY;

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
+++ b/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
+++ b/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
@@ -4440,7 +4440,7 @@ int scsipi_ibmtape_get_serialnumber(void *device, char **result)
 	ltfs_profiler_add_entry(priv->profiler, NULL, CHANGER_REQ_ENTER(REQ_TC_GETSER));
 
 	*result = strdup((const char *) priv->drive_serial);
-	if (! *result) {
+	if (! (*result)) {
 		ltfsmsg(LTFS_ERR, 10001E, "scsipi_ibmtape_get_serialnumber: result");
 		ltfs_profiler_add_entry(priv->profiler, NULL, CHANGER_REQ_EXIT(REQ_TC_GETSER));
 		return -EDEV_NO_MEMORY;

--- a/src/tape_drivers/osx/iokit/iokit_tape.c
+++ b/src/tape_drivers/osx/iokit/iokit_tape.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/tape_drivers/osx/iokit/iokit_tape.c
+++ b/src/tape_drivers/osx/iokit/iokit_tape.c
@@ -4160,7 +4160,7 @@ int iokit_get_serialnumber(void *device, char **result)
 	ltfs_profiler_add_entry(priv->profiler, NULL, CHANGER_REQ_ENTER(REQ_TC_GETSER));
 
 	*result = strdup((const char *) priv->drive_serial);
-	if (! *result) {
+	if (! (*result)) {
 		ltfsmsg(LTFS_ERR, 10001E, "iokit_get_serialnumber: result");
 		ltfs_profiler_add_entry(priv->profiler, NULL, CHANGER_REQ_EXIT(REQ_TC_GETSER));
 		return -EDEV_NO_MEMORY;

--- a/src/utils/ltfsck.c
+++ b/src/utils/ltfsck.c
@@ -294,10 +294,15 @@ int main(int argc, char **argv)
 	while (true) {
 		int option_index = 0;
 		int c = getopt_long(argc, argv, short_options, long_options, &option_index);
+		// TODO: Check for optarg to not be null before using it
 		if (c == -1)
 			break;
 		if (c == 'i') {
 			config_file = strdup(optarg);
+			if (! config_file) {
+				ltfsmsg(LTFS_ERR, 10001E, "main: config file assign");
+				return LTFSCK_OPERATIONAL_ERROR;
+			}
 			break;
 		}
 	}
@@ -336,6 +341,10 @@ int main(int argc, char **argv)
 					opt.op_mode = MODE_VERIFY;
 				opt.search_mode = SEARCH_BY_GEN;
 				opt.str_gen = strdup(optarg);
+				if (! opt.str_gen) {
+					ltfsmsg(LTFS_ERR, 10001E, "main: opt strgen assign");
+					return LTFSCK_OPERATIONAL_ERROR;
+				}
 				break;
 			case 'v':
 				if ( strcmp(optarg, "forward") == 0)
@@ -417,6 +426,10 @@ int main(int argc, char **argv)
 			return LTFSCK_OPERATIONAL_ERROR;
 		}
 		opt.backend_path = strdup(default_backend);
+		if (! opt.backend_path) {
+			ltfsmsg(LTFS_ERR, 10001E, "main: opt backend path assign");
+			return LTFSCK_OPERATIONAL_ERROR;
+		}
 	}
 	if (! opt.kmi_backend_name) {
 		const char *default_backend = config_file_get_default_plugin("kmi", opt.config);
@@ -424,6 +437,11 @@ int main(int argc, char **argv)
 			opt.kmi_backend_name = strdup(default_backend);
 		else
 			opt.kmi_backend_name = strdup("none");
+		
+		if (! opt.kmi_backend_name) {
+			ltfsmsg(LTFS_ERR, 10001E, "main: opt kmi backend name assign");
+			return LTFSCK_OPERATIONAL_ERROR;
+		}
 	}
 	if (opt.kmi_backend_name && strcmp(opt.kmi_backend_name, "none") == 0)
 		opt.kmi_backend_name = NULL;
@@ -487,10 +505,19 @@ int main(int argc, char **argv)
 		return LTFSCK_OPERATIONAL_ERROR;
 	}
 
-	if(argv[optind + num_of_o])
+	if(argv[optind + num_of_o]) {
 		opt.devname = strdup(argv[optind + num_of_o]);
+		if (! opt.devname) {
+			ltfsmsg(LTFS_ERR, 10001E, "main: opt devname assign");
+			return LTFSCK_OPERATIONAL_ERROR;
+		}
+	}
 
 	opt.prg_name = strdup(argv[0]);
+	if (! opt.prg_name) {
+		ltfsmsg(LTFS_ERR, 10001E, "main: opt prg name assign");
+		return LTFSCK_OPERATIONAL_ERROR;
+	}
 
 	if (_ltfsck_validate_options(&opt)) {
 		ltfsmsg(LTFS_ERR, 16002E);

--- a/src/utils/ltfsck.c
+++ b/src/utils/ltfsck.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/utils/mkltfs.c
+++ b/src/utils/mkltfs.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2020 IBM Corp. All rights reserved.
+**  Copyright 2010, 2025 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions

--- a/src/utils/mkltfs.c
+++ b/src/utils/mkltfs.c
@@ -155,8 +155,12 @@ void show_usage(char *appname, struct config_file *config, bool full)
 		plugin_unload(&backend);
 	}
 
-	if (! devname)
+	if (! devname) {
 		devname = strdup("<devname>");
+		if (! devname) {	
+			ltfsmsg(LTFS_ERR, 10001E, "show_usage: devname assign");
+		}
+	}
 
 	fprintf(stderr, "\n");
 	ltfsresult(15400I, appname);  /* Usage: %s <options> */
@@ -219,6 +223,7 @@ int main(int argc, char **argv)
 	for (i = 0; i < fuse_argc; ++i) {
 		fuse_argv[i] = strdup(argv[i]);
 		if (! fuse_argv[i]) {
+			ltfsmsg(LTFS_ERR, 10001E, "main: fuse argv assign");
 			return MKLTFS_OPERATIONAL_ERROR;
 		}
 	}
@@ -278,6 +283,10 @@ int main(int argc, char **argv)
 			break;
 		if (c == 'i') {
 			config_file = strdup(optarg);
+			if (! config_file) {
+				ltfsmsg(LTFS_ERR, 10001E, "main: config file assign");
+				return MKLTFS_OPERATIONAL_ERROR;
+			}
 			break;
 		}
 	}
@@ -307,18 +316,34 @@ int main(int argc, char **argv)
 				break;
 			case 'd':
 				opt.devname = strdup(optarg);
+				if (! opt.devname) {
+					ltfsmsg(LTFS_ERR, 10001E, "main mkltfs: opt devname assign");
+					return MKLTFS_OPERATIONAL_ERROR;
+				}
 				break;
 			case 'b':
 				opt.blocksize = atoi(optarg);
 				break;
 			case 's':
 				opt.barcode = strdup(optarg);
+				if (! opt.barcode) {
+					ltfsmsg(LTFS_ERR, 10001E, "main mkltfs: opt barcode assign");
+					return MKLTFS_OPERATIONAL_ERROR;
+				}
 				break;
 			case 'n':
 				opt.volume_name = strdup(optarg);
+				if (! opt.volume_name) {
+					ltfsmsg(LTFS_ERR, 10001E, "main mkltfs: opt volume name assign");
+					return MKLTFS_OPERATIONAL_ERROR;
+				}
 				break;
 			case 'r':
 				opt.filterrules = strdup(optarg);
+				if (! opt.filterrules) {
+					ltfsmsg(LTFS_ERR, 10001E, "main mkltfs: opt filterrules assign");
+					return MKLTFS_OPERATIONAL_ERROR;
+				}
 				break;
 			case '-':
 				opt.kmi_backend_name = strdup(optarg);
@@ -391,6 +416,10 @@ int main(int argc, char **argv)
 			return MKLTFS_OPERATIONAL_ERROR;
 		}
 		opt.backend_path = strdup(default_backend);
+		if (! opt.backend_path) {
+			ltfsmsg(LTFS_ERR, 10001E, "main mkltfs: opt backend path assign");
+			return MKLTFS_OPERATIONAL_ERROR;
+		}
 	}
 	if (! opt.kmi_backend_name) {
 		const char *default_backend = config_file_get_default_plugin("kmi", opt.config);
@@ -398,6 +427,10 @@ int main(int argc, char **argv)
 			opt.kmi_backend_name = strdup(default_backend);
 		else
 			opt.kmi_backend_name = strdup("none");
+		if (! opt.kmi_backend_name) {
+			ltfsmsg(LTFS_ERR, 10001E, "main mkltfs: opt kmi backend name assign");
+			return MKLTFS_OPERATIONAL_ERROR;
+		}
 	}
 	if (opt.kmi_backend_name && strcmp(opt.kmi_backend_name, "none") == 0)
 		opt.kmi_backend_name = NULL;


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Added checks for strdup
- Changed logic of delim strategy to avoid repeated code

# Description

This change adds checks for memory allocations done by strdup which previously could lead to unexpected Segmentation faults when the malloc failed and returned null.
Also updated the log of one of the uses of strdup to avoid repeated code and stepping up maintainability.

## Type of change

Please delete items that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works
