### PR TITLE
Set NA to GCC Version in Windows

### DIFF
--- a/messages/bin_ltfsck/root.txt
+++ b/messages/bin_ltfsck/root.txt
@@ -129,7 +129,7 @@ root:table {
 		16087E:string { "Volume is inconsistent. Try to recover consistency with ltfsck first." }
 		16088I:string { "Launched by \"%s\"." }
 		16089I:string { "%s." }
-		16090I:string { "GCC version is %s." }
+		16090I:string { "%s version is %s." }
 		16091E:string { "Cannot recover missing EOD (%d)." }
 		16092E:string { "Cannot set up tape drive (%s)." }
 		16093E:string { "Cannot recover the cartridge with ltfsck." }

--- a/messages/bin_mkltfs/root.txt
+++ b/messages/bin_mkltfs/root.txt
@@ -80,7 +80,7 @@ root:table {
 		15040I:string { "Medium unformatted successfully." }
 		15041I:string { "Launched by \"%s\"." }
 		15042I:string { "%s." }
-		15043I:string { "GCC version is %s." }
+		15043I:string { "%s version is %s." }
 		15044E:string { "Cannot set up tape device." }
 		15045E:string { "Formatting was canceled by the user." }
 		15046E:string { "Unformatting was canceled by the user." }

--- a/src/libltfs/arch/arch_info.h
+++ b/src/libltfs/arch/arch_info.h
@@ -87,7 +87,7 @@
 #elif defined(mingw_PLATFORM)
 
 #define BUILD_SYS_FOR "This binary is built for Windows"
-#define BUILD_SYS_GCC __VERSION__
+#define BUILD_SYS_GCC "NA"
 
 #else
 

--- a/src/libltfs/arch/arch_info.h
+++ b/src/libltfs/arch/arch_info.h
@@ -50,49 +50,58 @@
 #ifndef arch_info_h_
 #define arch_info_h_
 
+#if defined(_MSC_VER)
+#define BUILD_SYS_COMPILER "MSVC"
+#else
+#define BUILD_SYS_COMPILER "GCC"
+#endif
+
 #if defined(__linux__)
 
 #if defined(__i386__)
 #define BUILD_SYS_FOR "This binary is built for Linux (i386)"
-#define BUILD_SYS_GCC __VERSION__
+#define BUILD_SYS_COMPILER_VER __VERSION__
 #elif defined(__x86_64__)
 #define BUILD_SYS_FOR "This binary is built for Linux (x86_64)"
-#define BUILD_SYS_GCC __VERSION__
+#define BUILD_SYS_COMPILER_VER __VERSION__
 #elif defined(__ppc__)
 #define BUILD_SYS_FOR "This binary is built for Linux (ppc)"
-#define BUILD_SYS_GCC __VERSION__
+#define BUILD_SYS_COMPILER_VER __VERSION__
 #elif defined(__ppc64__)
 #define BUILD_SYS_FOR "This binary is built for Linux (ppc64)"
-#define BUILD_SYS_GCC __VERSION__
+#define BUILD_SYS_COMPILER_VER __VERSION__
 #else
 #define BUILD_SYS_FOR "This binary is built for Linux (unknown)"
-#define BUILD_SYS_GCC __VERSION__
+#define BUILD_SYS_COMPILER_VER __VERSION__
 #endif
 
 #elif defined(__APPLE__)
 
 #define BUILD_SYS_FOR "This binary is built for Mac OS X "
-#define BUILD_SYS_GCC __VERSION__
+#define BUILD_SYS_COMPILER_VER __VERSION__
 
 #elif defined(__FreeBSD__)
 
 #define BUILD_SYS_FOR "This binary is built for FreeBSD"
-#define BUILD_SYS_GCC __VERSION__
+#define BUILD_SYS_COMPILER_VER __VERSION__
 
 #elif defined(__NetBSD__)
 
 #define BUILD_SYS_FOR "This binary is built for NetBSD"
-#define BUILD_SYS_GCC __VERSION__
+#define BUILD_SYS_COMPILER_VER __VERSION__
 
 #elif defined(mingw_PLATFORM)
 
+#define STR_HELPER(x) #x
+#define STR_MACRO(x) STR_HELPER(x)
+
 #define BUILD_SYS_FOR "This binary is built for Windows"
-#define BUILD_SYS_GCC "NA"
+#define BUILD_SYS_COMPILER_VER STR_MACRO(_MSC_VER)
 
 #else
 
 #define BUILD_SYS_FOR "This binary is built on an unknown OS"
-#define BUILD_SYS_GCC __VERSION__
+#define BUILD_SYS_COMPILER_VER __VERSION__
 
 #endif
 

--- a/src/main.c
+++ b/src/main.c
@@ -695,7 +695,7 @@ int main(int argc, char **argv)
 
 	/* Show build time information */
 	ltfsmsg(LTFS_INFO, 14105I, BUILD_SYS_FOR);
-	ltfsmsg(LTFS_INFO, 14106I, BUILD_SYS_GCC);
+	ltfsmsg(LTFS_INFO, 14106I, BUILD_SYS_COMPILER_VER);
 
 	/* Show run time information */
 	show_runtime_system_info();

--- a/src/utils/ltfsck.c
+++ b/src/utils/ltfsck.c
@@ -481,7 +481,7 @@ int main(int argc, char **argv)
 
 	/* Show build time information */
 	ltfsmsg(LTFS_INFO, 16089I, BUILD_SYS_FOR);
-	ltfsmsg(LTFS_INFO, 16090I, BUILD_SYS_GCC);
+	ltfsmsg(LTFS_INFO, 16090I, BUILD_SYS_COMPILER, BUILD_SYS_COMPILER_VER);
 
 	/* Show run time information */
 	show_runtime_system_info();

--- a/src/utils/mkltfs.c
+++ b/src/utils/mkltfs.c
@@ -454,7 +454,7 @@ int main(int argc, char **argv)
 
 	/* Show build time information */
 	ltfsmsg(LTFS_INFO, 15042I, BUILD_SYS_FOR);
-	ltfsmsg(LTFS_INFO, 15043I, BUILD_SYS_GCC);
+	ltfsmsg(LTFS_INFO, 15043I, BUILD_SYS_COMPILER, BUILD_SYS_COMPILER_VER);
 
 	/* Show run time information */
 	show_runtime_system_info();


### PR DESCRIPTION
# Description

GCC `__VERSION__ ` Macro is undefined on the new compilation process in windows, causing crash in binaries

Fixes #534 

## Type of change


- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works
