### PR TITLE
Fix build on FreeBSD

### DIFF
--- a/src/libltfs/xattr.h
+++ b/src/libltfs/xattr.h
@@ -66,7 +66,9 @@ extern "C" {
 #include "libltfs/arch/freebsd/xattr.h"
 #endif
 
-#include "fuse.h"
+#include "libltfs/ltfs_fuse_version.h"
+#include <fuse.h>
+
 #include "ltfs.h"
 
 #define LTFS_PRIVATE_PREFIX "ltfs."


### PR DESCRIPTION
Include libltfs/ltfs_fuse_version.h and include fuse.h as a system header.

# Summary of changes

This pull request includes following changes or fixes. 

- Include libltfs/ltfs_fuse_version.h before fuse.h
- Since fuse.h is a system header, use brackets instead of quotes

# Description

On at least FreeBSD we get a compile time failure with v2.4.8.x branch.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works
