### PR TITLE
Fix README.md typo and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![](https://img.shields.io/github/issues/lineartapefilesystem/ltfs.svg)
-![GH Action status](https://github.com/LinearTapeFileSystem/ltfs/workflows/CentOS7%20Build%20Job/badge.svg?branch=master)
+![GH Action status](https://github.com/LinearTapeFileSystem/ltfs/actions/workflows/build-centos8.yml/badge.svg)
 [![BSD License](http://img.shields.io/badge/license-BSD-blue.svg?style=flat)](LICENSE)
 
 # About this branch


### PR DESCRIPTION
# Summary of changes

Fixes a typo in `ltfs_ordered_copy` and the links to the build badges
