### PR TITLE
fix: fuse_main error handling

### DIFF
--- a/messages/bin_ltfs/root.txt
+++ b/messages/bin_ltfs/root.txt
@@ -159,7 +159,7 @@ root:table {
 		14120W:string { "Cannot access to directory %s, disabled index capture mode (%d)." }
 		14121I:string { "Index will be captured at %s at update" }
 		14122I:string { "Index will not be captured." }
-		14123W:string { "The main function of FUSE returned error (%d)." }
+		14123E:string { "The main function of FUSE returned (%d) errno (%d)." }
 
 		// 14150 - 14199 are reserved for LE+
 

--- a/src/main.c
+++ b/src/main.c
@@ -1336,7 +1336,8 @@ int single_drive_main(struct fuse_args *args, struct ltfs_fuse_data *priv)
 	ltfsmsg(LTFS_INFO, 14113I);
 	ret = fuse_main(args->argc, args->argv, &ltfs_ops, priv);
 	if (ret != 0) {
-		ltfsmsg(LTFS_WARN, 14123W, ret);
+		ltfsmsg(LTFS_ERR, 14123E, ret, errno);
+		return ret;
 	}
 
 	/*  Setup signal handler again to terminate cleanly */


### PR DESCRIPTION
change the fuse main error handling

# Description

Fix #541
Now the main function does not ignore the return code of fuse_main and uses the errno that fuse_main sets for better logging information 

## Type of change

Please delete items that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works
