### PR TITLE
Fix links to coding style guide in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@ We love pull requests from everyone.
 
 When contributing to this repository, please first discuss the change you wish to make via issue, email, or any other method with the owners of this repository before making a change.
 
-Please note we have a [coding style guide](../docs/CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
+Please note we have a [coding style guide](/docs/CODE_OF_CONDUCT.md), please follow it in all your interactions with the project.
 
 1. Fork, then clone the repo
 
@@ -25,5 +25,5 @@ Please note we have a [coding style guide](../docs/CODE_OF_CONDUCT.md), please f
 
 __Some things that will increase the chance that your pull request is accepted__
 
-* Follow our [coding style guide](../docs/CODE_OF_CONDUCT.md).
+* Follow our [coding style guide](/docs/CODE_OF_CONDUCT.md).
 * Write a good commit message.


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Fix of issue #549
- Update links to current GitHub markdown compatible style

## Type of change

Please delete items that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [N/A] My code follows the style guidelines of this project
- [Y] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [N/A] My changes generate no new warnings
- [Y] I have confirmed my fix is effective or that my feature works
