### PR TITLE
fix: only logging when level permits it on Windows

### DIFF
--- a/src/libltfs/ltfslogging.c
+++ b/src/libltfs/ltfslogging.c
@@ -466,7 +466,9 @@ int ltfsmsg_internal(bool print_id, int level, char **msg_out, const char *_id, 
 	}
 
 #ifdef mingw_PLATFORM
-	if (level <= ltfs_syslog_level || level <= ltfs_log_level)
+	if (level <= ltfs_syslog_level 
+		|| level <= ltfs_log_level
+		|| level == (LTFS_TRACE + 1)) // For "Help" messages
 	{
 		va_start(argp, _id);
 		vsyslog2(level, output_buf, argp);


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

# Description

On Windows platform, logs of LTFS were not properly set up, every message is logged causing a performance issue when using LTFS with logs enabled. To fix this, a conditional was added to log only messages permitted by the log level set.

## Type of change

- Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works
