### PR TITLE
Fix: Avoid double free on ltfsck and mkltfs

### DIFF
--- a/src/utils/ltfsck.c
+++ b/src/utils/ltfsck.c
@@ -531,7 +531,6 @@ int main(int argc, char **argv)
 		arch_strcat(cmd_args, cmd_args_len, argv[i]);
 	}
 	ltfsmsg(LTFS_INFO, 16088I, cmd_args);
-	free(cmd_args);
 
 	/* Show build time information */
 	ltfsmsg(LTFS_INFO, 16089I, BUILD_SYS_FOR);

--- a/src/utils/mkltfs.c
+++ b/src/utils/mkltfs.c
@@ -532,7 +532,6 @@ int main(int argc, char **argv)
 		arch_strcat(cmd_args, cmd_args_len, argv[i]);
 	}
 	ltfsmsg(LTFS_INFO, 15041I, cmd_args);
-	free(cmd_args);
 
 	/* Show build time information */
 	ltfsmsg(LTFS_INFO, 15042I, BUILD_SYS_FOR);


### PR DESCRIPTION
# Summary of changes

This PR fixes a free that was left from a section that was refactored with a cleanup

- Solves issue #594 

# Description

When adding memory checks the files ltfsck.c and mkltfs.c were reworked to use a cleanup section, but in doing so an old free was left in there making a double free happen

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works
