### PR TITLE
Suggested fix for the ltfs_ordered_copy single file special case issue.

### DIFF
--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -336,6 +336,9 @@ if args.DEST == None:
     logger.error('No destination is specified')
     exit(2)
 
+if args.keep_tree is None:
+    args.keep_tree = ''
+
 # Special case:
 #  Copy source is only one file
 if args.recursive == False and len(args.SOURCE) == 1:
@@ -386,9 +389,6 @@ if len(args.SOURCE) == 0:
     for line in sys.stdin:
         args.SOURCE.append(line.rstrip('\r\n'))
     logger.log(NOTSET + 1, 'Source: {}'.format(args.SOURCE))
-
-if args.keep_tree is None:
-    args.keep_tree = ''
 
 # Create the list of copy item
 copyq = CopyQueue(logger, args.sort_files)


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 
- Fixes issue #598 
- Set `args.keep_tree = ''` just before the single file case to remove the python error

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
