### PR TITLE
feat: add --move option to ltfs_ordered_copy

### DIFF
--- a/man/ltfs_ordered_copy.1
+++ b/man/ltfs_ordered_copy.1
@@ -40,6 +40,9 @@ Configure verbosity of logger. VERBOSE shall be 0-6. (Default: 4)
 .TP
 \fB-q, --quiet\fR
 No message outout
+.TP
+\fB--move\fR
+Move files instead of copying them. Each source file is removed only after it has been successfully copied to the destination, so the LTFS tape read order is preserved and no data is lost if a copy fails. This option implies \fB-p\fR so that file attributes are preserved like a normal move. After a recursive move the emptied source directories are pruned; source directories that still contain files (for example because a copy failed) are left untouched.
 .SH "COMMAND EXAMPLES"
 .PP
 This section shows various command examples.

--- a/man/sgml/ltfs_ordered_copy.sgml
+++ b/man/sgml/ltfs_ordered_copy.sgml
@@ -104,6 +104,12 @@
             <para>No message outout</para>
           </listitem>
         </varlistentry>
+        <varlistentry>
+          <term><option>--move</option></term>
+          <listitem>
+            <para>Move files instead of copying them. Each source file is removed only after it has been successfully copied to the destination, so the LTFS tape read order is preserved and no data is lost if a copy fails. This option implies <option>-p</option> so that file attributes are preserved like a normal move. After a recursive move the emptied source directories are pruned; source directories that still contain files (for example because a copy failed) are left untouched.</para>
+          </listitem>
+        </varlistentry>
       </variablelist>
     </refsect1>
 

--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -128,6 +128,7 @@ class CopyQueue:
         self.items = 0
         self.logger = logger
         self.sort_files = sort_files
+        self.walked_dirs = [] # (source_dir, dest_dir) pairs for metadata replication
 
     def add_copy_item(self, c):
         (u, p, s) = c.eval()
@@ -177,6 +178,12 @@ class CopyQueue:
             t = root[prefix_len:]
             dst = dest + "/" + t
             dst = os.path.normpath(dst)
+
+            # Record every directory (os.walk yields each one once, including
+            # empty ones) together with a snapshot of its metadata taken now,
+            # before any files are moved out -- removing a source file bumps its
+            # directory's mtime, so the snapshot must be captured up front.
+            self.walked_dirs.append((root, dst, os.stat(root)))
 
             for d in sorted(dirs) if self.sort_files else dirs:
                 walk_dirs.append(os.path.join(dst, d))
@@ -497,6 +504,23 @@ while tape != None:
 
     (tape_key, tape) = copyq.pop_tape()
     prog_tape.finish()
+
+# Replicate directory metadata (mode and timestamps with -p; xattrs with --all)
+# onto each walked destination directory. Mode/timestamps come from the snapshot
+# taken during the walk, before the move removed any files (which would bump the
+# source directory mtimes). Runs after all files are copied and before move-mode
+# pruning, deepest-first so setting a child never re-bumps an already-set parent.
+if args.p or args.all:
+    for (src_dir, dst_dir, src_stat) in reversed(copyq.walked_dirs):
+        try:
+            if args.p:
+                os.chmod(dst_dir, src_stat.st_mode & 0o7777)
+                os.utime(dst_dir, (src_stat.st_atime, src_stat.st_mtime))
+            if args.all:
+                for key in xattr.list(src_dir):
+                    xattr.set(dst_dir, key, xattr.get(src_dir, key))
+        except Exception as e:
+            logger.error('Failed to copy directory metadata to "{0}": {1}'.format(dst_dir, str(e)))
 
 # In move mode the source files have been removed as they were copied. Prune the
 # now-empty source directory trees bottom-up. Only directories that were actually

--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -414,6 +414,9 @@ if args.keep_tree is None:
 
 # Create the list of copy item
 copyq = CopyQueue(logger, args.sort_files)
+# Track directory sources that were actually recursed into, so a --move run only
+# prunes trees it really moved (not plain files, not directories skipped without -r).
+moved_dirs = []
 for s in args.SOURCE:
     dst = args.DEST
     if os.path.isfile(s):
@@ -437,6 +440,8 @@ for s in args.SOURCE:
                    os.makedirs(new_d)
                 dst = new_d
             copyq.walk_dir(s, dst, args.p, args.all, args.move)
+            if args.move:
+                moved_dirs.append(s)
         else:
             logger.warning("omitting directory '{0}'".format(s))
 
@@ -494,11 +499,13 @@ while tape != None:
     prog_tape.finish()
 
 # In move mode the source files have been removed as they were copied. Prune the
-# now-empty source directory trees bottom-up. Directories that still hold files
-# (e.g. because a copy failed, or a non-recursive directory was skipped) are left
-# untouched, so no data is ever discarded.
+# now-empty source directory trees bottom-up. Only directories that were actually
+# recursed into by this move are considered (moved_dirs), so a directory passed
+# without -r, or an empty directory outside the moved trees, is never touched.
+# Directories that still hold files (e.g. because a copy failed) make rmdir fail
+# and are left untouched, so no data is ever discarded.
 if args.move:
-    for s in args.SOURCE:
+    for s in moved_dirs:
         if os.path.isdir(s):
             for dirpath, dirnames, filenames in os.walk(s, topdown=False):
                 try:

--- a/src/utils/ltfs_ordered_copy
+++ b/src/utils/ltfs_ordered_copy
@@ -46,12 +46,13 @@ from collections import deque
 
 class CopyItem:
     """"""
-    def __init__(self, src, dst, vea_pre, cp_attr, cp_xattr, logger): #initialization
+    def __init__(self, src, dst, vea_pre, cp_attr, cp_xattr, logger, move=False): #initialization
         self.src     = src
         self.dst     = dst
         self.vea_pre = vea_pre
         self.cp_attr = cp_attr
         self.cp_xattr = cp_xattr
+        self.move    = move
         self.vuuid   = ''
         self.part    = ''
         self.start   = -1
@@ -78,6 +79,7 @@ class CopyItem:
         return (self.vuuid, self.part, self.start)
 
     def run(self):
+        action = 'move' if self.move else 'copy'
         try:
             if len(self.vuuid):
                 logger.debug('"{0}" ({2}) -> "{1}"'.format(self.src, self.dst, str(self.start)))
@@ -98,8 +100,18 @@ class CopyItem:
             else: #Only copy data
                 shutil.copy(self.src, self.dst)
         except Exception as e:
-            self.logger.error('Failed to copy "{0}" to "{1}": {2}'.format(self.src, self.dst, str(str(e))))
+            self.logger.error('Failed to {3} "{0}" to "{1}": {2}'.format(self.src, self.dst, str(str(e)), action))
             return False
+
+        if self.move:
+            # The data is safely on the destination now; remove the source to
+            # complete the move. Deletion happens only after a successful copy so
+            # that nothing is lost if the copy above failed.
+            try:
+                os.remove(self.src)
+            except Exception as e:
+                self.logger.error('Copied "{0}" to "{1}" but failed to remove source: {2}'.format(self.src, self.dst, str(e)))
+                return False
 
         return True
 
@@ -151,7 +163,7 @@ class CopyQueue:
 
             self.items = self.items + 1
 
-    def walk_dir(self, source, dest, cp_attr, cp_xattr=False):
+    def walk_dir(self, source, dest, cp_attr, cp_xattr=False, move=False):
         (source_root, t) = os.path.split(source)
         prefix_len = len(source_root)
         dst = dest + "/" + t
@@ -171,7 +183,7 @@ class CopyQueue:
             for f in sorted(files) if self.sort_files else files:
                 self.logger.log(NOTSET + 1, 'Creating a copy item for file {}'.format(f))
                 c = CopyItem(os.path.join(root, f), os.path.join(dst, f), VEA_PREFIX,
-                             cp_attr, cp_xattr, logger)
+                             cp_attr, cp_xattr, logger, move)
                 self.add_copy_item(c)
 
         for d in walk_dirs:
@@ -280,12 +292,17 @@ parser.add_argument('-v', help='Verbose output. Set VERBOSE level 5', action='st
 parser.add_argument('--verbose', help='Configure verbosity of logger. VERBOSE shall be 0-6. default is 4', default = str(logger_info))
 parser.add_argument('-q','--quiet', help='No message output', action='store_true')
 parser.add_argument('--sort-files', help='Sort the file list before copying', action='store_true')
+parser.add_argument('--move', help='Move files instead of copying. Each source file is removed only after it has been successfully copied to the destination, preserving tape read order. Implies -p so file attributes are preserved like a normal move. Empty source directories are pruned after a recursive move.', action='store_true')
 
 args=parser.parse_args()
 
 if args.all:
     args.p = True
     args.recursive = True
+
+if args.move:
+    # A move should preserve file metadata like a regular "mv".
+    args.p = True
 
 logger = getLogger(__name__)
 basicConfig(format = '')
@@ -348,7 +365,12 @@ if args.recursive == False and len(args.SOURCE) == 1:
                 (new_d, t) = os.path.split(dst)
                 if not os.path.exists(new_d):
                     os.makedirs(new_d)
-            shutil.copy(args.SOURCE[0], args.DEST)
+            if args.p:
+                shutil.copy2(args.SOURCE[0], args.DEST)
+            else:
+                shutil.copy(args.SOURCE[0], args.DEST)
+            if args.move:
+                os.remove(args.SOURCE[0])
         except Exception as e:
             logger.error(str(e))
             exit(1)
@@ -402,7 +424,7 @@ for s in args.SOURCE:
             (new_d, t) = os.path.split(dst)
             if not os.path.exists(new_d):
                 os.makedirs(new_d)
-        c = CopyItem(s, dst, VEA_PREFIX, args.p, args.all, logger)
+        c = CopyItem(s, dst, VEA_PREFIX, args.p, args.all, logger, args.move)
         copyq.add_copy_item(c)
     else:
         logger.log(NOTSET + 1, 'Creating copy item for directory {}'.format(s))
@@ -414,7 +436,7 @@ for s in args.SOURCE:
                 if not os.path.exists(new_d):
                    os.makedirs(new_d)
                 dst = new_d
-            copyq.walk_dir(s, dst, args.p, args.all)
+            copyq.walk_dir(s, dst, args.p, args.all, args.move)
         else:
             logger.warning("omitting directory '{0}'".format(s))
 
@@ -471,10 +493,24 @@ while tape != None:
     (tape_key, tape) = copyq.pop_tape()
     prog_tape.finish()
 
+# In move mode the source files have been removed as they were copied. Prune the
+# now-empty source directory trees bottom-up. Directories that still hold files
+# (e.g. because a copy failed, or a non-recursive directory was skipped) are left
+# untouched, so no data is ever discarded.
+if args.move:
+    for s in args.SOURCE:
+        if os.path.isdir(s):
+            for dirpath, dirnames, filenames in os.walk(s, topdown=False):
+                try:
+                    os.rmdir(dirpath)
+                except OSError:
+                    pass # Not empty or already removed
+
 # Return code
+done = 'Moved' if args.move else 'Copied'
 if fail:
-    logger.info("Copied {} files, Failed {} files.".format(success, fail))
+    logger.info("{} {} files, Failed {} files.".format(done, success, fail))
     exit(1)
 else:
-    logger.info("Copied {} files.".format(success, fail))
+    logger.info("{} {} files.".format(done, success))
     exit(0)


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Add a move mode to ltfs_ordered_copy that deletes each source only after
it has been successfully copied to the destination, so the LTFS tape read
order is preserved and no data is lost if a copy fails.
- The single-file copy path now honours -p as well (copy2 vs copy).

# Description


- Each CopyItem removes its source after a successful copy; a failed copy
  (or a failed source removal) leaves the source in place.
- --move implies -p so file metadata is preserved like a normal mv. 
- After a recursive move, emptied source directory trees are pruned
  bottom-up; directories still holding files (e.g. a copy failed, or a
  non-recursive directory was skipped) are left untouched.
- Log output and error messages now say "move"/"Moved" in move mode.
- Document --move in man/ltfs_ordered_copy.1 and the SGML source.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
