### PR TITLE
Add HPE LTO-10 drives to the supported drive list

### DIFF
--- a/src/tape_drivers/hp_tape.c
+++ b/src/tape_drivers/hp_tape.c
@@ -68,6 +68,8 @@ struct supported_device *hp_supported_drives[] = {
 		TAPEDRIVE( HP_VENDOR_ID,  "Ultrium 7-SCSI", DRIVE_LTO7,    "[Ultrium 7-SCSI]" ),  /* HP Ultrium Gen 7  */
 		TAPEDRIVE( HPE_VENDOR_ID, "Ultrium 8-SCSI", DRIVE_LTO8,    "[Ultrium 8-SCSI]" ),  /* HPE Ultrium Gen 8 */
 		TAPEDRIVE( HPE_VENDOR_ID, "Ultrium 9-SCSI", DRIVE_LTO9,    "[Ultrium 9-SCSI]" ),  /* HPE Ultrium Gen 9 */
+		TAPEDRIVE( HPE_VENDOR_ID, "Ultrium A-SCSI", DRIVE_LTO10,   "[Ultrium A-SCSI]" ),  /* HPE Ultrium Gen A (Gen 10) */
+		TAPEDRIVE( HPE_VENDOR_ID, "Ultrium 10-SCSI", DRIVE_LTO10,  "[Ultrium 10-SCSI]" ), /* HPE Ultrium Gen 10 */
 		/* End of supported_devices */
 		NULL
 };


### PR DESCRIPTION
## Summary

`hp_supported_drives[]` currently stops at generation 9, so HPE LTO-10 drives are rejected by the sg and iokit backends with `EDEV_DEVICE_UNSUPPORTABLE` (drive identification in `sg_tape.c` / `iokit_tape.c` only accepts product IDs found in the vendor tables).

This adds two entries mapping to `DRIVE_LTO10`:

- `Ultrium A-SCSI` — generation "A" naming, matching the convention IBM uses for its Gen 10 drives (`ULTRIUM-TDA`, `ULT3580-TDA`).
- `Ultrium 10-SCSI` — HPE's established product ID pattern (`Ultrium 8-SCSI`, `Ultrium 9-SCSI`, ...).

No other changes are needed: `hp_tape_init_timeout()` already handles `DRIVE_LTO10` / `DRIVE_LTO10_HH`, and the error/density handling is generation-independent.