### PR TITLE
Add TANDBERG LTO-6 HH drive support

### DIFF
--- a/src/tape_drivers/hp_tape.c
+++ b/src/tape_drivers/hp_tape.c
@@ -68,6 +68,7 @@ struct supported_device *hp_supported_drives[] = {
 		TAPEDRIVE( HP_VENDOR_ID,  "Ultrium 7-SCSI", DRIVE_LTO7,    "[Ultrium 7-SCSI]" ),  /* HP Ultrium Gen 7  */
 		TAPEDRIVE( HPE_VENDOR_ID, "Ultrium 8-SCSI", DRIVE_LTO8,    "[Ultrium 8-SCSI]" ),  /* HPE Ultrium Gen 8 */
 		TAPEDRIVE( HPE_VENDOR_ID, "Ultrium 9-SCSI", DRIVE_LTO9,    "[Ultrium 9-SCSI]" ),  /* HPE Ultrium Gen 9 */
+		TAPEDRIVE( TANDBERG_VENDOR_ID, "LTO-6 HH       ", DRIVE_LTO6_HH, "[LTO-6 HH]" ),  /* TANDBERG LTO-6 HH */
 		/* End of supported_devices */
 		NULL
 };

--- a/src/tape_drivers/hp_tape.h
+++ b/src/tape_drivers/hp_tape.h
@@ -67,6 +67,7 @@ extern "C" {
 
 #define HP_VENDOR_ID  "HP"
 #define HPE_VENDOR_ID "HPE"
+#define TANDBERG_VENDOR_ID "TANDBERG"
 
 extern struct error_table hp_tape_errors[];
 


### PR DESCRIPTION
Add TANDBERG LTO-6 HH drive entry to hp_tape.c.

This is independent of FUSE3 changes and was suggested to be split
from #590 by @matejk.

## Test environment
- OS: AlmaLinux 9.7
- Drive: TANDBERG LTO-6 HH (firmware 3319)
- Serial: HUJ430176D

## Test results
- Mount succeeded without errors
- File listing verified
- 12.7GB file read and verified with `cmp` (no difference)
- Unmount and eject completed normally

## Type of change
- New feature (non-breaking change which adds functionality)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have confirmed my feature works