### PR TITLE
Fix data loss on writes larger than the tape block size

### DIFF
--- a/src/iosched/unified.c
+++ b/src/iosched/unified.c
@@ -1790,7 +1790,11 @@ ssize_t _unified_insert_new_request(const char *buf, off_t offset, size_t count,
 	if (new_req->offset + new_req->count > dpr->file_size)
 		dpr->file_size = new_req->offset + new_req->count;
 
-	return (ssize_t)count;
+	/* Only copy_count bytes were stored (one cache block at most); the
+	 * caller's append loop must advance by that, not the full count, or
+	 * everything past the first block of a larger-than-blocksize write is
+	 * silently dropped. */
+	return (ssize_t)copy_count;
 }
 
 /**


### PR DESCRIPTION
`_unified_insert_new_request` in the unified I/O scheduler copies at most one tape block of an incoming write into the new request, but reports the full count as written. Any single `write()` larger than the tape block size is silently truncated to one block — a 1 MiB write with the default 512 KiB block size stores exactly 524288 bytes while the application sees success.

One commit, 5 lines: cap the reported count at what was actually queued, so the caller loops over the remainder.

This matches the corruption reported in #591. A regression test that verifies the content of multi-block single writes ships with the integration test-suite PR (#611, `t/13-large-write-integrity.sh`).

Note: #603 (FUSE 3) includes this same commit, because FUSE 3's 1 MiB requests expose the bug in the default configuration; git drops the duplicate whichever PR merges first.

Fixes #591.
