### PR TITLE
Build and CLI fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -377,7 +377,7 @@ if test "x${snmp}" != "xno"
 then
     SNMP_ENABLE="-D ENABLE_SNMP"
     SNMP_MODULE_CFLAGS="`net-snmp-config --cflags 2> /dev/null`";
-    SNMP_MODULE_LIBS_A="`net-snmp-config --agent-libs` 2> /dev/null";
+    SNMP_MODULE_LIBS_A="`net-snmp-config --agent-libs 2> /dev/null`";
     SNMP_MODULE_LIBS="`net-snmp-config --libs 2> /dev/null`";
     if test -z "$SNMP_MODULE_LIBS_A"
     then

--- a/src/libltfs/ltfs_thread.h
+++ b/src/libltfs/ltfs_thread.h
@@ -67,6 +67,7 @@ extern "C" {
 #endif
 
 #include <pthread.h>
+#include <sched.h>
 #include <sys/time.h>
 #include <sys/syscall.h>
 #include <unistd.h>
@@ -208,11 +209,10 @@ static inline ltfs_thread_t ltfs_thread_self(void)
 
 static inline int ltfs_thread_yield(void)
 {
-#if defined (__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__)
+	/* sched_yield() is the POSIX standard and is available on every
+	 * supported platform; pthread_yield() is deprecated since glibc 2.34
+	 * and absent on some libcs (e.g. musl). */
 	return sched_yield();
-#else
-	return pthread_yield();
-#endif
 }
 
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__)

--- a/src/main.c
+++ b/src/main.c
@@ -704,7 +704,7 @@ int main(int argc, char **argv)
 	if (priv->device_list) {
 		ret = show_device_list(priv);
 		ltfs_finish();
-		return (ret != 0) ? 0 : 1;
+		return ret ? 1 : 0;
 	}
 
 	/* Validate sync option */


### PR DESCRIPTION
Three small independent fixes, each its own commit (rebased onto the v2.4.8.4 release):

- **`sched_yield` instead of `pthread_yield`**: `pthread_yield` is deprecated and removed from glibc 2.34+, breaking the build on CentOS Stream 9, RHEL 9, and recent Fedora/Ubuntu. Addresses the `pthread_yield` half of #465 (the FUSE API half is in #603).
- **SNMP agent link flags**: a stray `2>/dev/null` token in the flags ended up on the link command line.
- **`ltfs --device-list` exit status**: the exit code was inverted — success returned non-zero and failure zero, breaking scripts that probe for drives.

Note: this PR originally also carried the `xattr.h` `FUSE_USE_VERSION` include fix, but the v2.4.8.4 release shipped the identical change (as part of the FreeBSD build fix), so it has been dropped from the rebased branch.