### PR TITLE
Fix file permissions passed to open(2) by the POSIX arch_open

### DIFF
--- a/src/libltfs/arch/ltfs_arch_ops.h
+++ b/src/libltfs/arch/ltfs_arch_ops.h
@@ -151,7 +151,7 @@ extern "C" {
 
     #define arch_sscanf     sscanf
 
-    #define arch_open( descriptor_ptr, filename_ptr, open_flg, share_flg, unused) do{ *descriptor_ptr = open(filename_ptr, open_flg, share_flg); }while(0)
+    #define arch_open( descriptor_ptr, filename_ptr, open_flg, share_flg, perm) do{ *descriptor_ptr = open(filename_ptr, open_flg, perm); }while(0)
 
     #define arch_fopen(file, mode, file_ptr)  do {file_ptr = fopen(file, mode);}while(0)
 


### PR DESCRIPTION
The POSIX `arch_open` macro passed the Windows-style share flag as the mode argument of `open(2)` and ignored the permission argument. Files created by the file tape backend get mode 0200 (write-only), so a non-root user cannot reopen records it has just written; mounting a freshly formatted file-backend volume fails with `EDEV_RW_PERM`. Running as root masks the problem.

Prerequisite for the integration test suite (#611), which formats and mounts file-backend volumes as a regular user. #611 carries a duplicate of this commit; git drops the duplicate whichever merges first.