### PR TITLE
Fix locking and a double free in fsops rename and unlink

### DIFF
--- a/src/libltfs/ltfs_fsops.c
+++ b/src/libltfs/ltfs_fsops.c
@@ -868,6 +868,10 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 	fromdentry->name.percent_encode = fs_is_percent_encode_required(fromdentry->name.name);
 	fromdentry->platform_safe_name = to_filename_copy2;
 	fromdentry->matches_name_criteria = index_criteria_match(fromdentry, vol);
+	/* Ownership of both buffers has moved to fromdentry; clear the locals so
+	 * the out_free path does not free them again if a later step fails. */
+	to_filename_copy = NULL;
+	to_filename_copy2 = NULL;
 
 	/* Add fromdentry to new directory */
 	todir->child_list = fs_add_key_to_hash_table(todir->child_list, fromdentry, &ret);

--- a/src/libltfs/ltfs_fsops.c
+++ b/src/libltfs/ltfs_fsops.c
@@ -460,6 +460,13 @@ int ltfs_fsops_unlink(const char *path, ltfs_file_id *id, struct ltfs_volume *vo
 	}
 	parent = d->parent;
 
+	/* Acquire parent->meta_lock up front: the shared out: path releases it
+	 * via fs_release_dentry_unlocked(), so every goto out (including the WORM
+	 * and non-empty-directory error paths below) must hold it. Ordering is
+	 * preserved: parent->contents_lock (held by fs_path_lookup) before
+	 * parent->meta_lock before the child d->meta_lock. */
+	acquirewrite_mrsw(&parent->meta_lock);
+
 	if (parent->is_immutable || parent->is_appendonly) {
 		ltfsmsg(LTFS_ERR, 17237E, "unlink: parent is WORM");
 		ret = -LTFS_WORM_ENABLED;
@@ -482,7 +489,6 @@ int ltfs_fsops_unlink(const char *path, ltfs_file_id *id, struct ltfs_volume *vo
 			goto out;
 	}
 
-	acquirewrite_mrsw(&parent->meta_lock);
 	acquirewrite_mrsw(&d->meta_lock);
 
 	if (dcache_initialized(vol)) {
@@ -640,18 +646,9 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 		goto out_release;
 	}
 
-	if (fromdir->is_appendonly || fromdir->is_immutable ) {
-		ltfsmsg(LTFS_ERR, 17237E, "rename: parent is WORM");
-		ret = -LTFS_WORM_ENABLED;
-		acquirewrite_mrsw(&fromdir->meta_lock);
-		goto out_release;
-	}
-	if (todir->is_immutable || todir->is_appendonly) {
-		ltfsmsg(LTFS_ERR, 17237E, "rename: target dir is WORM");
-		ret = -LTFS_WORM_ENABLED;
-		acquirewrite_mrsw(&fromdir->meta_lock);
-		goto out_release;
-	}
+	/* The WORM state of the source and target directories is checked below,
+	 * after both directory meta_locks are held (the fields are meta_lock
+	 * protected, and the out_release path expects both meta_locks held). */
 
 	/* Take locks in the appropriate order and look up the source and destination dentries */
 	if (todir == fromdir || fs_is_predecessor(todir, fromdir)) {
@@ -759,6 +756,20 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 		goto out_unlock;
 	}
 #endif
+
+	/* Reject renames into or out of a WORM directory. Checked here, with both
+	 * directory meta_locks held, rather than right after lookup: the fields are
+	 * meta_lock protected and the out_unlock/out_release path releases both
+	 * directory meta_locks via fs_release_dentry_unlocked. */
+	if (fromdir->is_immutable || fromdir->is_appendonly ||
+		todir->is_immutable || todir->is_appendonly) {
+		ltfsmsg(LTFS_ERR, 17237E, "rename: source or target dir is WORM");
+		ret = -LTFS_WORM_ENABLED;
+		fs_release_dentry(fromdentry);
+		if (todentry && todentry != fromdentry)
+			fs_release_dentry(todentry);
+		goto out_unlock;
+	}
 
 	if (fromdentry->is_immutable || fromdentry->is_appendonly) {
 		ltfsmsg(LTFS_ERR, 17237E, "rename: src entry is WORM");

--- a/src/libltfs/ltfs_fsops.c
+++ b/src/libltfs/ltfs_fsops.c
@@ -460,6 +460,9 @@ int ltfs_fsops_unlink(const char *path, ltfs_file_id *id, struct ltfs_volume *vo
 	}
 	parent = d->parent;
 
+	/* Lock order: parent contents_lock, parent meta_lock, then child meta_lock */
+	acquirewrite_mrsw(&parent->meta_lock);
+
 	if (parent->is_immutable || parent->is_appendonly) {
 		ltfsmsg(LTFS_ERR, 17237E, "unlink: parent is WORM");
 		ret = -LTFS_WORM_ENABLED;
@@ -482,7 +485,6 @@ int ltfs_fsops_unlink(const char *path, ltfs_file_id *id, struct ltfs_volume *vo
 			goto out;
 	}
 
-	acquirewrite_mrsw(&parent->meta_lock);
 	acquirewrite_mrsw(&d->meta_lock);
 
 	if (dcache_initialized(vol)) {
@@ -640,19 +642,6 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 		goto out_release;
 	}
 
-	if (fromdir->is_appendonly || fromdir->is_immutable ) {
-		ltfsmsg(LTFS_ERR, 17237E, "rename: parent is WORM");
-		ret = -LTFS_WORM_ENABLED;
-		acquirewrite_mrsw(&fromdir->meta_lock);
-		goto out_release;
-	}
-	if (todir->is_immutable || todir->is_appendonly) {
-		ltfsmsg(LTFS_ERR, 17237E, "rename: target dir is WORM");
-		ret = -LTFS_WORM_ENABLED;
-		acquirewrite_mrsw(&fromdir->meta_lock);
-		goto out_release;
-	}
-
 	/* Take locks in the appropriate order and look up the source and destination dentries */
 	if (todir == fromdir || fs_is_predecessor(todir, fromdir)) {
 		acquirewrite_mrsw(&todir->contents_lock);
@@ -759,6 +748,16 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 		goto out_unlock;
 	}
 #endif
+
+	if (fromdir->is_immutable || fromdir->is_appendonly ||
+		todir->is_immutable || todir->is_appendonly) {
+		ltfsmsg(LTFS_ERR, 17237E, "rename: source or target dir is WORM");
+		ret = -LTFS_WORM_ENABLED;
+		fs_release_dentry(fromdentry);
+		if (todentry && todentry != fromdentry)
+			fs_release_dentry(todentry);
+		goto out_unlock;
+	}
 
 	if (fromdentry->is_immutable || fromdentry->is_appendonly) {
 		ltfsmsg(LTFS_ERR, 17237E, "rename: src entry is WORM");

--- a/src/libltfs/ltfs_fsops.c
+++ b/src/libltfs/ltfs_fsops.c
@@ -856,6 +856,9 @@ int ltfs_fsops_rename(const char *from, const char *to, ltfs_file_id *id, struct
 	fromdentry->name.percent_encode = fs_is_percent_encode_required(fromdentry->name.name);
 	fromdentry->platform_safe_name = to_filename_copy2;
 	fromdentry->matches_name_criteria = index_criteria_match(fromdentry, vol);
+	/* fromdentry owns the buffers now; keep out_free from freeing them again */
+	to_filename_copy = NULL;
+	to_filename_copy2 = NULL;
 
 	/* Add fromdentry to new directory */
 	todir->child_list = fs_add_key_to_hash_table(todir->child_list, fromdentry, &ret);

--- a/src/libltfs/ltfs_fsops.c
+++ b/src/libltfs/ltfs_fsops.c
@@ -460,6 +460,23 @@ int ltfs_fsops_unlink(const char *path, ltfs_file_id *id, struct ltfs_volume *vo
 	}
 	parent = d->parent;
 
+	/* Can't remove non-empty directories */
+	if (d->isdir) {
+		ret = 0;
+		acquireread_mrsw(&d->contents_lock);
+		if (HASH_COUNT(d->child_list) != 0)
+			ret = -LTFS_DIRNOTEMPTY;
+		releaseread_mrsw(&d->contents_lock);
+		if (ret < 0) {
+			releasewrite_mrsw(&parent->contents_lock);
+			fs_release_dentry(parent);
+			releaseread_mrsw(&vol->lock);
+			free(path_norm);
+			fs_release_dentry(d);
+			return ret;
+		}
+	}
+
 	/* Lock order: parent contents_lock, parent meta_lock, then child meta_lock */
 	acquirewrite_mrsw(&parent->meta_lock);
 
@@ -472,17 +489,6 @@ int ltfs_fsops_unlink(const char *path, ltfs_file_id *id, struct ltfs_volume *vo
 		ltfsmsg(LTFS_ERR, 17237E, "unlink: WORM ently");
 		ret = -LTFS_WORM_ENABLED;
 		goto out;
-	}
-
-	/* Can't remove non-empty directories */
-	if (d->isdir) {
-		ret = 0;
-		acquireread_mrsw(&d->contents_lock);
-		if (HASH_COUNT(d->child_list) != 0)
-			ret = -LTFS_DIRNOTEMPTY;
-		releaseread_mrsw(&d->contents_lock);
-		if (ret < 0)
-			goto out;
 	}
 
 	acquirewrite_mrsw(&d->meta_lock);


### PR DESCRIPTION
Two commits:

- **Releases of unheld meta_lock**: in `ltfs_fsops_rename`, the directory WORM checks ran before `todir`'s `meta_lock` was acquired but their error path released it (whenever `todir != fromdir`); `ltfs_fsops_unlink` had the same defect for `parent->meta_lock` on its WORM and non-empty-directory error paths. Releasing an unheld rwlock is undefined behaviour and can corrupt the lock state. The checks now run with the locks held; lock ordering is preserved.
- **Double free on a late rename failure**: after the destination name buffers were assigned to `fromdentry`, a later failure freed them via `out_free` and left dangling pointers that were freed again when the dentry is disposed. Ownership is now cleared from the locals when it moves.