### PR TITLE
build: enforce C11 as minimum compiler standard

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -44,9 +44,21 @@ AC_CANONICAL_HOST
 AC_CANONICAL_BUILD
 AC_CANONICAL_TARGET
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
+
 AC_PROG_CC
 AC_USE_SYSTEM_EXTENSIONS
-AC_PROG_CC_C99
+dnl
+dnl Check that compiler supports C11 or newer standard
+dnl
+AC_COMPILE_IFELSE(
+  [AC_LANG_PROGRAM([[
+    #if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 201112L
+    # error C11 or newer required
+    #endif
+  ]])],
+  [],
+  [AC_MSG_ERROR([C11 or newer compiler required (GCC >= 4.9, Clang >= 3.3)])]
+)
 AM_PROG_CC_C_O
 AM_PROG_AR
 AC_PROG_LIBTOOL


### PR DESCRIPTION
Replace obsolete AC_PROG_CC_C99 with AC_PROG_CC (which auto-selects the newest available standard: C17 on GCC 8+, C11 on GCC 4.9-7) and add an AC_COMPILE_IFELSE gate that aborts configure if __STDC_VERSION__ < 201112L. 

# Description

Makes C11 or newer a hard build requirement in line with the project coding guidelines ("C11 recommended, C99 acceptable") and enables use of _Static_assert, _Noreturn, and inline functions without preprocessor guards.

## Type of change

- This change might need a documentation update (the C11 compiler is actually a requirement now)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
