### PR TITLE
ci: update deprecated GitHub Actions versions

### DIFF
--- a/.github/workflows/build-centos8.yml
+++ b/.github/workflows/build-centos8.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Build LTFS

--- a/.github/workflows/build-debian11.yml
+++ b/.github/workflows/build-debian11.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Build LTFS

--- a/.github/workflows/build-debian12.yml
+++ b/.github/workflows/build-debian12.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Build LTFS

--- a/.github/workflows/build-fedora28.yml
+++ b/.github/workflows/build-fedora28.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Build LTFS

--- a/.github/workflows/build-ubuntu-bionic.yml
+++ b/.github/workflows/build-ubuntu-bionic.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Build LTFS

--- a/.github/workflows/build-ubuntu-focal.yml
+++ b/.github/workflows/build-ubuntu-focal.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Build LTFS

--- a/.github/workflows/build-ubuntu-xeneal.yml
+++ b/.github/workflows/build-ubuntu-xeneal.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Set up Git repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
       - name: Build LTFS

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,13 +39,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v2
+    #  uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -75,4 +75,4 @@ jobs:
        make
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,13 +39,13 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +56,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     #- name: Autobuild
-    #  uses: github/codeql-action/autobuild@v2
+    #  uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -74,4 +74,4 @@ jobs:
        make
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/update-uthash.yml
+++ b/.github/workflows/update-uthash.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -36,7 +36,7 @@ jobs:
           
       - name: Create Pull Request
         if: steps.check_changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v5
+        uses: peter-evans/create-pull-request@v8
         with:
           commit-message: 'chore: update uthash.h from upstream'
           title: 'chore: update uthash.h from upstream'


### PR DESCRIPTION
Updates the action versions the workflows pin, one commit, yaml-only:

- `actions/checkout` v4 → v6 in the seven `build-*.yml` distro workflows, `codeql-analysis.yml`, and `update-uthash.yml`.
- `github/codeql-action` (init/autobuild/analyze) v2 → v4 — CodeQL Action v2 was turned off in 2024 and v3 stopped receiving updates in 2025, so `codeql-analysis.yml` fails until bumped.
- `peter-evans/create-pull-request` v5 → v8 in `update-uthash.yml`.

No workflow logic changes. Extracted from #606 on reviewer feedback so the CI maintenance can merge independently of the CMake build. (#606's own new `cmake.yml` workflow uses `checkout@v6` as well.)