### PR TITLE
Fix intermittent VCI signature failure in cart coherency MAM

### DIFF
--- a/src/libltfs/tape.c
+++ b/src/libltfs/tape.c
@@ -1772,6 +1772,17 @@ int tape_set_cart_coherency(struct device_data *dev, const tape_partition_t part
 	CHECK_ARG_NULL(dev, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(dev->backend, -LTFS_NULL_ARG);
 
+	/* Zero the whole buffer so any byte not written explicitly below is
+	 * deterministic. In particular byte 36 (the byte following the 4-char
+	 * "LTFS" signature) is never assigned: arch_strncpy() copies exactly 4
+	 * bytes and, since the count equals strlen("LTFS"), strncpy() writes no
+	 * terminating NUL on POSIX. Without this memset that byte would carry
+	 * uninitialized stack data onto the medium, and tape_get_cart_coherency()
+	 * compares the signature with sizeof("LTFS") == 5 bytes, so a non-zero
+	 * byte 36 makes the read-back fail (LTFS12062W) and forces a full
+	 * consistency check on the next mount. */
+	memset(coh_data, 0, sizeof(coh_data));
+
 	ltfs_u16tobe(coh_data, TC_MAM_PAGE_COHERENCY);
 	coh_data[2]  = 0;
 	ltfs_u16tobe(coh_data + 3, TC_MAM_PAGE_COHERENCY_SIZE);


### PR DESCRIPTION
tape_set_cart_coherency() builds the Volume Coherency Information MAM parameter in an uninitialized stack buffer and writes byte 36 (the byte right after the 4-char "LTFS" signature) nowhere. The signature is copied with arch_strncpy(coh_data + 32, "LTFS", 5, 4), which on POSIX is strncpy(dst, "LTFS", 4); since the count equals strlen("LTFS"), no terminating NUL is written, leaving byte 36 as uninitialized stack data.

tape_get_cart_coherency() validates the signature with strncmp(coh_data + 32, "LTFS", sizeof("LTFS")), i.e. 5 bytes, so it requires byte 36 to be 0x00. When the leftover stack byte happens to be non-zero, the read-back fails with LTFS12062W, the coherency data for the partition is discarded (LTFS11016W/LTFS11017W), and the next mount falls back to a full medium consistency check. Because the value depends on stack contents at write time, the failure is intermittent.

This was introduced in commit 1f1ee3c (#575), which replaced the previous NUL-terminating copy with the 4-byte strncpy. Windows is unaffected because arch_strncpy maps to strncpy_s, which NUL-terminates.

Zero the buffer before populating it so byte 36 (and any other gap) is deterministic, restoring a valid signature on the medium.


Claude-Session: https://claude.ai/code/session_01PqvvYQzkFL6nNFgbJ9kSuq

# Summary of changes

This pull request includes following changes or fixes. 

- Fix of issue #issue_no
- Add foo
- Change bar

# Description

Please include relevant motivation and context. List any dependencies that are required for this change.

Fixes #issue_no

## Type of change

Please delete items that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Refactoring
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have confirmed my fix is effective or that my feature works
