### PR TITLE
Initialize coh_data buffer in set_cart_coherency with zeros

### DIFF
--- a/src/libltfs/tape.c
+++ b/src/libltfs/tape.c
@@ -1767,7 +1767,7 @@ int tape_set_cart_coherency(struct device_data *dev, const tape_partition_t part
 	struct tc_coherency *coh)
 {
 	int ret;
-	unsigned char coh_data[TC_MAM_PAGE_COHERENCY_SIZE + TC_MAM_PAGE_HEADER_SIZE];
+	unsigned char coh_data[TC_MAM_PAGE_COHERENCY_SIZE + TC_MAM_PAGE_HEADER_SIZE] = {0};
 
 	CHECK_ARG_NULL(dev, -LTFS_NULL_ARG);
 	CHECK_ARG_NULL(dev->backend, -LTFS_NULL_ARG);

--- a/src/libltfs/tape.c
+++ b/src/libltfs/tape.c
@@ -3,7 +3,7 @@
 **  OO_Copyright_BEGIN
 **
 **
-**  Copyright 2010, 2025 IBM Corp. All rights reserved.
+**  Copyright 2010, 2026 IBM Corp. All rights reserved.
 **
 **  Redistribution and use in source and binary forms, with or without
 **   modification, are permitted provided that the following conditions


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Sets buffer in 0 to prevent garbage
