### PR TITLE
Fix/write soft error handling

### DIFF
--- a/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
+++ b/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
@@ -1541,8 +1541,8 @@ write_start:
 				rc = DEVICE_GOOD;
 			}
 		} else if (errno == ENOMEM && retry < MAX_WRITE_RETRY) {
-			sleep(3); // Wait for kernel GC
 			ltfsmsg(LTFS_WARN, 30440W, ++retry);
+			sleep(3); // Wait for kernel GC
 			rc = _handle_block_write_failure(device, pos);
 			if (rc == WRITE_RETRY) {
 				errno = 0;

--- a/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
+++ b/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
@@ -1541,8 +1541,8 @@ write_start:
 				rc = DEVICE_GOOD;
 			}
 		} else if (errno == ENOMEM && retry < MAX_WRITE_RETRY) {
-		  sleep(3); // Wait for kernel GC
-      ltfsmsg(LTFS_WARN, 30440W, ++retry);
+			sleep(3); // Wait for kernel GC
+			ltfsmsg(LTFS_WARN, 30440W, ++retry);
 			rc = _handle_block_write_failure(device, pos);
 			if (rc == WRITE_RETRY) {
 				errno = 0;
@@ -1569,7 +1569,7 @@ write_start:
 
 			if (retry < MAX_WRITE_RETRY
 				&& ((current_errno == EIO && rc == -EDEV_NO_SENSE ) || (rc == -EDEV_CONFIGURE_CHANGED) || (rc == -EDEV_TIME_STAMP_CHANGED))) {
-		    sleep(5);
+				sleep(5);
 				rc = _handle_block_write_failure(device, pos);
 				if (rc == WRITE_RETRY) {
 					errno = 0;

--- a/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
+++ b/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
@@ -1437,14 +1437,10 @@ int lin_tape_ibmtape_read(void *device, char *buf, size_t count, struct tc_posit
 
 #define WRITE_RETRY (-LINUX_MAX_BLOCK_SIZE)
 
-static inline int _handle_block_allocation_failure(void *device, struct tc_position *pos, int *retry)
+static inline int _handle_block_write_failure(void *device, struct tc_position *pos)
 {
     int ret = 0;
     struct tc_position tmp_pos = {0, 0};
-
-    /* Sleep 3 secs to wait garbage correction in kernel side and retry */
-    ltfsmsg(LTFS_WARN, 30440W, ++(*retry));
-    sleep(3);
 
     ret = lin_tape_ibmtape_readpos(device, &tmp_pos);
     if (ret == DEVICE_GOOD && pos->partition == tmp_pos.partition) {
@@ -1545,7 +1541,9 @@ write_start:
 				rc = DEVICE_GOOD;
 			}
 		} else if (errno == ENOMEM && retry < MAX_WRITE_RETRY) {
-			rc = _handle_block_allocation_failure(device, pos, &retry);
+		  sleep(3); // Wait for kernel GC
+      ltfsmsg(LTFS_WARN, 30440W, ++retry);
+			rc = _handle_block_write_failure(device, pos);
 			if (rc == WRITE_RETRY) {
 				errno = 0;
 				goto write_start;
@@ -1571,7 +1569,8 @@ write_start:
 
 			if (retry < MAX_WRITE_RETRY
 				&& ((current_errno == EIO && rc == -EDEV_NO_SENSE ) || (rc == -EDEV_CONFIGURE_CHANGED) || (rc == -EDEV_TIME_STAMP_CHANGED))) {
-				rc = _handle_block_allocation_failure(device, pos, &retry);
+		    sleep(5);
+				rc = _handle_block_write_failure(device, pos);
 				if (rc == WRITE_RETRY) {
 					errno = 0;
 					goto write_start;

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -105,7 +105,7 @@ struct sg_global_data global_data;
 #define MAX_RETRY          (100)
 
 #define MAX_TAKE_DUMP_ATTEMPTS (10)
-#define SOFT_ERROR_MAX_RETRIES (3)
+#define POR_MAX_RETRIES (3)
 
 /* Forward references (For keep function order to struct tape_ops) */
 int sg_readpos(void *device, struct tc_position *pos);
@@ -2101,7 +2101,7 @@ int sg_write(void *device, const char *buf, size_t count, struct tc_position *po
 	struct sg_data *priv = (struct sg_data*)device;
 	struct tc_position cur_pos;
 	size_t datacount = count;
-	int retry_count = 0;
+	int retry_count = 0, por_retry_count = 0;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_WRITE));
 
@@ -2152,11 +2152,11 @@ start_write:
 		ret = _handle_block_allocation_failure(device, pos, &retry_count, "write");
 		if (ret == -EDEV_RETRY)
 			goto start_write;
-	} else if (ret == -EDEV_HOST_ERROR && retry_count < SOFT_ERROR_MAX_RETRIES) {
+	} else if (ret == -EDEV_HOST_ERROR && por_retry_count < POR_MAX_RETRIES) {
 		sleep(5);
 		ret = _clear_por(priv);
 		if (ret == DEVICE_GOOD) {
-  		ret = _handle_block_allocation_failure(device, pos, &retry_count, "write");
+  		ret = _handle_block_allocation_failure(device, pos, &por_retry_count, "write");
   		if (ret == -EDEV_RETRY)
   			goto start_write;
 		}

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -1982,8 +1982,8 @@ start_read:
 		priv->use_sili = false;
 		ret = _cdb_read(device, buf, datacount, unusual_size);
 	} else if (ret == -EDEV_BUFFER_ALLOCATE_ERROR && retry_count < MAX_RETRY) {
-		sleep(3); // Wait for kernel GC
 		ltfsmsg(LTFS_WARN, 30277W, ++retry_count);
+		sleep(3); // Wait for kernel GC
 		ret = _handle_block_write_failure(device, pos, "read");
 		if (ret == -EDEV_RETRY)
 			goto start_read;
@@ -2146,8 +2146,8 @@ start_write:
 				ret = -EDEV_POR_OR_BUS_RESET;
 		}
 	} else if (ret_write == -EDEV_BUFFER_ALLOCATE_ERROR && retry_count < MAX_RETRY) {
-		sleep(3); // Wait for kernel GC
 		ltfsmsg(LTFS_WARN, 30277W, ++retry_count);
+		sleep(3); // Wait for kernel GC
 		ret = _handle_block_write_failure(device, pos, "write");
 		if (ret == -EDEV_RETRY)
 			goto start_write;
@@ -2156,9 +2156,10 @@ start_write:
 		sleep(5);
 		ret = _clear_por(priv);
 		if (ret == DEVICE_GOOD) {
-  			ret = _handle_block_write_failure(device, pos, "write");
-  			if (ret == -EDEV_RETRY)
-  				goto start_write;
+			ret = _handle_block_write_failure(device, pos, "write");
+				if (ret == -EDEV_RETRY)
+					goto start_write;
+			ret_write = DEVICE_GOOD;
 		}
 	}
 

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -104,6 +104,7 @@ struct sg_global_data global_data;
 #define MAX_RETRY          (100)
 
 #define MAX_TAKE_DUMP_ATTEMPTS (10)
+#define SOFT_ERROR_MAX_RETRIES (3)
 
 /* Forward references (For keep function order to struct tape_ops) */
 int sg_readpos(void *device, struct tc_position *pos);
@@ -2098,7 +2099,8 @@ int sg_write(void *device, const char *buf, size_t count, struct tc_position *po
 	struct sg_data *priv = (struct sg_data*)device;
 	struct tc_position cur_pos;
 	size_t datacount = count;
-	int retry_count = 0;
+	int reconnect_retry_count = 0, soft_error_retry_count = 0;
+	int TBL_SLEEP_SECS[SOFT_ERROR_MAX_RETRIES] = {45, 60, 75}; // Hardcoded exponentially increasing sleep time
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_WRITE));
 
@@ -2145,7 +2147,12 @@ start_write:
 			} else
 				ret = -EDEV_POR_OR_BUS_RESET;
 		}
-	} else if (ret == -EDEV_BUFFER_ALLOCATE_ERROR && retry_count < MAX_RETRY) {
+	} else if (ret == -EDEV_BUFFER_ALLOCATE_ERROR && reconnect_retry_count < MAX_RETRY) {
+		ret = _handle_block_allocation_failure(device, pos, &reconnect_retry_count, "write");
+		if (ret == -EDEV_RETRY)
+			goto start_write;
+	} else if (ret == -EDEV_HOST_ERROR && soft_error_retry_count < SOFT_ERROR_MAX_RETRIES) {
+		sleep(TBL_SLEEP_SECS[soft_error_retry_count]);
 		ret = _handle_block_allocation_failure(device, pos, &retry_count, "write");
 		if (ret == -EDEV_RETRY)
 			goto start_write;

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -2145,13 +2145,13 @@ start_write:
 			} else
 				ret = -EDEV_POR_OR_BUS_RESET;
 		}
-	} else if (ret == -EDEV_BUFFER_ALLOCATE_ERROR && retry_count < MAX_RETRY) {
+	} else if (ret_write == -EDEV_BUFFER_ALLOCATE_ERROR && retry_count < MAX_RETRY) {
 		sleep(3); // Wait for kernel GC
 		ltfsmsg(LTFS_WARN, 30277W, ++retry_count);
 		ret = _handle_block_write_failure(device, pos, "write");
 		if (ret == -EDEV_RETRY)
 			goto start_write;
-	} else if (ret == -EDEV_HOST_ERROR && por_retry_count < POR_MAX_RETRIES) {
+	} else if (ret_write == -EDEV_HOST_ERROR && por_retry_count < POR_MAX_RETRIES) {
 		por_retry_count++;
 		sleep(5);
 		ret = _clear_por(priv);

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -1864,15 +1864,10 @@ static int _cdb_read(void *device, char *buf, size_t size, bool sili)
 	return length;
 }
 
-static inline int _handle_block_allocation_failure(void *device, struct tc_position *pos,
-												   int *retry, char *op)
+static inline int _handle_block_write_failure(void *device, struct tc_position *pos, char *op)
 {
 	int ret = 0;
 	struct tc_position tmp_pos = {0, 0};
-
-	/* Sleep 3 secs to wait garbage correction in kernel side and retry */
-	ltfsmsg(LTFS_WARN, 30277W, ++(*retry));
-	sleep(3);
 
 	ret = sg_readpos(device, &tmp_pos);
 	if (ret == DEVICE_GOOD && pos->partition == tmp_pos.partition) {
@@ -1987,7 +1982,9 @@ start_read:
 		priv->use_sili = false;
 		ret = _cdb_read(device, buf, datacount, unusual_size);
 	} else if (ret == -EDEV_BUFFER_ALLOCATE_ERROR && retry_count < MAX_RETRY) {
-		ret = _handle_block_allocation_failure(device, pos, &retry_count, "read");
+    sleep(3); // Wait for kernel GC
+    ltfsmsg(LTFS_WARN, 30277W, ++retry_count);
+		ret = _handle_block_write_failure(device, pos, "read");
 		if (ret == -EDEV_RETRY)
 			goto start_read;
 	}
@@ -2149,14 +2146,17 @@ start_write:
 				ret = -EDEV_POR_OR_BUS_RESET;
 		}
 	} else if (ret == -EDEV_BUFFER_ALLOCATE_ERROR && retry_count < MAX_RETRY) {
-		ret = _handle_block_allocation_failure(device, pos, &retry_count, "write");
+	  sleep(3); // Wait for kernel GC
+    ltfsmsg(LTFS_WARN, 30277W, ++retry_count);
+		ret = _handle_block_write_failure(device, pos, "write");
 		if (ret == -EDEV_RETRY)
 			goto start_write;
 	} else if (ret == -EDEV_HOST_ERROR && por_retry_count < POR_MAX_RETRIES) {
+    por_retry_count++;
 		sleep(5);
 		ret = _clear_por(priv);
 		if (ret == DEVICE_GOOD) {
-  		ret = _handle_block_allocation_failure(device, pos, &por_retry_count, "write");
+  		ret = _handle_block_write_failure(device, pos, "write");
   		if (ret == -EDEV_RETRY)
   			goto start_write;
 		}

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -54,6 +54,7 @@
 #include <dirent.h>
 #include <sys/ioctl.h>
 
+#include "libltfs/ltfs_error.h"
 #include "ltfs_copyright.h"
 #include "libltfs/ltfslogging.h"
 #include "libltfs/fs.h"
@@ -605,7 +606,7 @@ int _raw_tur(const int fd)
 
 #define _clear_por(p) _clear_por_raw((p)->dev.fd);
 
-void _clear_por_raw(const int fd)
+int _clear_por_raw(const int fd)
 {
 	int i = 0, ret = -1;
 
@@ -625,6 +626,7 @@ void _clear_por_raw(const int fd)
 		}
 		i++;
 	}
+	return ret;
 }
 
 #define _get_stable_tur_response(p) _get_stable_tur_response_raw((p)->dev.fd)
@@ -2099,8 +2101,7 @@ int sg_write(void *device, const char *buf, size_t count, struct tc_position *po
 	struct sg_data *priv = (struct sg_data*)device;
 	struct tc_position cur_pos;
 	size_t datacount = count;
-	int reconnect_retry_count = 0, soft_error_retry_count = 0;
-	int TBL_SLEEP_SECS[SOFT_ERROR_MAX_RETRIES] = {45, 60, 75}; // Hardcoded exponentially increasing sleep time
+	int retry_count = 0;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_WRITE));
 
@@ -2147,15 +2148,18 @@ start_write:
 			} else
 				ret = -EDEV_POR_OR_BUS_RESET;
 		}
-	} else if (ret == -EDEV_BUFFER_ALLOCATE_ERROR && reconnect_retry_count < MAX_RETRY) {
-		ret = _handle_block_allocation_failure(device, pos, &reconnect_retry_count, "write");
-		if (ret == -EDEV_RETRY)
-			goto start_write;
-	} else if (ret == -EDEV_HOST_ERROR && soft_error_retry_count < SOFT_ERROR_MAX_RETRIES) {
-		sleep(TBL_SLEEP_SECS[soft_error_retry_count]);
+	} else if (ret == -EDEV_BUFFER_ALLOCATE_ERROR && retry_count < MAX_RETRY) {
 		ret = _handle_block_allocation_failure(device, pos, &retry_count, "write");
 		if (ret == -EDEV_RETRY)
 			goto start_write;
+	} else if (ret == -EDEV_HOST_ERROR && retry_count < SOFT_ERROR_MAX_RETRIES) {
+		sleep(5);
+		ret = _clear_por(priv);
+		if (ret == DEVICE_GOOD) {
+  		ret = _handle_block_allocation_failure(device, pos, &retry_count, "write");
+  		if (ret == -EDEV_RETRY)
+  			goto start_write;
+		}
 	}
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_WRITE));

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -1982,8 +1982,8 @@ start_read:
 		priv->use_sili = false;
 		ret = _cdb_read(device, buf, datacount, unusual_size);
 	} else if (ret == -EDEV_BUFFER_ALLOCATE_ERROR && retry_count < MAX_RETRY) {
-    sleep(3); // Wait for kernel GC
-    ltfsmsg(LTFS_WARN, 30277W, ++retry_count);
+		sleep(3); // Wait for kernel GC
+		ltfsmsg(LTFS_WARN, 30277W, ++retry_count);
 		ret = _handle_block_write_failure(device, pos, "read");
 		if (ret == -EDEV_RETRY)
 			goto start_read;
@@ -2146,13 +2146,13 @@ start_write:
 				ret = -EDEV_POR_OR_BUS_RESET;
 		}
 	} else if (ret == -EDEV_BUFFER_ALLOCATE_ERROR && retry_count < MAX_RETRY) {
-	  sleep(3); // Wait for kernel GC
-    ltfsmsg(LTFS_WARN, 30277W, ++retry_count);
+		sleep(3); // Wait for kernel GC
+		ltfsmsg(LTFS_WARN, 30277W, ++retry_count);
 		ret = _handle_block_write_failure(device, pos, "write");
 		if (ret == -EDEV_RETRY)
 			goto start_write;
 	} else if (ret == -EDEV_HOST_ERROR && por_retry_count < POR_MAX_RETRIES) {
-    por_retry_count++;
+		por_retry_count++;
 		sleep(5);
 		ret = _clear_por(priv);
 		if (ret == DEVICE_GOOD) {

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -2093,7 +2093,7 @@ static int _cdb_write(void *device, uint8_t *buf, size_t size, bool *ew, bool *p
 
 int sg_write(void *device, const char *buf, size_t count, struct tc_position *pos)
 {
-	int ret, ret_fo;
+	int ret, ret_fo, ret_write = -1;
 	bool ew = false, pew = false;
 	struct sg_data *priv = (struct sg_data*)device;
 	struct tc_position cur_pos;
@@ -2128,12 +2128,12 @@ int sg_write(void *device, const char *buf, size_t count, struct tc_position *po
 	}
 
 start_write:
-	ret = _cdb_write(device, (uint8_t *)buf, datacount, &ew, &pew);
-	if (ret == DEVICE_GOOD) {
+	ret_write = _cdb_write(device, (uint8_t *)buf, datacount, &ew, &pew);
+	if (ret_write == DEVICE_GOOD) {
 		pos->block++;
 		pos->early_warning = ew;
 		pos->programmable_early_warning = pew;
-	} else if (ret == -EDEV_NEED_FAILOVER) {
+	} else if (ret_write == -EDEV_NEED_FAILOVER) {
 		ret_fo = sg_readpos(device, &cur_pos);
 		if (!ret_fo) {
 			if (pos->partition == cur_pos.partition
@@ -2141,7 +2141,7 @@ start_write:
 				pos->block++;
 				pos->early_warning = cur_pos.early_warning;
 				pos->programmable_early_warning = cur_pos.programmable_early_warning;
-				ret = DEVICE_GOOD;
+				ret = ret_write = DEVICE_GOOD;
 			} else
 				ret = -EDEV_POR_OR_BUS_RESET;
 		}
@@ -2156,15 +2156,15 @@ start_write:
 		sleep(5);
 		ret = _clear_por(priv);
 		if (ret == DEVICE_GOOD) {
-  		ret = _handle_block_write_failure(device, pos, "write");
-  		if (ret == -EDEV_RETRY)
-  			goto start_write;
+  			ret = _handle_block_write_failure(device, pos, "write");
+  			if (ret == -EDEV_RETRY)
+  				goto start_write;
 		}
 	}
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_WRITE));
 
-	return ret;
+	return ret_write;
 }
 
 int sg_writefm(void *device, size_t count, struct tc_position *pos, bool immed)

--- a/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
+++ b/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
@@ -1427,15 +1427,10 @@ static int _cdb_read(void *device, char *buf, size_t size, bool sili)
 	return length;
 }
 
-static inline int _handle_block_allocation_failure(void *device, struct tc_position *pos,
-												   int *retry, char *op)
+static inline int _handle_block_write_failure(void *device, struct tc_position *pos, char *op)
 {
 	int ret = 0;
 	struct tc_position tmp_pos = {0, 0};
-
-	/* Sleep 3 secs to wait garbage correction in kernel side and retry */
-	ltfsmsg(LTFS_WARN, 30277W, ++(*retry));
-	sleep(3);
 
 	ret = scsipi_ibmtape_readpos(device, &tmp_pos);
 	if (ret == DEVICE_GOOD && pos->partition == tmp_pos.partition) {
@@ -1550,7 +1545,9 @@ start_read:
 		priv->use_sili = false;
 		ret = _cdb_read(device, buf, datacount, unusual_size);
 	} else if (ret == -EDEV_BUFFER_ALLOCATE_ERROR && retry_count < MAX_RETRY) {
-		ret = _handle_block_allocation_failure(device, pos, &retry_count, "read");
+		ltfsmsg(LTFS_WARN, 30277W, ++(*retry));
+		sleep(3); // Wait for kernel GC
+		ret = _handle_block_write_failure(device, pos, "read");
 		if (ret == -EDEV_RETRY)
 			goto start_read;
 	}
@@ -1706,15 +1703,18 @@ start_write:
 				ret = -EDEV_POR_OR_BUS_RESET;
 		}
 	} else if (ret == -EDEV_BUFFER_ALLOCATE_ERROR && retry_count < MAX_RETRY) {
-		ret = _handle_block_allocation_failure(device, pos, &retry_count, "write");
+		ltfsmsg(LTFS_WARN, 30277W, ++(*retry));
+		sleep(3); // Wait for kernel GC
+		ret = _handle_block_write_failure(device, pos, "write");
 		if (ret == -EDEV_RETRY)
 			goto start_write;
 	} else if (ret == -EDEV_HOST_ERROR && por_retry_count < POR_MAX_RETRIES) {
+		por_retry_count++;
 		sleep(5);
 		ret = _clear_por(priv);
 		if (ret == DEVICE_GOOD) {
-  		ret = _handle_block_allocation_failure(device, pos, &por_retry_count, "write");
-  		if (ret == -EDEV_RETRY)
+			ret = _handle_block_write_failure(device, pos, "write");
+			if (ret == -EDEV_RETRY)
   			goto start_write;
 		}
 	}

--- a/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
+++ b/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
@@ -569,7 +569,7 @@ int _raw_tur(const int fd)
 
 #define _clear_por(p) _clear_por_raw((p)->dev.fd);
 
-void _clear_por_raw(const int fd)
+int _clear_por_raw(const int fd)
 {
 	int i = 0, ret = -1;
 
@@ -589,6 +589,7 @@ void _clear_por_raw(const int fd)
 		}
 		i++;
 	}
+	return ret;
 }
 
 /* Forward reference */
@@ -1707,6 +1708,14 @@ start_write:
 		ret = _handle_block_allocation_failure(device, pos, &retry_count, "write");
 		if (ret == -EDEV_RETRY)
 			goto start_write;
+	} else if (ret == -EDEV_HOST_ERROR && retry_count < SOFT_ERROR_MAX_RETRIES) {
+		sleep(5);
+		ret = _clear_por(priv);
+		if (ret == DEVICE_GOOD) {
+  		ret = _handle_block_allocation_failure(device, pos, &retry_count, "write");
+  		if (ret == -EDEV_RETRY)
+  			goto start_write;
+		}
 	}
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_WRITE));

--- a/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
+++ b/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
@@ -96,6 +96,7 @@ struct scsipi_ibmtape_global_data global_data;
 
 #define TU_DEFAULT_TIMEOUT (60)
 #define MAX_RETRY          (100)
+#define POR_MAX_RETRIES (3)
 
 /* Forward references (For keep function order to struct tape_ops) */
 int scsipi_ibmtape_readpos(void *device, struct tc_position *pos);
@@ -1657,7 +1658,7 @@ int scsipi_ibmtape_write(void *device, const char *buf, size_t count, struct tc_
 	struct scsipi_ibmtape_data *priv = (struct scsipi_ibmtape_data*)device;
 	struct tc_position cur_pos;
 	size_t datacount = count;
-	int retry_count = 0;
+	int retry_count = 0, por_retry_count = 0;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_WRITE));
 
@@ -1708,11 +1709,11 @@ start_write:
 		ret = _handle_block_allocation_failure(device, pos, &retry_count, "write");
 		if (ret == -EDEV_RETRY)
 			goto start_write;
-	} else if (ret == -EDEV_HOST_ERROR && retry_count < SOFT_ERROR_MAX_RETRIES) {
+	} else if (ret == -EDEV_HOST_ERROR && por_retry_count < POR_MAX_RETRIES) {
 		sleep(5);
 		ret = _clear_por(priv);
 		if (ret == DEVICE_GOOD) {
-  		ret = _handle_block_allocation_failure(device, pos, &retry_count, "write");
+  		ret = _handle_block_allocation_failure(device, pos, &por_retry_count, "write");
   		if (ret == -EDEV_RETRY)
   			goto start_write;
 		}


### PR DESCRIPTION

# Summary of changes

This pull request includes the following changes:

- Fix retry logic for write operations after drive repositioning
- Implement power-on-reset (POR) handling with retry mechanism
- Refactor block allocation failure handling across multiple tape drivers
- Add generic block write failure handling function
- Fix indentation and code formatting issues
- Correct return value handling in write operations

# Description

This PR addresses issues with write operation failures in tape drivers by implementing a more robust retry mechanism. The changes focus on properly handling buffer allocation errors and host errors (particularly power-on-reset conditions) by:

1. Separating retry counters for different error types (buffer allocation vs POR)
2. Implementing a `_clear_por()` function that returns status instead of void
3. Creating a generic `_handle_block_write_failure()` function to consolidate retry logic
4. Adding appropriate sleep delays before retries to allow kernel garbage collection
5. Ensuring correct return values are propagated through the call stack

The changes affect three tape drivers:
- Linux sg driver (`sg_tape.c`)
- Linux lin_tape driver (`lin_tape_ibmtape.c`)
- NetBSD scsipi driver (`scsipi_ibmtape.c`)

# Type of change

- Bug fix (non-breaking change which fixes an issue)
- Refactoring

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works
