### PR TITLE
fix(iokit): read remaining capacity from LogPage 0x31 on HP LTO drives

### DIFF
--- a/src/tape_drivers/osx/iokit/iokit_tape.c
+++ b/src/tape_drivers/osx/iokit/iokit_tape.c
@@ -2302,7 +2302,14 @@ int iokit_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 
 	memset(&buffer, 0, LOGSENSEPAGE);
 
-	if (IS_LTO(priv->drive_type) && (DRIVE_GEN(priv->drive_type) == 0x05)) {
+	/*
+	 * HP LTO drives do not report VOLSTATS_PART_REMAIN_CAP (0x0204) on LogPage 0x17,
+	 * so the generic path below cannot get the remaining capacity from them. They do
+	 * provide both remaining and max capacity on LogPage 0x31 instead.
+	 * Verified against HP Ultrium 6-SCSI, firmware 253W.
+	 */
+	if (IS_LTO(priv->drive_type) &&
+		(DRIVE_GEN(priv->drive_type) == 0x05 || priv->vendor == VENDOR_HP)) {
 		/* Use LogPage 0x31 */
 		ret = iokit_logsense(device, (uint8_t)LOG_TAPECAPACITY, (uint8_t)0, (void *)buffer, LOGSENSEPAGE);
 		if(ret < 0)
@@ -2344,6 +2351,15 @@ int iokit_remaining_capacity(void *device, struct tc_remaining_cap *cap)
 					break;
 			}
 		}
+
+		if (priv->vendor == VENDOR_HP) {
+			/* HP reports LogPage 0x31 values in MB while tc_remaining_cap is in MiB */
+			cap->max_p0 = (cap->max_p0 * 1000 * 1000) >> 20;
+			cap->max_p1 = (cap->max_p1 * 1000 * 1000) >> 20;
+			cap->remaining_p0 = (cap->remaining_p0 * 1000 * 1000) >> 20;
+			cap->remaining_p1 = (cap->remaining_p1 * 1000 * 1000) >> 20;
+		}
+
 		ret = DEVICE_GOOD;
 	} else {
 		/* Use LogPage 0x17 */


### PR DESCRIPTION
# Summary of changes

Fix remaining-capacity detection for HP LTO drives in the macOS IOKit backend.

- Route HP LTO drives through LogPage 0x31 instead of LogPage 0x17 when querying remaining capacity.
- Convert HP LogPage 0x31 capacity values from MB to MiB.
- Preserve the existing behavior for IBM drives.

# Description

`iokit_remaining_capacity()` currently uses LogPage 0x17 for every LTO
drive except LTO-5 and requires `VOLSTATS_PART_REMAIN_CAP` (0x0204)
to be present.

On the tested HP Ultrium 6-SCSI, LogPage 0x17 does not contain 0x0204.
It reports 0x0202 (native capacity) and 0x0203 (used capacity), causing
the capacity query to fail and `mkltfs` to abort with:

    LTFS12030E Cannot get capacity data: backend call failed (-21700)
    LTFS11999E Cannot load the medium: failed to get capacity data (-21700)

The drive exposes both remaining and maximum capacity through LogPage
0x31. `iokit_remaining_capacity()` already parses this page for LTO-5,
so this change uses the same path for HP LTO drives.

HP reports the LogPage 0x31 capacity values in MB, while the values
returned through `tc_remaining_cap` are expected in MiB. Apply the same
MB-to-MiB conversion already used by the LogPage 0x17 path.

This also corrects the values reported for HP LTO-5 drives. Previously
they used LogPage 0x31 without this conversion, causing the reported
capacity to be approximately 5% too high. IBM drive behavior is
unchanged.

## Verification

Tested with:

- HP Ultrium 6-SCSI, firmware 253W
- ATTO Celerity FC-82EN
- macOS 26.6.2
- Apple Silicon

The following operations were verified successfully:

- `mkltfs`
- LTFS mount
- 1 GiB write/read with matching SHA-256
- unmount and remount
- `ltfsck`

The Linux `sg` backend has the same 0x0204 dependency in
`sg_remaining_capacity()` and may be affected by the same behavior.
It has not been tested here, so this PR intentionally leaves that
backend unchanged.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have confirmed my fix is effective or that my feature works