### PR TITLE
Assume cart type fron density as fallback for unknown cart type

### DIFF
--- a/messages/tape_linux_sg/root.txt
+++ b/messages/tape_linux_sg/root.txt
@@ -138,6 +138,7 @@ root:table {
 		30295I:string { "Have unstable TUR response, start over (Cur = %d, Prev = %d)." }
 		30296I:string { "Capturing a stable TUR at line %d." }
 		30297W:string { "Cannot retrieve drive dump: failed to communicate with drive. Tried (%d) times." }
+		30298I:string { "Sense data returned unknown cart type, compat: assume_cart_type from density code (%x %x) " }
 
 		30392D:string { "Backend %s %s." }
 		30393D:string { "Backend %s: %d %s." }

--- a/src/tape_drivers/linux/sg/sg_tape.c
+++ b/src/tape_drivers/linux/sg/sg_tape.c
@@ -2761,6 +2761,12 @@ int sg_load(void *device, struct tc_position *pos)
 		priv->cart_type = buf[2];
 	}
 
+	ret = is_known_tape_type(priv->cart_type);
+	if (ret == -LTFS_UNSUPPORTED_CART) {
+		priv->cart_type = assume_cart_type(priv->density_code);
+		ltfsmsg(LTFS_INFO, 30298I, priv->cart_type, priv->density_code);
+	}
+
 	if (priv->cart_type == 0x00) {
 		ltfsmsg(LTFS_WARN, 30265W);
 		ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_EXIT(REQ_TC_LOAD));

--- a/src/tape_drivers/vendor_compat.c
+++ b/src/tape_drivers/vendor_compat.c
@@ -396,6 +396,37 @@ int is_supported_tape(unsigned char type, unsigned char density, bool *is_worm)
 	return ret;
 }
 
+int is_known_tape_type(unsigned char type)
+{
+	// Thought about using supported_cart[] here, but it does not contain
+	// all known tape types. Different use case.
+	switch (type) {
+		case TC_MP_LTO1D_CART:
+		case TC_MP_LTO2D_CART:
+		case TC_MP_LTO3D_CART:
+		case TC_MP_LTO4D_CART:
+		case TC_MP_LTO5D_CART:
+		case TC_MP_LTO6D_CART:
+		case TC_MP_LTO7D_CART:
+		case TC_MP_LTO8D_CART:
+		case TC_MP_LTO9D_CART:
+		case TC_MP_LTO10D_CART:
+		case TC_MP_LTOP10D_CART:
+		case TC_MP_LTO3W_CART:
+		case TC_MP_LTO4W_CART:
+		case TC_MP_LTO5W_CART:
+		case TC_MP_LTO6W_CART:
+		case TC_MP_LTO7W_CART:
+		case TC_MP_LTO8W_CART:
+		case TC_MP_LTO9W_CART:
+		case TC_MP_LTO10W_CART:
+			return 0;
+		default:
+			return -LTFS_UNSUPPORTED_CART;
+	}
+	return 0;
+}
+
 void init_error_table(int vendor,
 					  struct error_table **standard_table,
 					  struct error_table **vendor_table)

--- a/src/tape_drivers/vendor_compat.h
+++ b/src/tape_drivers/vendor_compat.h
@@ -70,6 +70,7 @@ struct supported_device **get_supported_devs(int vendor);
 bool drive_has_supported_fw(int vendor, int drive_type, const unsigned char * const revision);
 unsigned char assume_cart_type(const unsigned char dc);
 int  is_supported_tape(unsigned char type, unsigned char density, bool *is_worm);
+int  is_known_tape_type(unsigned char type);
 
 void init_error_table(int vendor,
 					  struct error_table **standard_table,


### PR DESCRIPTION
# Summary of changes

This pull request includes following changes or fixes. 

- Fix of issue #638

# Description

Adds a fallback method of cart_type setting - if sens data is unknown cart

## Type of change

- Bug fix
- New feature
- Refactoring

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works

Please do review, the fallback will run for any tape drive that didn't get a known cart_type back from sense data, not specific to vendor