### PR TITLE
fix: remove vendor condition from lintape

### DIFF
--- a/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
+++ b/src/tape_drivers/linux/lin_tape/lin_tape_ibmtape.c
@@ -2268,8 +2268,7 @@ int lin_tape_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *c
 	struct lin_tape_ibmtape *priv = (struct lin_tape_ibmtape *) device;
 
 	ltfs_profiler_add_entry(priv->profiler, NULL, TAPEBEND_REQ_ENTER(REQ_TC_REMAINCAP));
-	if ((IS_LTO(priv->drive_type) && (DRIVE_GEN(priv->drive_type) == 0x05)) ||
-		(priv->vendor == VENDOR_HP && IS_LTO(priv->drive_type) && (DRIVE_GEN(priv->drive_type) == 0x06))) {
+	if (IS_LTO(priv->drive_type) && (DRIVE_GEN(priv->drive_type) == 0x05)) {
 		/* Issue LogPage 0x31 */
 		rc = lin_tape_ibmtape_logsense(device, LOG_TAPECAPACITY, (uint8_t)0, logdata, LOGSENSEPAGE);
 		if (rc) {

--- a/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
+++ b/src/tape_drivers/netbsd/scsipi-ibmtape/scsipi_ibmtape.c
@@ -2575,8 +2575,7 @@ int scsipi_ibmtape_remaining_capacity(void *device, struct tc_remaining_cap *cap
 
 	memset(buffer, 0, LOGSENSEPAGE);
 
-	if ((IS_LTO(priv->drive_type) && (DRIVE_GEN(priv->drive_type) == 0x05)) ||
-		(priv->vendor == VENDOR_HP && IS_LTO(priv->drive_type) && (DRIVE_GEN(priv->drive_type) == 0x06))) {
+	if (IS_LTO(priv->drive_type) && (DRIVE_GEN(priv->drive_type) == 0x05)) {
 		/* Use LogPage 0x31 */
 		ret = scsipi_ibmtape_logsense(device, (uint8_t)LOG_TAPECAPACITY, (uint8_t)0, (void *)buffer, LOGSENSEPAGE);
 		if(ret < 0)


### PR DESCRIPTION
# Summary of changes

Removed invalid condition from lintape driver since vendor does not exist for lintape devices

# Description

When making #634 I added the vendor condition for all available drivers but lintape and scsi_ibmtape do not have vendor attribute for compatible devices, ignored it since the checks worked and I did not validated it myself, this PR reverts that change for lintape and scsi_ibmtape only

```
lin_tape_ibmtape.c: In function 'lin_tape_ibmtape_remaining_capacity':
lin_tape_ibmtape.c:2272:22: error: 'struct lin_tape_ibmtape' has no member named 'vendor'
 2272 |         (priv->vendor == VENDOR_HP && IS_LTO(priv->drive_type) && (DRIVE_GEN(priv->drive_type) == 0x06))) {
   |           ^~
lin_tape_ibmtape.c: In function 'lin_tape_ibmtape_open':
lin_tape_ibmtape.c:1163:70: warning: '%s' directive output may be truncated writing up to 254 bytes into a region of size 33 [-Wformat-truncation=]
 1163 |     snprintf(priv->info.serial_number, TAPE_SERIAL_LEN_MAX + 1, "%s", priv->drive_serial);
   |                                   ^~
lin_tape_ibmtape.c:1163:9: note: 'snprintf' output between 1 and 255 bytes into a destination of size 33
 1163 |     snprintf(priv->info.serial_number, TAPE_SERIAL_LEN_MAX + 1, "%s", priv->drive_serial);
   |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
make[3]: *** [Makefile:527: libtape_lin_tape_la-lin_tape_ibmtape.lo] Error 1
make[3]: Leaving directory 'ltfs/src/tape_drivers/linux/lin_tape'
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have confirmed my fix is effective or that my feature works
