### PR TITLE
fix(tape): terminate the LTFS signature in the volume coherency attribute

### DIFF
--- a/src/libltfs/tape.c
+++ b/src/libltfs/tape.c
@@ -1783,7 +1783,7 @@ int tape_set_cart_coherency(struct device_data *dev, const tape_partition_t part
 	coh_data[30] = 0;  /* Size of APPLICATION CLIENT SPECIFIC INFORMATION (Byte 1) */
 	coh_data[31] = 43; /* Size of APPLICATION CLIENT SPECIFIC INFORMATION (Byte 0) */
 	/* Size of the buffer to insert 'LTFS' needs to be size of 5 for the 4 letters and the null terminator*/
-	arch_strncpy((char *)coh_data + 32,"LTFS", 5, 4);
+	arch_strncpy((char *)coh_data + 32,"LTFS", 5, 5);
 	memcpy(coh_data + 37, coh->uuid, 37);
 	/*
 	   Version field


### PR DESCRIPTION
The LTFS signature in the volume coherency MAM attribute is written without its terminating NUL, so LTFS rejects the attribute it wrote itself.

- On Linux `arch_strncpy` expands to plain `strncpy`, which terminates only when the count exceeds the source length. With a count of 4 and a four character source, the byte at offset 36 keeps whatever the uninitialised stack buffer held.
- The reader compares five bytes, so the check fails whenever that byte is not zero.
- Windows is unaffected: there the macro maps to `strncpy_s`, which always terminates.

Effect: every mount logs `LTFS12062W Cannot get VCI data`, both partitions report their MAM parameter as unusable, and LTFS falls back to a full medium consistency check. The volume stays usable, but mount time grows with the amount written to the cartridge.

Introduced by 1f1ee3c ("fix: Memory leaks (#575)"). Releases up to 2.4.8.2 write the field correctly; 2.4.8.3, 2.4.8.4 and the current `release/v2.4.9.0` do not.

## Testing

Built from `release/v2.4.9.0` with this change, against an emulated IBM ULT3580-TD9 drive (mhvtl) on Ubuntu 26.04. The attribute was read back off the medium with a raw READ ATTRIBUTE.

| | signature bytes | mount |
| --- | --- | --- |
| Before | `4c 54 46 53 01`, and `4c 54 46 53 33` on another volume | `Cannot get VCI data`, full medium consistency check |
| After | `4c 54 46 53 00` on both partitions | no warnings, no consistency check |

`ltfsck` reports the volume consistent in both cases; it performs a full check by design. No new compiler warnings.
